### PR TITLE
fix exponential runtime of the to_webdataset() method

### DIFF
--- a/src/luxonis_ml/ops/dataset.py
+++ b/src/luxonis_ml/ops/dataset.py
@@ -585,28 +585,12 @@ class LuxonisDataset:
             file_list = []
             tar_count = 0
             for i, basename in tqdm(enumerate(basenames)):
-                if not self.s3:
-                    if sources is None and components is None:
-                        file_list += glob.glob(f"{basename}.*")
-                    elif components is None:
-                        for source in sources:
-                            file_list += glob.glob(f"{basename}.{source}.*")
-                    elif sources is None:
-                        for component in components:
-                            if component == 'json':
-                                file_list += glob.glob(f"{basename}.*.{component}*")
-                            else:
-                                file_list += glob.glob(f"{basename}.*.{component}.*")
-                    else:
-                        for source in sources:
-                            for component in components:
-                                if component == 'json':
-                                    file_list += glob.glob(f"{basename}.{source}.{component}*")
-                                else:
-                                    file_list += glob.glob(f"{basename}.{source}.{component}.*")
-
-                else:
-                    file_list += [file for file in files if file.startswith(basename)]
+                if i == 0: # extract all possible extensions based on one basename
+                    possible_extensions = []
+                    for filename in glob.glob(f"{basename}.*"):
+                        possible_extensions.append(filename.replace(basename,""))
+                for extension in possible_extensions:
+                    file_list.append(f"{basename}{extension}")
 
                 if (i+1) % shard_size == 0 or (i+1) == len(basenames):
                     tar_count_str = str(tar_count).zfill(6)


### PR DESCRIPTION
I noticed that to_webdataset() method has exponential runtime depending on the amount of data instances in our LDF dataset. This problem becomes very obvious when running on Google Colab which has fairly slow file/folder management.

Thus, I propose this change to the code which eliminates usage of glob.glob() search for every basename in our dataset. Instead, it extracts file extensions for a single basename and assumes that other basenames come with same extensions. I believe this is a meaningful assumption, based on how we define data sources and components.

We definitely need to fix this exponential runtime problem but maybe there exists a more elegant way that what I propose (that's why I propose it through a PR).