### PR TITLE
GCS Support, annotated tag, delete rework

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tqdm>=4.64.1
 lakefs_client>=0.90.0
 webdataset>=0.2.31
 b2>=3.6.0
-opencv-python>=4.7.0.68
+opencv-python==4.7.0.68
 PyYAML>=6.0
 pandasql>=0.7.3
 pycocotools>=2.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ sqlalchemy==1.4.46
 idx2numpy==1.2.3
 fiftyone==0.21.0
 label-studio-sdk>=0.0.28
+google-cloud-storage>=2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ lakefs_client>=0.90.0
 webdataset>=0.2.31
 b2>=3.6.0
 opencv-python==4.7.0.68
+opencv-python-headless==4.7.0.68
 PyYAML>=6.0
 pandasql>=0.7.3
 pycocotools>=2.0.6

--- a/src/luxonis_ml/data/dataset.py
+++ b/src/luxonis_ml/data/dataset.py
@@ -514,13 +514,21 @@ class LuxonisDataset:
     def sync_from_cloud(self):
         if self.bucket_storage.value == "local":
             self.logger.warning("This is a local dataset! Cannot sync")
-        else:
+        elif self.bucket_storage.value == "s3":
             sync_from_s3(
                 non_streaming_dir=str(Path.home() / ".cache" / "luxonis_ml" / "data"),
                 bucket=self.bucket,
                 bucket_dir=str(Path(self.team_id) / "datasets" / self.dataset_id),
                 endpoint_url=self._get_credentials("AWS_S3_ENDPOINT_URL"),
             )
+        elif self.bucket_storage.value == "gcs":
+            sync_from_gcs(
+                non_streaming_dir=str(Path.home() / ".cache" / "luxonis_ml" / "data"),
+                bucket=self.bucket,
+                bucket_dir=str(Path(self.team_id) / "datasets" / self.dataset_id),
+            )
+        else:
+            raise NotImplementedError
 
     def get_classes(self):
         classes = set()
@@ -1023,7 +1031,11 @@ class LuxonisDataset:
                         endpoint_url=self._get_credentials("AWS_S3_ENDPOINT_URL"),
                     )
                 else:
-                    raise NotImplementedError
+                    sync_to_gcs(
+                        bucket=self.bucket,
+                        gcs_dir=self.bucket_path,
+                        local_dir=local_cache,
+                    )
 
         elif self.bucket_storage.value == "gcs" and not from_bucket:
             sync_to_gcs(

--- a/src/luxonis_ml/data/dataset.py
+++ b/src/luxonis_ml/data/dataset.py
@@ -744,9 +744,7 @@ class LuxonisDataset:
                         additions[i][component_name]["_old_filepath"] = filepath
                         if not data_utils.is_modified_filepath(self, filepath):
                             try:
-                                hashpath, hash = data_utils.generate_hashname(
-                                    self, filepath
-                                )
+                                hashpath, hash = data_utils.generate_hashname(filepath)
                             except:
                                 raise AdditionNotFoundException(
                                     f"{filepath} does not exist"

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -328,20 +328,21 @@ def construct_keypoints_label(dataset, kps):
 
 
 def generate_hashname(dataset, filepath, from_bucket):
-    if dataset.bucket_storage.value == "local" or not from_bucket:
-        # Read the contents of the file
-        with open(filepath, "rb") as file:
-            file_contents = file.read()
+    # if dataset.bucket_storage.value == "local" or not from_bucket:
 
-        # TODO: check for a corrupted image by handling cv2.imread
+    # elif from_bucket and dataset.bucket_storage.value == "s3":
+    #     object_key = filepath.split(f"s3://{dataset.bucket}/")[-1]
+    #     response = dataset.client.get_object(Bucket=dataset.bucket, Key=object_key)
+    #     file_contents = response["Body"].read()
 
-    elif from_bucket and dataset.bucket_storage.value == "s3":
-        object_key = filepath.split(f"s3://{dataset.bucket}/")[-1]
-        response = dataset.client.get_object(Bucket=dataset.bucket, Key=object_key)
-        file_contents = response["Body"].read()
+    # elif from_bucket and dataset.bucket_storage.value == "gcs":
+    #     raise NotImplementedError()
 
-    elif from_bucket and dataset.bucket_storage.value == "gcs":
-        raise NotImplementedError()
+    # Read the contents of the file
+    with open(filepath, "rb") as file:
+        file_contents = file.read()
+
+    # TODO: check for a corrupted image by handling cv2.imread
 
     # Generate the UUID5 based on the file contents and the NAMESPACE_URL
     file_hash_uuid = uuid.uuid5(uuid.NAMESPACE_URL, file_contents.hex())

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -327,17 +327,7 @@ def construct_keypoints_label(dataset, kps):
     )
 
 
-def generate_hashname(dataset, filepath, from_bucket):
-    # if dataset.bucket_storage.value == "local" or not from_bucket:
-
-    # elif from_bucket and dataset.bucket_storage.value == "s3":
-    #     object_key = filepath.split(f"s3://{dataset.bucket}/")[-1]
-    #     response = dataset.client.get_object(Bucket=dataset.bucket, Key=object_key)
-    #     file_contents = response["Body"].read()
-
-    # elif from_bucket and dataset.bucket_storage.value == "gcs":
-    #     raise NotImplementedError()
-
+def generate_hashname(dataset, filepath):
     # Read the contents of the file
     with open(filepath, "rb") as file:
         file_contents = file.read()

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -327,7 +327,7 @@ def construct_keypoints_label(dataset, kps):
     )
 
 
