### PR TITLE
Small features and fixes

### DIFF
--- a/examples/COCO_people_subset.ipynb
+++ b/examples/COCO_people_subset.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "4c06d8fc",
    "metadata": {},
    "outputs": [],
@@ -23,6 +23,7 @@
     "from copy import deepcopy\n",
     "\n",
     "from luxonis_ml.data import *\n",
+    "from luxonis_ml.loader import *\n",
     "\n",
     "BUCKET_TYPE = 'local'"
    ]
@@ -37,12 +38,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "5cc9ddf2",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: gdown in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (4.7.1)\n",
+      "Requirement already satisfied: filelock in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (3.12.2)\n",
+      "Requirement already satisfied: six in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (1.16.0)\n",
+      "Requirement already satisfied: tqdm in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (4.65.0)\n",
+      "Requirement already satisfied: requests[socks] in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (2.31.0)\n",
+      "Requirement already satisfied: beautifulsoup4 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (4.12.2)\n",
+      "Requirement already satisfied: soupsieve>1.2 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from beautifulsoup4->gdown) (2.4.1)\n",
+      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (1.26.16)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (2023.5.7)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (3.4)\n",
+      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (3.1.0)\n",
+      "Requirement already satisfied: PySocks!=1.5.7,>=1.5.6 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (1.7.1)\n",
+      "\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.1.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Downloading...\n",
+      "From: https://drive.google.com/uc?id=1XlvFK7aRmt8op6-hHkWVKIJQeDtOwoRT\n",
+      "To: /home/conor/Luxonis/luxonis-ml/data/COCO_people_subset.zip\n",
+      "100%|██████████████████████████████████████| 7.78M/7.78M [00:00<00:00, 17.7MB/s]\n",
+      "Archive:  ../data/COCO_people_subset.zip\n",
+      "replace ../data/person_keypoints_val2017.json? [y]es, [n]o, [A]ll, [N]one, [r]ename: ^C\n"
+     ]
+    }
+   ],
    "source": [
     "! pip install gdown\n",
     "! gdown 1XlvFK7aRmt8op6-hHkWVKIJQeDtOwoRT -O ../data/COCO_people_subset.zip\n",
@@ -59,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "7fa5d2b9",
    "metadata": {},
    "outputs": [],
@@ -172,10 +201,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "8171a7f9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset id: 64ad8195fb15ff76db990fcb\n"
+     ]
+    }
+   ],
    "source": [
     "team_id = \"luxonis_team_id\"\n",
     "team_name = \"luxonis\"\n",
@@ -192,12 +229,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "9a30216e",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 141381.03it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking for additions or modifications...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:01<00:00, 18.91it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting dataset media...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 127.36it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 100% |███████████████████| 30/30 [2.4s elapsed, 0s remaining, 12.7 samples/s]   \n"
+     ]
+    }
+   ],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",
@@ -229,10 +309,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "58991ba0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 186137.75it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Checking for additions or modifications...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:04<00:00,  6.65it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Extracting dataset media...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 30320.27it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",
@@ -252,10 +368,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "e60d5a44",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dataset version: 1.1\n",
+      "Class attribute presence in version 1.0:\n",
+      "[False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False]\n",
+      "Class attribute presence in version 1.1:\n",
+      "[True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True]\n"
+     ]
+    }
+   ],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",
@@ -272,6 +400,36 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d160b62a",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "float() argument must be a string or a number, not 'BaseDict'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m LuxonisDataset(\n\u001b[1;32m      2\u001b[0m     team_id\u001b[38;5;241m=\u001b[39mteam_id,\n\u001b[1;32m      3\u001b[0m     dataset_id\u001b[38;5;241m=\u001b[39mdataset_id,\n\u001b[1;32m      4\u001b[0m ) \u001b[38;5;28;01mas\u001b[39;00m dataset:\n\u001b[1;32m      6\u001b[0m     loader \u001b[38;5;241m=\u001b[39m LuxonisLoader(dataset)\n\u001b[0;32m----> 7\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m data \u001b[38;5;129;01min\u001b[39;00m loader:\n\u001b[1;32m      8\u001b[0m         \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;28mtype\u001b[39m(data))\n",
+      "File \u001b[0;32m~/Luxonis/luxonis-ml/src/luxonis_ml/loader/loader.py:98\u001b[0m, in \u001b[0;36mLuxonisLoader.__getitem__\u001b[0;34m(self, idx)\u001b[0m\n\u001b[1;32m     96\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m kps \u001b[38;5;129;01min\u001b[39;00m sample\u001b[38;5;241m.\u001b[39mkeypoints\u001b[38;5;241m.\u001b[39mkeypoints:\n\u001b[1;32m     97\u001b[0m     \u001b[38;5;28mcls\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclasses\u001b[38;5;241m.\u001b[39mindex(kps\u001b[38;5;241m.\u001b[39mlabel)\n\u001b[0;32m---> 98\u001b[0m     pnts \u001b[38;5;241m=\u001b[39m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43marray\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkps\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpoints\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mreshape\u001b[49m\u001b[43m(\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mastype\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfloat32\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     99\u001b[0m     kps \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mzeros((\u001b[38;5;28mlen\u001b[39m(pnts), \u001b[38;5;241m3\u001b[39m))\n\u001b[1;32m    100\u001b[0m     nan_key \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39misnan(pnts[:, \u001b[38;5;241m0\u001b[39m])\n",
+      "\u001b[0;31mTypeError\u001b[0m: float() argument must be a string or a number, not 'BaseDict'"
+     ]
+    }
+   ],
+   "source": [
+    "with LuxonisDataset(\n",
+    "    team_id=team_id,\n",
+    "    dataset_id=dataset_id,\n",
+    ") as dataset:\n",
+    "    \n",
+    "    loader = LuxonisLoader(dataset)\n",
+    "    for data in loader:\n",
+    "        break"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "cdcc8595",
    "metadata": {},
@@ -281,10 +439,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "2724865d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "KeyError",
+     "evalue": "'_dataset_id'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[9], line 6\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m LuxonisDataset(\n\u001b[1;32m      2\u001b[0m     team_id\u001b[38;5;241m=\u001b[39mteam_id,\n\u001b[1;32m      3\u001b[0m     dataset_id\u001b[38;5;241m=\u001b[39mdataset_id,\n\u001b[1;32m      4\u001b[0m ) \u001b[38;5;28;01mas\u001b[39;00m dataset:\n\u001b[0;32m----> 6\u001b[0m     \u001b[43mdataset\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdelete_dataset\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Luxonis/luxonis-ml/src/luxonis_ml/data/dataset.py:469\u001b[0m, in \u001b[0;36mLuxonisDataset.delete_dataset\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    463\u001b[0m ldf_doc \u001b[38;5;241m=\u001b[39m res[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    465\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mluxonis_source_document\u001b[38;5;241m.\u001b[39mdelete_many(\n\u001b[1;32m    466\u001b[0m     {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_luxonis_dataset_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: ldf_doc[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_id\u001b[39m\u001b[38;5;124m\"\u001b[39m]}\n\u001b[1;32m    467\u001b[0m )\n\u001b[1;32m    468\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mversion_document\u001b[38;5;241m.\u001b[39mdelete_many(\n\u001b[0;32m--> 469\u001b[0m     {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_dataset_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[43mldf_doc\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m_dataset_id\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m}\n\u001b[1;32m    470\u001b[0m )\n\u001b[1;32m    471\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mtransaction_document\u001b[38;5;241m.\u001b[39mdelete_many({\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_dataset_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: ldf_doc[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_id\u001b[39m\u001b[38;5;124m\"\u001b[39m]})\n\u001b[1;32m    472\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mluxonis_dataset_document\u001b[38;5;241m.\u001b[39mdelete_many(\n\u001b[1;32m    473\u001b[0m     {\n\u001b[1;32m    474\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m$and\u001b[39m\u001b[38;5;124m\"\u001b[39m: [\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    478\u001b[0m     }\n\u001b[1;32m    479\u001b[0m )\n",
+      "\u001b[0;31mKeyError\u001b[0m: '_dataset_id'"
+     ]
+    }
+   ],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",

--- a/examples/COCO_people_subset.ipynb
+++ b/examples/COCO_people_subset.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "4c06d8fc",
    "metadata": {},
    "outputs": [],
@@ -25,7 +25,7 @@
     "from luxonis_ml.data import *\n",
     "from luxonis_ml.loader import *\n",
     "\n",
-    "BUCKET_TYPE = 'local'"
+    "BUCKET_STORAGE = BucketStorage.LOCAL"
    ]
   },
   {
@@ -38,40 +38,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "5cc9ddf2",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: gdown in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (4.7.1)\n",
-      "Requirement already satisfied: filelock in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (3.12.2)\n",
-      "Requirement already satisfied: six in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (1.16.0)\n",
-      "Requirement already satisfied: tqdm in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (4.65.0)\n",
-      "Requirement already satisfied: requests[socks] in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (2.31.0)\n",
-      "Requirement already satisfied: beautifulsoup4 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from gdown) (4.12.2)\n",
-      "Requirement already satisfied: soupsieve>1.2 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from beautifulsoup4->gdown) (2.4.1)\n",
-      "Requirement already satisfied: urllib3<3,>=1.21.1 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (1.26.16)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (2023.5.7)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (3.4)\n",
-      "Requirement already satisfied: charset-normalizer<4,>=2 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (3.1.0)\n",
-      "Requirement already satisfied: PySocks!=1.5.7,>=1.5.6 in /home/conor/Luxonis/envs/fiftyone/lib/python3.9/site-packages (from requests[socks]->gdown) (1.7.1)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.1.2\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "Downloading...\n",
-      "From: https://drive.google.com/uc?id=1XlvFK7aRmt8op6-hHkWVKIJQeDtOwoRT\n",
-      "To: /home/conor/Luxonis/luxonis-ml/data/COCO_people_subset.zip\n",
-      "100%|██████████████████████████████████████| 7.78M/7.78M [00:00<00:00, 17.7MB/s]\n",
-      "Archive:  ../data/COCO_people_subset.zip\n",
-      "replace ../data/person_keypoints_val2017.json? [y]es, [n]o, [A]ll, [N]one, [r]ename: ^C\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "! pip install gdown\n",
     "! gdown 1XlvFK7aRmt8op6-hHkWVKIJQeDtOwoRT -O ../data/COCO_people_subset.zip\n",
@@ -88,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7fa5d2b9",
    "metadata": {},
    "outputs": [],
@@ -201,18 +173,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "8171a7f9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset id: 64ad8195fb15ff76db990fcb\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "team_id = \"luxonis_team_id\"\n",
     "team_name = \"luxonis\"\n",
@@ -229,62 +193,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "9a30216e",
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 141381.03it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Checking for additions or modifications...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:01<00:00, 18.91it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting dataset media...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 127.36it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 100% |███████████████████| 30/30 [2.4s elapsed, 0s remaining, 12.7 samples/s]   \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",
     "    dataset_id=dataset_id,\n",
     "    team_name=team_name,\n",
     "    dataset_name=dataset_name,\n",
-    "    bucket_type=BUCKET_TYPE\n",
+    "    bucket_storage=BUCKET_STORAGE\n",
     ") as dataset:\n",
     "    \n",
     "    # defines the format of the COCO data source,\n",
@@ -309,46 +230,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "58991ba0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 186137.75it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Checking for additions or modifications...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:04<00:00,  6.65it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Extracting dataset media...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 30320.27it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",
@@ -368,22 +253,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "e60d5a44",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Dataset version: 1.1\n",
-      "Class attribute presence in version 1.0:\n",
-      "[False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False, False]\n",
-      "Class attribute presence in version 1.1:\n",
-      "[True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True, True]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",
@@ -401,23 +274,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "d160b62a",
+   "execution_count": null,
+   "id": "d9e983a4",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "float() argument must be a string or a number, not 'BaseDict'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[3], line 7\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m LuxonisDataset(\n\u001b[1;32m      2\u001b[0m     team_id\u001b[38;5;241m=\u001b[39mteam_id,\n\u001b[1;32m      3\u001b[0m     dataset_id\u001b[38;5;241m=\u001b[39mdataset_id,\n\u001b[1;32m      4\u001b[0m ) \u001b[38;5;28;01mas\u001b[39;00m dataset:\n\u001b[1;32m      6\u001b[0m     loader \u001b[38;5;241m=\u001b[39m LuxonisLoader(dataset)\n\u001b[0;32m----> 7\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m data \u001b[38;5;129;01min\u001b[39;00m loader:\n\u001b[1;32m      8\u001b[0m         \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;28mtype\u001b[39m(data))\n",
-      "File \u001b[0;32m~/Luxonis/luxonis-ml/src/luxonis_ml/loader/loader.py:98\u001b[0m, in \u001b[0;36mLuxonisLoader.__getitem__\u001b[0;34m(self, idx)\u001b[0m\n\u001b[1;32m     96\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m kps \u001b[38;5;129;01min\u001b[39;00m sample\u001b[38;5;241m.\u001b[39mkeypoints\u001b[38;5;241m.\u001b[39mkeypoints:\n\u001b[1;32m     97\u001b[0m     \u001b[38;5;28mcls\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mclasses\u001b[38;5;241m.\u001b[39mindex(kps\u001b[38;5;241m.\u001b[39mlabel)\n\u001b[0;32m---> 98\u001b[0m     pnts \u001b[38;5;241m=\u001b[39m \u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43marray\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkps\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpoints\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mreshape\u001b[49m\u001b[43m(\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[38;5;241;43m1\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m2\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mastype\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfloat32\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     99\u001b[0m     kps \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39mzeros((\u001b[38;5;28mlen\u001b[39m(pnts), \u001b[38;5;241m3\u001b[39m))\n\u001b[1;32m    100\u001b[0m     nan_key \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39misnan(pnts[:, \u001b[38;5;241m0\u001b[39m])\n",
-      "\u001b[0;31mTypeError\u001b[0m: float() argument must be a string or a number, not 'BaseDict'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",
@@ -439,23 +299,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "2724865d",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "KeyError",
-     "evalue": "'_dataset_id'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[9], line 6\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m LuxonisDataset(\n\u001b[1;32m      2\u001b[0m     team_id\u001b[38;5;241m=\u001b[39mteam_id,\n\u001b[1;32m      3\u001b[0m     dataset_id\u001b[38;5;241m=\u001b[39mdataset_id,\n\u001b[1;32m      4\u001b[0m ) \u001b[38;5;28;01mas\u001b[39;00m dataset:\n\u001b[0;32m----> 6\u001b[0m     \u001b[43mdataset\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdelete_dataset\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Luxonis/luxonis-ml/src/luxonis_ml/data/dataset.py:469\u001b[0m, in \u001b[0;36mLuxonisDataset.delete_dataset\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    463\u001b[0m ldf_doc \u001b[38;5;241m=\u001b[39m res[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    465\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mluxonis_source_document\u001b[38;5;241m.\u001b[39mdelete_many(\n\u001b[1;32m    466\u001b[0m     {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_luxonis_dataset_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: ldf_doc[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_id\u001b[39m\u001b[38;5;124m\"\u001b[39m]}\n\u001b[1;32m    467\u001b[0m )\n\u001b[1;32m    468\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mversion_document\u001b[38;5;241m.\u001b[39mdelete_many(\n\u001b[0;32m--> 469\u001b[0m     {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_dataset_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[43mldf_doc\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m_dataset_id\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m}\n\u001b[1;32m    470\u001b[0m )\n\u001b[1;32m    471\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mtransaction_document\u001b[38;5;241m.\u001b[39mdelete_many({\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_dataset_id\u001b[39m\u001b[38;5;124m\"\u001b[39m: ldf_doc[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_id\u001b[39m\u001b[38;5;124m\"\u001b[39m]})\n\u001b[1;32m    472\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mconn\u001b[38;5;241m.\u001b[39mluxonis_dataset_document\u001b[38;5;241m.\u001b[39mdelete_many(\n\u001b[1;32m    473\u001b[0m     {\n\u001b[1;32m    474\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m$and\u001b[39m\u001b[38;5;124m\"\u001b[39m: [\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    478\u001b[0m     }\n\u001b[1;32m    479\u001b[0m )\n",
-      "\u001b[0;31mKeyError\u001b[0m: '_dataset_id'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with LuxonisDataset(\n",
     "    team_id=team_id,\n",

--- a/src/luxonis_ml/data/__init__.py
+++ b/src/luxonis_ml/data/__init__.py
@@ -1,5 +1,13 @@
 from .session import LuxonisSession
-from .dataset import LuxonisDataset, LDFComponent, IType, HType, LDFTransactionType
+from .dataset import (
+    LuxonisDataset,
+    LDFComponent,
+    IType,
+    HType,
+    LDFTransactionType,
+    BucketType,
+    BucketStorage,
+)
 from .version import LuxonisVersion
 from .parsers import LuxonisParser, DatasetType
 from .labelstudio import LabelStudioConnector

--- a/src/luxonis_ml/data/dataset.py
+++ b/src/luxonis_ml/data/dataset.py
@@ -631,13 +631,26 @@ class LuxonisDataset:
                     for change in changes:
                         field, value = list(change.items())[0]
                         field_change = True
-                        tid = self._make_transaction(
-                            LDFTransactionType.UPDATE,
-                            sample_id=latest_sample._id,
-                            field=field,
-                            value=value,
-                            component=component_name,
-                        )
+                        if field == "split":
+                            group = data_utils.get_group_from_sample(
+                                self, latest_sample
+                            )
+                            for component_name in group:
+                                tid = self._make_transaction(
+                                    LDFTransactionType.UPDATE,
+                                    sample_id=group[component_name]["id"],
+                                    field=field,
+                                    value=value,
+                                    component=component_name,
+                                )
+                        else:
+                            tid = self._make_transaction(
+                                LDFTransactionType.UPDATE,
+                                sample_id=latest_sample._id,
+                                field=field,
+                                value=value,
+                                component=component_name,
+                            )
 
         if media_change or field_change:
             self._make_transaction(LDFTransactionType.END)
@@ -1043,7 +1056,9 @@ class LuxonisDataset:
                 if sample is None:  # a new sample which has had both ADD and UPDATE
                     # sample = get_previous_sample(transaction)
                     # TODO: Find a better way to handle those.
-                    print(f"Sample is none, skipping and versioning transatction")
+                    print(
+                        f"Sample is none for {transaction['_id']}, skipping and versioning transatction"
+                    )
                     self._version_transaction(transaction["_id"])
                     continue
                 else:

--- a/src/luxonis_ml/data/fiftyone_plugins/database.py
+++ b/src/luxonis_ml/data/fiftyone_plugins/database.py
@@ -20,8 +20,10 @@ class LuxonisDatasetDocument(Document):
     team_name = StringField()
     dataset_name = StringField()
     fo_dataset_id = ObjectIdField(db_field="_dataset_id")
+    ldf_version = StringField()
     path = StringField()
     bucket_type = StringField()
+    bucket_storage = StringField()
     current_version = FloatField()
 
 

--- a/src/luxonis_ml/data/utils/s3_utils.py
+++ b/src/luxonis_ml/data/utils/s3_utils.py
@@ -4,6 +4,7 @@ from botocore.exceptions import NoCredentialsError, ClientError
 import datetime
 from concurrent.futures import ThreadPoolExecutor
 import hashlib
+from pathlib import Path
 
 
 def get_file_hash(local_file):
@@ -15,7 +16,7 @@ def get_file_hash(local_file):
 
 def download_file(bucket, s3_file, local_dir):
     try:
-        local_file_path = os.path.join(local_dir, s3_file.key)
+        local_file_path = str(Path(local_dir) / s3_file.key)
         if (
             os.path.exists(local_file_path)
             and get_file_hash(local_file_path) == s3_file.e_tag[1:-1]

--- a/src/luxonis_ml/loader/loader.py
+++ b/src/luxonis_ml/loader/loader.py
@@ -40,7 +40,7 @@ class LuxonisLoader(torch.utils.data.Dataset):
             self.nk = 0
         self.augmentations = augmentations
 
-        if not self.stream and self.dataset.bucket_type != "local":
+        if not self.stream and self.dataset.bucket_storage.value != "local":
             self.dataset.sync_from_cloud()
 
         self.dataset.fo_dataset.group_slice = self.dataset.source.main_component
@@ -52,7 +52,7 @@ class LuxonisLoader(torch.utils.data.Dataset):
         sample_id = self.ids[idx]
         path = self.paths[idx]
         sample = self.dataset.fo_dataset[sample_id]
-        if self.stream and self.dataset.bucket_type != "local":
+        if self.stream and self.dataset.bucket_storage.value != "local":
             img_path = str(Path.home() / ".luxonis_mount" / path[1:])
         else:
             img_path = str(Path.home() / ".cache" / "luxonis_ml" / "data" / path[1:])

--- a/src/luxonis_ml/loader/loader.py
+++ b/src/luxonis_ml/loader/loader.py
@@ -53,9 +53,9 @@ class LuxonisLoader(torch.utils.data.Dataset):
         path = self.paths[idx]
         sample = self.dataset.fo_dataset[sample_id]
         if self.stream and self.dataset.bucket_type != "local":
-            img_path = f"{str(Path.home())}/.luxonis_mount/{path}"
+            img_path = str(Path.home() / ".luxonis_mount" / path[1:])
         else:
-            img_path = f"{str(Path.home())}/.cache/luxonis_ml/data/{path}"
+            img_path = str(Path.home() / ".cache" / "luxonis_ml" / "data" / path[1:])
         img = np.transpose(cv2.imread(img_path), (2, 0, 1))
         _, ih, iw = img.shape
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -161,11 +161,22 @@ class LuxonisDatasetTester(unittest.TestCase):
         self.assertEqual(res["current_version"], 0.0, "Version initialize failure")
         self.assertEqual(
             res["path"],
-            f"{Path.home()}/.cache/luxonis_ml/data/{self.team_id}/datasets/{self.dataset_id}",
+            str(
+                Path.home()
+                / ".cache"
+                / "luxonis_ml"
+                / "data"
+                / self.team_id
+                / "datasets"
+                / self.dataset_id
+            ),
             "Dataset path failure",
         )
         self.assertEqual(
-            res["bucket_type"], "local", "Default bucket type is not local"
+            res["bucket_type"], "external", "Default bucket type is not external"
+        )
+        self.assertEqual(
+            res["bucket_storage"], "local", "Default bucket storage is not local"
         )
 
         curr = self.conn.datasets.find({"name": f"{self.team_id}-{self.dataset_id}"})
@@ -179,44 +190,22 @@ class LuxonisDatasetTester(unittest.TestCase):
             "Luxonis dataset does not reference fo dataset",
         )
 
-        with LuxonisDataset(
-            self.team_id, self.dataset_id, bucket_type="aws"
-        ) as dataset:
-            dataset.version = 5
+    # def test_aws_init(self):
+    #     with LuxonisDataset(
+    #         self.team_id, self.dataset_id, bucket_type="aws", override_bucket_type=True
+    #     ) as dataset:
+    #         pass
 
-        curr = self.conn.luxonis_dataset_document.find(
-            {"$and": [{"team_id": self.team_id}, {"_id": ObjectId(self.dataset_id)}]}
-        )
-        res = list(curr)
-        self.assertGreater(len(res), 0, "Document not created")
-        self.assertEqual(len(res), 1, "Multiple documents created")
-        res = res[0]
-        self.assertEqual(res["current_version"], 5.0, "Update version field fail")
-        self.assertEqual(
-            res["bucket_type"], "local", "Default override_bucket_type arg fail"
-        )
-
-        with LuxonisDataset(
-            self.team_id, self.dataset_id, bucket_type="aws"
-        ) as dataset:
-            dataset.version = 0  # set back to 0
-
-    def test_aws_init(self):
-        with LuxonisDataset(
-            self.team_id, self.dataset_id, bucket_type="aws", override_bucket_type=True
-        ) as dataset:
-            pass
-
-        curr = self.conn.luxonis_dataset_document.find(
-            {"$and": [{"team_id": self.team_id}, {"_id": ObjectId(self.dataset_id)}]}
-        )
-        res = list(curr)
-        self.assertGreater(len(res), 0, "Document not created")
-        self.assertEqual(len(res), 1, "Multiple documents created")
-        res = res[0]
-        self.assertEqual(
-            res["bucket_type"], "aws", "Default override_bucket_type arg fail"
-        )
+    #     curr = self.conn.luxonis_dataset_document.find(
+    #         {"$and": [{"team_id": self.team_id}, {"_id": ObjectId(self.dataset_id)}]}
+    #     )
+    #     res = list(curr)
+    #     self.assertGreater(len(res), 0, "Document not created")
+    #     self.assertEqual(len(res), 1, "Multiple documents created")
+    #     res = res[0]
+    #     self.assertEqual(
+    #         res["bucket_type"], "aws", "Default override_bucket_type arg fail"
+    #     )
 
     def test_source(self):
         with LuxonisDataset(self.team_id, self.dataset_id) as dataset:
@@ -749,7 +738,7 @@ if __name__ == "__main__":
     suite = unittest.TestSuite()
     suite.keep = args.keep
     suite.addTest(LuxonisDatasetTester("test_local_init"))
-    suite.addTest(LuxonisDatasetTester("test_aws_init"))
+    # suite.addTest(LuxonisDatasetTester("test_aws_init"))
     suite.addTest(LuxonisDatasetTester("test_source"))
     suite.addTest(LuxonisDatasetTester("test_transactions"))
     suite.addTest(LuxonisDatasetTester("test_add"))


### PR DESCRIPTION
- Ensure all components have the same split
- Add an `instance_id` field to all samples with the instance hash
- Check format for bounding box label to start with class
- Replace static paths with pathlib for paths referencing local OS
- If no field is present in an update, assume it does not change instead of assuming it is removed. This also fixes the issue with `split` becoming `None`
- Add `ldf_version` to the LDF mongo doc
- Rework bucket_type with `BucketType` and `BucketStorage`