### PR TITLE
Changed config handler

### DIFF
--- a/src/luxonis_ml/utils/__init__.py
+++ b/src/luxonis_ml/utils/__init__.py
@@ -1,3 +1,6 @@
-from .config_handler import ConfigHandler
+from .config import Config
 from .filesystem import LuxonisFileSystem
 from .registry import Registry
+
+
+__all__ = ["Config", "LuxonisFileSystem", "Registry"]

--- a/src/luxonis_ml/utils/config.py
+++ b/src/luxonis_ml/utils/config.py
@@ -17,21 +17,23 @@ from .filesystem import LuxonisFileSystem
 
 
 class Config(BaseModel):
-    """Singleton class which checks and merges user config with default one and provides access to its values"""
+    """Class to store configuration.
 
-    def __new__(
-        cls,
-        cfg: Optional[Union[str, Dict[str, Any]]] = None,
-    ):
-        """If needed creates new singleton instance of the Config, otherwise returns already created one
+    Singleton class which checks and merges user config with a default one
+    and provides access to its values.
+
+    """
+    def __new__(cls, cfg: Optional[Union[str, Dict[str, Any]]] = None) -> "Config":
+        """
+        If needed creates new singleton instance of the Config,
+        otherwise returns already created one.
 
         Args:
-            cfg (Optional[Union[str, Dict[str, Any]]], optional): Path to config or config dictionary. Defaults to None.
-            cfg_cls (Optional[type], optional): Class to use as internal config structure representation. This should be
-            a Pydantic BaseModel class. Defaults to None.
+            cfg (Optional[Union[str, Dict[str, Any]]], optional): Path to config or
+                config dictionary. Defaults to None.
 
         Returns:
-            _type_: Singleton instance
+            Config: Singleton instance
         """
         if not hasattr(cls, "instance"):
             if cfg is None:
@@ -186,7 +188,7 @@ class Config(BaseModel):
                     continue
             elif isinstance(last_obj, dict):
                 attr = last_obj.get(last_key, None)
-                if attr != None:
+                if attr is not None:
                     value_typed = TypeAdapter(type(attr)).validate_python(value)
                 else:
                     # infer correct type

--- a/src/luxonis_ml/utils/config.py
+++ b/src/luxonis_ml/utils/config.py
@@ -23,6 +23,7 @@ class Config(BaseModel):
     and provides access to its values.
 
     """
+
     def __new__(cls, cfg: Optional[Union[str, Dict[str, Any]]] = None) -> "Config":
         """
         If needed creates new singleton instance of the Config,
@@ -56,19 +57,10 @@ class Config(BaseModel):
 
             load_dotenv()  # load environment variables needed for authorization
 
-            fs = LuxonisFileSystem(cfg)
-            buffer = fs.read_to_byte_buffer()
+            self.fs = LuxonisFileSystem(cfg)
+            buffer = self.fs.read_to_byte_buffer()
             cfg_data = yaml.load(buffer, Loader=yaml.SafeLoader)
             super().__init__(**cfg_data)
-
-            if fs.is_mlflow:
-                warnings.warn(
-                    "Setting `project_id` and `run_id` to config's MLFlow run"
-                )
-                # set logger parameters to continue run
-                # TODO: should not be set here
-                self.logger.project_id = fs.experiment_id  # type: ignore
-                self.logger.run_id = fs.run_id  # type: ignore
 
         elif isinstance(cfg, dict):
             super().__init__(**cfg)


### PR DESCRIPTION
Renamed `ConfigHandler` to `Config` and made it inherit from `pydantic.BaseConfig`. This removes the necesity to define two classes (`ConfigHandler` and pydantic `Config`)  when using this util.