### PR TITLE
fix bbox construction if bbox is empty

### DIFF
--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -230,7 +230,7 @@ def construct_class_label(dataset, classes):
 
 
 def construct_boxes_label(dataset, boxes):
-    if not isinstance(boxes[0], list):  # fix for only one box without a nested list
+    if boxes and not isinstance(boxes[0], list):  # fix for only one box without a nested list
         boxes = [boxes]
     return fo.Detections(
         detections=[


### PR DESCRIPTION
Adding a fix for constructing LDF with data instances without bbox annotations (boxes[0] was trowing error if boxes was an empty list)