-def generate_hashname(dataset, filepath):
+def generate_hashname(filepath):
     # Read the contents of the file
     with open(filepath, "rb") as file:
         file_contents = file.read()

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -327,10 +327,21 @@ def construct_keypoints_label(dataset, kps):
     )
 
 
-def generate_hashname(filepath):
-    # Read the contents of the file
-    with open(filepath, "rb") as file:
-        file_contents = file.read()
+def generate_hashname(dataset, filepath, from_bucket):
+    if dataset.bucket_storage.value == "local" or not from_bucket:
+        # Read the contents of the file
+        with open(filepath, "rb") as file:
+            file_contents = file.read()
+
+        # TODO: check for a corrupted image by handling cv2.imread
+
+    elif from_bucket and dataset.bucket_storage.value == "s3":
+        object_key = filepath.split(f"s3://{dataset.bucket}/")[-1]
+        response = dataset.client.get_object(Bucket=dataset.bucket, Key=object_key)
+        file_contents = response["Body"].read()
+
+    elif from_bucket and dataset.bucket_storage.value == "gcs":
+        raise NotImplementedError()
 
     # Generate the UUID5 based on the file contents and the NAMESPACE_URL
     file_hash_uuid = uuid.uuid5(uuid.NAMESPACE_URL, file_contents.hex())

--- a/src/luxonis_ml/data/utils/gcs_utils.py
+++ b/src/luxonis_ml/data/utils/gcs_utils.py
@@ -25,10 +25,8 @@ def copy_file(bucket, addition):
         if dst_prefix.startswith("/"):
             dst_prefix = dst_prefix[1:]
 
-        print(1, src_prefix, dst_prefix)
         blob = bucket.blob(src_prefix)
-        print(2, blob.name)
-        new_blob = bucket.copy_blob(blob, bucket, dst_prefix)
+        bucket.copy_blob(blob, bucket, dst_prefix)
 
 
 def get_uuid(bucket, gcp_path):

--- a/src/luxonis_ml/data/utils/gcs_utils.py
+++ b/src/luxonis_ml/data/utils/gcs_utils.py
@@ -1,0 +1,32 @@
+import os
+from google.cloud import storage
+from concurrent.futures import ThreadPoolExecutor
+
+
+def sync_from_gcs():
+    raise NotImplementedError
+
+
+def upload_file(bucket, local_file, gcs_file):
+    blob = bucket.blob(gcs_file)
+    blob.upload_from_filename(local_file)
+
+
+def sync_to_gcs(bucket, gcs_dir, local_dir):
+    print("Syncing to cloud...")
+    bucket = storage.Client().bucket(bucket)
+
+    try:
+        files_to_upload = [
+            os.path.join(dp, f) for dp, _, fn in os.walk(local_dir) for f in fn
+        ]
+
+        with ThreadPoolExecutor() as executor:
+            for local_file_path in files_to_upload:
+                gcs_dest = os.path.join(
+                    gcs_dir, os.path.relpath(local_file_path, local_dir)
+                )
+                executor.submit(upload_file, bucket, local_file_path, gcs_dest)
+
+    except Exception as e:
+        print("Unable to upload files. Reason:", e)

--- a/src/luxonis_ml/data/utils/s3_utils.py
+++ b/src/luxonis_ml/data/utils/s3_utils.py
@@ -1,7 +1,6 @@
 import os
 import boto3
 from botocore.exceptions import NoCredentialsError, ClientError
-import datetime
 from concurrent.futures import ThreadPoolExecutor
 import hashlib
 from pathlib import Path

