### PR TITLE
fix LDF construction if bbox list is empty

### DIFF
--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -347,6 +347,8 @@ def construct_boxes_label(
 
     if boxes is None:
         return None
+    if len(boxes) == 0:
+        return fo.Detections(detections=[])
     if not isinstance(boxes[0], list):  # fix for only one box without a nested list
         boxes = [boxes]
     return fo.Detections(

--- a/src/luxonis_ml/data/utils/data_utils.py
+++ b/src/luxonis_ml/data/utils/data_utils.py
@@ -69,7 +69,7 @@ def assert_boxes_format(
 ) -> None:
     """Asserts that the format for the "boxes" field in additions is correct"""
 
-    if val is not None:
+    if val is not None and val != []:
         if not isinstance(val, list) or not isinstance(val[0], list):
             raise BoundingBoxFormatException("Bounding boxes need to be a nested list!")
 


### PR DESCRIPTION
Moving this PR from main to dev. It's a fix for constructing LDF with data instances without bbox annotations. Currently, only way to add a data instance without bbox annotation is to make an addition without 'boxes' key. However, this causes troubles during training. So we either have to fix it here or in luxonis/models. I'm suggesting a PR here because a fix is quite easy and short.