### PR TITLE
Initial Exceptions

### DIFF
--- a/src/luxonis_ml/data/dataset.py
+++ b/src/luxonis_ml/data/dataset.py
@@ -6,14 +6,11 @@ from luxonis_ml.data.utils.exceptions import *
 from fiftyone import ViewField as F
 import os, subprocess, shutil
 from pathlib import Path
-import glob
 import warnings
 import cv2
 from PIL import Image
-import pickle
 import json
 import boto3
-import glob
 from tqdm import tqdm
 from enum import Enum
 import numpy as np
@@ -516,6 +513,11 @@ class LuxonisDataset:
     def _make_transaction(
         self, action, sample_id=None, field=None, value=None, component=None
     ):
+        if field == "segmentation":
+            mask = value
+            value = {"segmentation": "mask"}
+        else:
+            mask = None
         transaction_doc = fop.TransactionDocument(
             dataset_id=self.dataset_doc.id,
             created_at=datetime.utcnow(),
@@ -524,6 +526,7 @@ class LuxonisDataset:
             sample_id=sample_id,
             field=field,
             value={"value": value},
+            mask=mask,
             component=component,
             version=-1,  # encodes no version yet assigned
         )
@@ -914,7 +917,7 @@ class LuxonisDataset:
                             sample[
                                 transaction["field"]
                             ] = data_utils.construct_segmentation_label(
-                                self, transaction["value"]["value"]
+                                self, transaction["mask"]
                             )
                         elif transaction["field"] == "keypoints":
                             sample[
@@ -946,7 +949,7 @@ class LuxonisDataset:
                             sample[
                                 transaction["field"]
                             ] = data_utils.construct_segmentation_label(
-                                self, transaction["value"]["value"]
+                                self, transaction["mask"]
                             )
                         elif transaction["field"] == "keypoints":
                             sample[

--- a/src/luxonis_ml/data/dataset.py
+++ b/src/luxonis_ml/data/dataset.py
@@ -649,13 +649,20 @@ class LuxonisDataset:
 
                         if "class" in additions[i][component_name].keys():
                             data_utils.assert_classification_format(
-                                additions[i][component_name]["class"]
+                                self, additions[i][component_name]["class"]
                             )
                         if "boxes" in additions[i][component_name].keys():
                             data_utils.assert_boxes_format(
-                                additions[i][component_name]["boxes"]
+                                self, additions[i][component_name]["boxes"]
                             )
-                        # TODO: complete for segmentation and keypoints
+                        if "segmentation" in additions[i][component_name].keys():
+                            data_utils.assert_segmentation_format(
+                                self, additions[i][component_name]["segmentation"]
+                            )
+                        if "keypoints" in additions[i][component_name].keys():
+                            data_utils.assert_keypoints_format(
+                                self, additions[i][component_name]["keypoints"]
+                            )
 
                         tid = self._make_transaction(
                             LDFTransactionType.ADD,

--- a/src/luxonis_ml/data/dataset.py
+++ b/src/luxonis_ml/data/dataset.py
@@ -646,6 +646,17 @@ class LuxonisDataset:
                         # ADD case
                         media_change = True
                         additions[i][component_name]["_group"] = group
+
+                        if "class" in additions[i][component_name].keys():
+                            data_utils.assert_classification_format(
+                                additions[i][component_name]["class"]
+                            )
+                        if "boxes" in additions[i][component_name].keys():
+                            data_utils.assert_boxes_format(
+                                additions[i][component_name]["boxes"]
+                            )
+                        # TODO: complete for segmentation and keypoints
+
                         tid = self._make_transaction(
                             LDFTransactionType.ADD,
                             sample_id=None,

--- a/src/luxonis_ml/data/dataset.py
+++ b/src/luxonis_ml/data/dataset.py
@@ -624,7 +624,7 @@ class LuxonisDataset:
                     try:
                         filepath = addition[component_name]["filepath"]
                     except:
-                        raise AdditionsStructureError(
+                        raise AdditionsStructureException(
                             "Additions must be List[dict] with {'<component_name>': {'filepath':...}}. The <component_name> and filepath are required"
                         )
                     additions[i][component_name]["_old_filepath"] = filepath
@@ -632,7 +632,9 @@ class LuxonisDataset:
                         try:
                             hashpath, hash = data_utils.generate_hashname(filepath)
                         except:
-                            raise AdditionNotFoundError(f"{filepath} does not exist")
+                            raise AdditionNotFoundException(
+                                f"{filepath} does not exist"
+                            )
                         additions[i][component_name]["instance_id"] = hash
                         additions[i][component_name]["_new_image_name"] = hashpath
                     granule = data_utils.get_granule(filepath, addition, component_name)
@@ -868,7 +870,7 @@ class LuxonisDataset:
                         )
 
                     if transaction_to_additions.get(str(transaction["_id"])) is None:
-                        raise TransactionNotFoundError(
+                        raise TransactionNotFoundException(
                             f"{str(transaction['_id'])} not found matching an addition"
                         )
 

--- a/src/luxonis_ml/data/fiftyone_plugins/database.py
+++ b/src/luxonis_ml/data/fiftyone_plugins/database.py
@@ -7,6 +7,7 @@ from fiftyone.core.fields import (
     IntField,
     DictField,
     BooleanField,
+    ArrayField,
 )
 
 from fiftyone.core.odm.document import Document
@@ -60,5 +61,6 @@ class TransactionDocument(Document):
     sample_id = ObjectIdField()
     field = StringField()
     value = DictField()
+    mask = ArrayField()
     component = StringField()
     version = FloatField()

--- a/src/luxonis_ml/data/fiftyone_plugins/database.py
+++ b/src/luxonis_ml/data/fiftyone_plugins/database.py
@@ -24,7 +24,7 @@ class LuxonisDatasetDocument(Document):
     path = StringField()
     bucket_type = StringField()
     bucket_storage = StringField()
-    current_version = FloatField()
+    dataset_version = StringField()
 
 
 class LuxonisSourceDocument(Document):

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -5,6 +5,7 @@ import os
 import uuid
 from pathlib import Path
 from fiftyone import ViewField as F
+from luxonis_ml.data.utils.exceptions import *
 
 
 def get_granule(filepath, addition, component_name):
@@ -59,7 +60,7 @@ def check_boxes(dataset, val1, val2):
                 (isinstance(val1[0], int) or isinstance(val1[0], str))
                 and len(val1) == 5
             ):
-                raise Exception(
+                raise BoundingBoxFormatError(
                     "Wrong bounding box format! It should start with int or str for the class label"
                 )
 
@@ -164,7 +165,7 @@ def check_fields(dataset, latest_sample, addition, component_name):
             elif field == "keypoints":
                 changes += check_keypoints(dataset, val1, val2)
             else:
-                raise NotImplementedError()
+                raise NotImplementedError("The CV task {field} is not implement yet")
         elif val1 != val2:
             changes.append({field: val1})
 

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -33,7 +33,7 @@ def assert_classification_format(dataset, val):
                     raise ClassNotFoundError(f"Class {v} is not found in dataset")
         else:
             raise ClassificationFormatError(
-                "Classification annotation ('class') must be a string or list os strings"
+                "Classification annotation  must be a string or list of strings"
             )
 
 

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -263,6 +263,9 @@ def get_group_from_sample(dataset, sample):
 
 def get_filepath_from_hash(dataset, hash):
     instance_view = dataset.fo_dataset.match(F("instance_id") == hash)
-    for sample in instance_view:
-        break
-    return sample.filepath
+    if len(instance_view):
+        for sample in instance_view:
+            break
+        return sample.filepath
+    else:
+        return None

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -1,8 +1,7 @@
 import numpy as np
-import hashlib
 import fiftyone as fo
+import fiftyone.core.utils as fou
 import os
-import subprocess
 import uuid
 from pathlib import Path
 from fiftyone import ViewField as F
@@ -216,6 +215,9 @@ def construct_segmentation_label(dataset, mask):
         return None
     if isinstance(mask, list):
         mask = np.array(mask)
+    elif isinstance(mask, bytes):
+        mask = fou.deserialize_numpy_array(mask)
+    mask = mask.astype(np.uint16)  # decrease size of binary
     return fo.Segmentation(mask=mask)
 
 

--- a/src/luxonis_ml/data/utils/exceptions.py
+++ b/src/luxonis_ml/data/utils/exceptions.py
@@ -24,6 +24,12 @@ class AdditionNotFoundError(Exception):
     pass
 
 
+class ClassificationFormatError(Exception):
+    """Exception for wrong classification format being passed in additions"""
+
+    pass
+
+
 class BoundingBoxFormatError(Exception):
     """Exception for wrong bounding box format being passed in additions"""
 

--- a/src/luxonis_ml/data/utils/exceptions.py
+++ b/src/luxonis_ml/data/utils/exceptions.py
@@ -1,5 +1,4 @@
 class DataTransactionException(Exception):
-
     """
     Exception for the _add_filer function, which provides
     a specific reason along with a more general message
@@ -10,15 +9,27 @@ class DataTransactionException(Exception):
         super().__init__(message)
 
 
-class AdditionsStructureError(Exception):
+class DataExecutionException(Exception):
+    """
+    Exception for the _add_execute function, which provides
+    a specific reason along with a more general message
+    """
 
+    def __init__(self, transaction, exception_type, reason):
+        if transaction is None:
+            message = f"Executing transaction {transaction} failed with {exception_type}: {reason}"
+        else:
+            message = f"Executing transaction {transaction['_id']} [{transaction['action']}] failed with {exception_type}: {reason}"
+        super().__init__(message)
+
+
+class AdditionsStructureError(Exception):
     """Excpetion if incorrect format of additions"""
 
     pass
 
 
 class AdditionNotFoundError(Exception):
-
     """Excpetion for not finding filepath"""
 
     pass
@@ -50,5 +61,11 @@ class KeypointFormatError(Exception):
 
 class ClassNotFoundError(Exception):
     """Exception for classes not found in dataset"""
+
+    pass
+
+
+class TransactionNotFoundError(Exception):
+    """Exception not finding a transaction in data execution"""
 
     pass

--- a/src/luxonis_ml/data/utils/exceptions.py
+++ b/src/luxonis_ml/data/utils/exceptions.py
@@ -1,0 +1,17 @@
+class DataTransactionException(Exception):
+
+    """
+    Exception for the _add_filer function, which provides
+    a specific reason along with a more general message
+    """
+
+    def __init__(self, filepath, exception_type, reason):
+        message = f"Creating a transaction for filepath {filepath} failed with {exception_type}: {reason}"
+        super().__init__(message)
+
+
+class AdditionsStructureException(Exception):
+
+    """Excpetion if incorrect format of additions"""
+
+    pass

--- a/src/luxonis_ml/data/utils/exceptions.py
+++ b/src/luxonis_ml/data/utils/exceptions.py
@@ -10,8 +10,21 @@ class DataTransactionException(Exception):
         super().__init__(message)
 
 
-class AdditionsStructureException(Exception):
+class AdditionsStructureError(Exception):
 
     """Excpetion if incorrect format of additions"""
+
+    pass
+
+
+class AdditionNotFoundError(Exception):
+
+    """Excpetion for not finding filepath"""
+
+    pass
+
+
+class BoundingBoxFormatError(Exception):
+    """Exception for wrong bounding box format being passed in additions"""
 
     pass

--- a/src/luxonis_ml/data/utils/exceptions.py
+++ b/src/luxonis_ml/data/utils/exceptions.py
@@ -34,3 +34,21 @@ class BoundingBoxFormatError(Exception):
     """Exception for wrong bounding box format being passed in additions"""
 
     pass
+
+
+class SegmentationFormatError(Exception):
+    """Exception for wrong segmentation mask format being passed in additions"""
+
+    pass
+
+
+class KeypointFormatError(Exception):
+    """Exception for wrong segmentation mask format being passed in additions"""
+
+    pass
+
+
+class ClassNotFoundError(Exception):
+    """Exception for classes not found in dataset"""
+
+    pass

--- a/src/luxonis_ml/data/utils/exceptions.py
+++ b/src/luxonis_ml/data/utils/exceptions.py
@@ -23,49 +23,49 @@ class DataExecutionException(Exception):
         super().__init__(message)
 
 
-class AdditionsStructureError(Exception):
+class AdditionsStructureException(Exception):
     """Excpetion if incorrect format of additions"""
 
     pass
 
 
-class AdditionNotFoundError(Exception):
+class AdditionNotFoundException(Exception):
     """Excpetion for not finding filepath"""
 
     pass
 
 
-class ClassificationFormatError(Exception):
+class ClassificationFormatException(Exception):
     """Exception for wrong classification format being passed in additions"""
 
     pass
 
 
-class BoundingBoxFormatError(Exception):
+class BoundingBoxFormatException(Exception):
     """Exception for wrong bounding box format being passed in additions"""
 
     pass
 
 
-class SegmentationFormatError(Exception):
+class SegmentationFormatException(Exception):
     """Exception for wrong segmentation mask format being passed in additions"""
 
     pass
 
 
-class KeypointFormatError(Exception):
+class KeypointFormatException(Exception):
     """Exception for wrong segmentation mask format being passed in additions"""
 
     pass
 
 
-class ClassNotFoundError(Exception):
+class ClassUnknownException(Exception):
     """Exception for classes not found in dataset"""
 
     pass
 
 
-class TransactionNotFoundError(Exception):
+class TransactionNotFoundException(Exception):
     """Exception not finding a transaction in data execution"""
 
     pass

--- a/tests/test.py
+++ b/tests/test.py
@@ -28,22 +28,22 @@ class LuxonisDatasetTester(unittest.TestCase):
         self.team_name = "unittest"
         self.dataset_name = "coco"
 
-        self.coco_images_path = "../data/person_val2017_subset"
-        self.coco_annotation_path = "../data/person_keypoints_val2017.json"
-        if os.path.exists(self.coco_images_path):
-            shutil.rmtree(self.coco_images_path)
-        if os.path.exists(self.coco_annotation_path):
-            os.remove(self.coco_annotation_path)
+        # self.coco_images_path = "../data/person_val2017_subset"
+        # self.coco_annotation_path = "../data/person_keypoints_val2017.json"
+        # if os.path.exists(self.coco_images_path):
+        #     shutil.rmtree(self.coco_images_path)
+        # if os.path.exists(self.coco_annotation_path):
+        #     os.remove(self.coco_annotation_path)
 
-        print("Downloading data from GDrive...")
-        cmd = (
-            "gdown 1XlvFK7aRmt8op6-hHkWVKIJQeDtOwoRT -O ../data/COCO_people_subset.zip"
-        )
-        subprocess.check_output(cmd, shell=True)
+        # print("Downloading data from GDrive...")
+        # cmd = (
+        #     "gdown 1XlvFK7aRmt8op6-hHkWVKIJQeDtOwoRT -O ../data/COCO_people_subset.zip"
+        # )
+        # subprocess.check_output(cmd, shell=True)
 
-        print("Extracting data...")
-        cmd = "unzip ../data/COCO_people_subset.zip -d ../data/"
-        subprocess.check_output(cmd, shell=True)
+        # print("Extracting data...")
+        # cmd = "unzip ../data/COCO_people_subset.zip -d ../data/"
+        # subprocess.check_output(cmd, shell=True)
 
         self.conn = foo.get_db_conn()
         # if dataset already exists, delete it
@@ -742,12 +742,12 @@ if __name__ == "__main__":
     suite.addTest(LuxonisDatasetTester("test_local_init"))
     suite.addTest(LuxonisDatasetTester("test_source"))
     suite.addTest(LuxonisDatasetTester("test_transactions"))
-    # suite.addTest(LuxonisDatasetTester("test_add"))
-    # suite.addTest(LuxonisDatasetTester("test_version_1"))
-    # suite.addTest(LuxonisDatasetTester("test_modify"))
-    # suite.addTest(LuxonisDatasetTester("test_version_2"))
-    # suite.addTest(LuxonisDatasetTester("test_delete"))
-    # suite.addTest(LuxonisDatasetTester("test_version_3"))
+    suite.addTest(LuxonisDatasetTester("test_add"))
+    suite.addTest(LuxonisDatasetTester("test_version_1"))
+    suite.addTest(LuxonisDatasetTester("test_modify"))
+    suite.addTest(LuxonisDatasetTester("test_version_2"))
+    suite.addTest(LuxonisDatasetTester("test_delete"))
+    suite.addTest(LuxonisDatasetTester("test_version_3"))
     suite.addTest(LuxonisDatasetTester("test_add_filter_exceptions"))
     if not args.keep:
         suite.addTest(LuxonisDatasetTester("test_delete_dataset"))

--- a/tests/test.py
+++ b/tests/test.py
@@ -673,14 +673,14 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions = [{"nonsense": 5}]  # complete nonsense
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with AdditionsStructureError:*",
+                "Creating a transaction for filepath .* failed with AdditionsStructureException:*",
                 dataset._add_filter,
                 additions,
             )
             additions = [{"A": {"weather": "sunny"}}]  # missing filepath
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with AdditionsStructureError:*",
+                "Creating a transaction for filepath .* failed with AdditionsStructureException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -689,7 +689,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions = [{"A": {"filepath": "/some/made/up/path"}}]
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with AdditionNotFoundError:*",
+                "Creating a transaction for filepath .* failed with AdditionNotFoundException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -702,7 +702,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[1]["A"]["filepath"] = "/some/made/up/path"  # intentional error
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with AdditionNotFoundError:*",
+                "Creating a transaction for filepath .* failed with AdditionNotFoundException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -721,7 +721,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["class"] = 0.5  # wrong class type
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with ClassificationFormatError:*",
+                "Creating a transaction for filepath .* failed with ClassificationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -729,7 +729,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["class"] = ["person", 0.5]  # wrong class type within list
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with ClassificationFormatError:*",
+                "Creating a transaction for filepath .* failed with ClassificationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -737,7 +737,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["class"] = "cat"  # class not in dataset
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with ClassNotFoundError:*",
+                "Creating a transaction for filepath .* failed with ClassUnknownException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -749,7 +749,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # remove class from bounding box
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -759,7 +759,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # remove a point from bounding box
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -767,7 +767,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["boxes"] = [0, 1, 2, 3]  # bad format
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -777,7 +777,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # int in x,y,w,h
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -787,7 +787,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # value in x,y,w,h < 0
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -797,7 +797,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # value in x+w > 1
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -807,7 +807,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # class is not string
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -815,7 +815,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["boxes"][0][0] = "cat"  # invalid class
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with ClassNotFoundError:*",
+                "Creating a transaction for filepath .* failed with ClassUnknownException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -825,7 +825,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["segmentation"] = 5
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with SegmentationFormatError:*",
+                "Creating a transaction for filepath .* failed with SegmentationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -833,7 +833,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["segmentation"] = np.zeros(10)  # wrong shape
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with SegmentationFormatError:*",
+                "Creating a transaction for filepath .* failed with SegmentationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -841,7 +841,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["segmentation"][1, :] = -1  # negative numbers
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with SegmentationFormatError:*",
+                "Creating a transaction for filepath .* failed with SegmentationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -850,7 +850,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["segmentation"][1, :] = 0.5  # non-int numbers
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with SegmentationFormatError:*",
+                "Creating a transaction for filepath .* failed with SegmentationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -860,7 +860,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["keypoints"] = [[0.2, 0.3]]
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with KeypointFormatError:*",
+                "Creating a transaction for filepath .* failed with KeypointFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -870,7 +870,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # length 3 point
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with KeypointFormatError:*",
+                "Creating a transaction for filepath .* failed with KeypointFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -880,7 +880,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # negative number
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with KeypointFormatError:*",
+                "Creating a transaction for filepath .* failed with KeypointFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -888,7 +888,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions[0]["A"]["keypoints"] = [[0, [[0.2, 0.3]]]]  # class is not string
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with KeypointFormatError:*",
+                "Creating a transaction for filepath .* failed with KeypointFormatException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -898,7 +898,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             ]  # class not in dataset
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with ClassNotFoundError:*",
+                "Creating a transaction for filepath .* failed with ClassUnknownException:*",
                 dataset._add_filter,
                 additions,
             )
@@ -907,28 +907,28 @@ class LuxonisDatasetTester(unittest.TestCase):
             additions = [{"A": {"filepath": "../data/nothing.jpg", "class": 5}}]
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with ClassificationFormatError:*",
+                "Creating a transaction for filepath .* failed with ClassificationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
             additions = [{"A": {"filepath": "../data/nothing.jpg", "boxes": 5}}]
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with BoundingBoxFormatError:*",
+                "Creating a transaction for filepath .* failed with BoundingBoxFormatException:*",
                 dataset._add_filter,
                 additions,
             )
             additions = [{"A": {"filepath": "../data/nothing.jpg", "segmentation": 5}}]
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with SegmentationFormatError:*",
+                "Creating a transaction for filepath .* failed with SegmentationFormatException:*",
                 dataset._add_filter,
                 additions,
             )
             additions = [{"A": {"filepath": "../data/nothing.jpg", "keypoints": 5}}]
             self.assertRaisesRegex(
                 DataTransactionException,
-                "Creating a transaction for filepath .* failed with KeypointFormatError:*",
+                "Creating a transaction for filepath .* failed with KeypointFormatException:*",
                 dataset._add_filter,
                 additions,
             )


### PR DESCRIPTION
- Efficiently store segmentation arrays as serialized bytes (using fiftyone `ArrayField`) to speed up transactions
- Custom exception handling for `LuxonisDataset.add`, which provide more detailed error messages
- Rollback for `LuxonisDataset.add` so that in the case of an error or `KeyboardInterrupt`, we attempt to return the dataset to its original state
- Thorough annotation checking for classification, bounding boxes, segmentation, and keypoints to ensure the correct format from `additions`