### PR TITLE
Added metaclass for automatic registration

### DIFF
--- a/src/luxonis_ml/utils/registry.py
+++ b/src/luxonis_ml/utils/registry.py
@@ -1,4 +1,5 @@
-from typing import Optional, Callable, Dict, Union
+from typing import Optional, Callable, Dict, Union, Tuple
+from abc import ABCMeta
 
 
 class Registry:
@@ -96,3 +97,63 @@ class Registry:
             )
 
         self._module_dict[module_name] = module
+
+
+class AutoRegisterMeta(ABCMeta):
+    """Metaclass for automatically registering modules.
+
+    Can be set as a metaclass for abstract base classes. Then, all subclasses will be
+    automatically registered under the name of the subclass.
+
+    Attributes:
+        REGISTRY (Registry): Registry used for registration of sub-classes.
+
+    Example:
+        >>> REGISTRY = Registry(name="modules")
+        >>> class BaseClass(metaclass=AutoRegisterMeta, registry=REGISTRY):
+        ...     pass
+        >>> class SubClass(BaseClass):
+        ...     pass
+        >>> REGISTRY.get("SubClass")
+        <class '__main__.SubClass'>
+        >>> BaseClass.REGISTRY.get("SubClass")
+        <class '__main__.SubClass'>
+    """
+
+    REGISTRY: Registry
+
+    def __new__(
+        cls,
+        name: str,
+        bases: Tuple[type, ...],
+        attrs: Dict[str, type],
+        register: bool = True,
+        register_name: Optional[str] = None,
+        registry: Optional[Registry] = None,
+    ):
+        """Automatically register the class.
+
+        Args:
+            name (str): Class name
+            bases (tuple): Base classes
+            attrs (dict): Class attributes
+            register (bool, optional): Weather to register the class. Defaults to True.
+              Should be set to False for abstract base classes.
+            register_name (str | None, optional): Name used for registration.
+              If unset, the class name is used. Defaults to None.
+            registry (Registry | None, optional): Registry to use for registration.
+              Defaults to None. Has to be set in the base class.
+        """
+        new_class = super().__new__(cls, name, bases, attrs)
+        if not hasattr(new_class, "REGISTRY"):
+            if registry is not None:
+                new_class.REGISTRY = registry
+            elif register:
+                raise ValueError(
+                    "Registry has to be set in the base class or passed as an argument."
+                )
+        if register:
+            (registry or new_class.REGISTRY).register_module(
+                name=register_name or name, module=new_class
+            )
+        return new_class


### PR DESCRIPTION
Moved the `AutoRegisterMeta` metaclass from `luxonis-train` to here.