--- a/tests/test.py
+++ b/tests/test.py
@@ -608,7 +608,7 @@ class LuxonisDatasetTester(unittest.TestCase):
         with LuxonisDataset(self.team_id, self.dataset_id) as dataset:
             for sample in dataset.fo_dataset:
                 break
-            dataset.delete(["fe163bd9-6381-5533-9d41-c1735edf96d5"])
+            dataset.delete([sample.instance_id])
 
             res = (
                 dataset._check_transactions_to_version()

--- a/tests/test.py
+++ b/tests/test.py
@@ -254,11 +254,11 @@ class LuxonisDatasetTester(unittest.TestCase):
                 }
             )  # optional for keypoints to define the skeleton visualization
 
-            result = dataset._check_transactions()
+            result = dataset._check_transactions_to_execute()
             self.assertEqual(result, None, "Empty transactions fail")
 
             dataset._make_transaction(LDFTransactionType.ADD)
-            result = dataset._check_transactions()
+            result = dataset._check_transactions_to_execute()
             self.assertEqual(result, None, "Missing END transaction fail")
             time.sleep(0.5)
             curr = self.conn.transaction_document.find(
@@ -271,7 +271,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             dataset._make_transaction(LDFTransactionType.DELETE)
             dataset._make_transaction(LDFTransactionType.END)
             time.sleep(0.5)
-            result = dataset._check_transactions()
+            result = dataset._check_transactions_to_execute()
             self.assertEqual(len(result), 3, "With END transaction fail")
 
             # cleanup
@@ -387,7 +387,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             self.assertEqual(media_change, False, "media_change failed")
             self.assertEqual(field_change, True, "field_change failed")
 
-            res = dataset._check_transactions()
+            res = dataset._check_transactions_to_execute()
             self.assertEqual(len(res), 4, "Correct number of new transactions")
             num_adds = np.sum([True if t["action"] == "ADD" else False for t in res])
             num_updates = np.sum(
@@ -610,8 +610,8 @@ class LuxonisDatasetTester(unittest.TestCase):
                 break
             dataset.delete([sample.id])
 
-            res = dataset._check_transactions(
-                for_versioning=True
+            res = (
+                dataset._check_transactions_to_version()
             )  # will show the latest 3 transactions
             self.assertEqual(len(res), 3, "Wrong number of transactions for delete")
             num_executed = np.sum(
@@ -714,7 +714,7 @@ class LuxonisDatasetTester(unittest.TestCase):
                 dataset._add_filter,
                 additions,
             )
-            transactions = dataset._check_transactions()
+            transactions = dataset._check_transactions_to_execute()
             # if cleanup is successful, checking transactions should return on END transaction
             self.assertEqual(
                 type(transactions), list, "DataTransactionException cleanup"
@@ -978,7 +978,7 @@ class LuxonisDatasetTester(unittest.TestCase):
                 original_length,
                 "Copied sample deletion in _add_execute rollback",
             )
-            num_transactions = len(dataset._check_transactions())
+            num_transactions = len(dataset._check_transactions_to_execute())
             self.assertEqual(
                 num_transactions, 7, "Un-execute transactions in _add_execute rollback"
             )
@@ -997,7 +997,7 @@ class LuxonisDatasetTester(unittest.TestCase):
             transactions_to_additions, _, _ = dataset._add_filter(additions)
             dataset._add_execute(additions, transactions_to_additions)
 
-            transactions = dataset._check_transactions(for_versioning=True)
+            transactions = dataset._check_transactions_to_version()
             num_transactions = len(transactions)
             original_version = dataset.version
             sample_collection = dataset._get_sample_collection()
@@ -1016,7 +1016,7 @@ class LuxonisDatasetTester(unittest.TestCase):
                 True,
             )
 
-            transactions = dataset._check_transactions(for_versioning=True)
+            transactions = dataset._check_transactions_to_version()
             new_num_latest_false = len(
                 list(self.conn[sample_collection].find({"latest": False}))
             )

--- a/tests/test.py
+++ b/tests/test.py
@@ -608,7 +608,7 @@ class LuxonisDatasetTester(unittest.TestCase):
         with LuxonisDataset(self.team_id, self.dataset_id) as dataset:
             for sample in dataset.fo_dataset:
                 break
-            dataset.delete([sample.id])
+            dataset.delete(["fe163bd9-6381-5533-9d41-c1735edf96d5"])
 
             res = (
                 dataset._check_transactions_to_version()


### PR DESCRIPTION
- Add support for GCS in both `from_bucket` and from laptop
- Add option when calling `dataset.add()` to specify `annotated=False` to ignore this in versioning for the FE until it is annotated
- Rework updating attributes based on instance_id and add a function to annotate an instance once annotated