### PR TITLE
To webdataset fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ pandasql>=0.7.3
 pycocotools>=2.0.6
 pytorch-lightning>=1.9.0
 boto3>=1.17.39
+sqlalchemy==1.4.46
+idx2numpy==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     license='MIT',
     packages=['luxonis_ml'], # https://docs.python.org/3/distutils/setupscript.html point 2.1
     package_dir={"": "src"},  # https://stackoverflow.com/a/67238346/5494277
+    package_data={"luxonis_ml": ["ops/*.py"]},
     install_requires=required,
     include_package_data=True,
     classifiers=[

--- a/src/luxonis_ml/ops/dataset.py
+++ b/src/luxonis_ml/ops/dataset.py
@@ -585,28 +585,12 @@ class LuxonisDataset:
             file_list = []
             tar_count = 0
             for i, basename in tqdm(enumerate(basenames)):
-                if not self.s3:
-                    if sources is None and components is None:
-                        file_list += glob.glob(f"{basename}.*")
-                    elif components is None:
-                        for source in sources:
-                            file_list += glob.glob(f"{basename}.{source}.*")
-                    elif sources is None:
-                        for component in components:
-                            if component == 'json':
-                                file_list += glob.glob(f"{basename}.*.{component}*")
-                            else:
-                                file_list += glob.glob(f"{basename}.*.{component}.*")
-                    else:
-                        for source in sources:
-                            for component in components:
-                                if component == 'json':
-                                    file_list += glob.glob(f"{basename}.{source}.{component}*")
-                                else:
-                                    file_list += glob.glob(f"{basename}.{source}.{component}.*")
-
-                else:
-                    file_list += [file for file in files if file.startswith(basename)]
+                if i == 0: # extract all possible extensions based on one basename
+                    possible_extensions = []
+                    for filename in glob.glob(f"{basename}.*"):
+                        possible_extensions.append(filename.replace(basename,""))
+                for extension in possible_extensions:
+                    file_list.append(f"{basename}{extension}")
 
                 if (i+1) % shard_size == 0 or (i+1) == len(basenames):
                     tar_count_str = str(tar_count).zfill(6)

--- a/src/luxonis_ml/ops/dataset.py
+++ b/src/luxonis_ml/ops/dataset.py
@@ -534,10 +534,20 @@ class LuxonisDataset:
             json_dict = json.load(file)
 
         for component in ann_data:
+            for i, ann in enumerate(ann_data[component]['annotations']):
+                if 'class_name' not in ann.keys():
+                    raise Exception("class_name is required in an annotation")
+                class_id = self._add_class(ann)
+                ann_data[component]['annotations'][i]['class'] = class_id
+
+        for component in ann_data:
             if component in json_dict.keys():
                 json_dict[component]['annotations'] = ann_data[component]['annotations']
             else:
                 warnings.warn(f"Component {component} not found for {basename}")
+
+        with open(json_path, 'w') as file:
+            json.dump(json_dict, file)
 
     def update_metadata(self, basename, **kwargs):
         json_path = glob.glob(f"{self.path}/{self.bough.value}/ldf/{basename}.*.json")[0]

--- a/src/luxonis_ml/ops/dataset_recognition.py
+++ b/src/luxonis_ml/ops/dataset_recognition.py
@@ -1,0 +1,52 @@
+import json
+import os
+import yaml
+from yaml.scanner import ScannerError
+from pathlib import Path
+
+# TODO: place for common parser args
+def recognize(dataset_path: str) -> str:
+    """
+    dataset_path (str): Path to the root folder of the dataset.
+
+    NOTE: Dataset type checking is done by some significant property of the dataset (has to contain json file, yaml file,..).
+    """
+
+    dataset_path = dataset_path if dataset_path[-1] != '/' else dataset_path[:-1]
+
+    if not os.path.isdir(dataset_path):
+        raise Exception("Invalid path name - not a directory.")
+
+    file_dir_list = [f"{dataset_path}/{dir_file}" for dir_file in os.listdir(dataset_path)] 
+    json_files = list(filter(lambda file_dir: file_dir.split(".")[-1] == "json", file_dir_list))
+    yaml_files = list(filter(lambda file_dir: file_dir.split(".")[-1] == "yaml", file_dir_list))
+    dirs = list(filter(lambda file_dir: os.path.isdir(file_dir), file_dir_list))
+
+    if json_files and dirs:
+        if len(json_files) > 1:
+            raise Exception("Possible COCO dataset but multiple json files present - possible ambiguity.")
+        json_file = json_files[0]
+
+        try:
+            with open(json_file) as file:
+                json.load(file)
+        except ValueError:
+            raise Exception(f"{json_file} is not a valid json file.")
+
+        # NOTE: if we want to validate the file further, we can use `if all(key in coco for key in ['images', 'annotations', 'categories']):``
+        return "COCO"
+
+    if yaml_files and dirs:
+        if len(yaml_files) > 1:
+            raise Exception("Possible YOLO dataset but multiple yaml files present - possible ambiguity.")
+        yaml_file = yaml_files[0]
+        try:
+            yaml.safe_load(Path(yaml_file).read_text())
+        except ScannerError:
+            raise Exception(f"{yaml_file} is not a valid yaml file.")
+
+        return "YAML"
+
+    return "Unknown dataset"
+    # TODO: - rest of datasets + appropriate parsers call
+    ...

--- a/src/luxonis_ml/ops/loader.py
+++ b/src/luxonis_ml/ops/loader.py
@@ -26,7 +26,10 @@ class LuxonisLoader:
             self.url = f"pipe:s3cmd -q get s3://{self.dataset.bucket}/{self.dataset.bucket_path}/{Bough.WEBDATASET.value}/{self.view}_{tar_numbers}.tar -"
 
         handlers = self.get_source_handlers()
-        self.webdataset = wds.WebDataset(self.url).shuffle(1000).decode(*handlers)
+        if self.view == 'train':
+            self.webdataset = wds.WebDataset(self.url).shuffle(1000).decode(*handlers)
+        else: # load webdataset without shuffling
+            self.webdataset = wds.WebDataset(self.url).decode(*handlers)
 
         self.nc = len(self.dataset.classes)
         nk = [len(definition["keypoints"]) for definition in self.dataset.keypoint_definitions.values()]

--- a/src/luxonis_ml/ops/parsers.py
+++ b/src/luxonis_ml/ops/parsers.py
@@ -320,8 +320,8 @@ def from_image_classification_with_text_annotations_format(
         source_name, 
         image_folder_path,
         info_file_path,
-        delimiter,
         split,
+        delimiter=" ",
         dataset_size=None,
         override_main_component=None
     ):
@@ -333,8 +333,8 @@ def from_image_classification_with_text_annotations_format(
         source_name: [string] name of the LDFSource to add to
         image_folder_path: [string] path to the directory where images are stored
         info_file_path: [string] path to the text annotations file where each line encodes a name and the associated class of an image
-        delimiter: [string] how image names and classes are separated in the info file (e.g. " ", "," or ";")
         split: [string] 'train', 'val', or 'test'
+        delimiter: [string] how image names and classes are separated in the info file (e.g. " ", "," or ";")
         dataset_size: [int] number of data instances to include in our dataset (if None include all)
         override_main_component: [LDFComponent] provide another LDFComponent if not using the main component from the LDFSource
     Returns:


### PR DESCRIPTION
I noticed that to_webdataset() method has exponential runtime depending on the amount of data instances in our LDF dataset. This problem becomes very obvious when running on Google Colab which has fairly slow file/folder management.

Thus, I propose this change to the code which eliminates usage of glob.glob() search for every basename in our dataset. Instead, it extracts file extensions for a single basename and assumes that other basenames come with same extensions. I believe this is a meaningful assumption, based on how we define data sources and components.

We definitely need to fix this exponential runtime problem but maybe there exists a more elegant way that what I propose (that's why I propose it through a PR).