### PR TITLE
Luxonis logging

### DIFF
--- a/src/luxonis_ml/utils/__init__.py
+++ b/src/luxonis_ml/utils/__init__.py
@@ -1,6 +1,7 @@
 from .config import Config
 from .filesystem import LuxonisFileSystem
 from .registry import Registry
+from .logging import setup_logging
 
 
-__all__ = ["Config", "LuxonisFileSystem", "Registry"]
+__all__ = ["Config", "LuxonisFileSystem", "Registry", "setup_logging"]

--- a/src/luxonis_ml/utils/logging.py
+++ b/src/luxonis_ml/utils/logging.py
@@ -1,0 +1,75 @@
+import logging
+import os
+import warnings
+from typing import Literal
+
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.theme import Theme
+
+
+def setup_logging(
+    *,
+    file: str | None = None,
+    use_rich: bool = False,
+    level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO",
+    configure_warnings: bool = True,
+) -> None:
+    """Globally configures logging.
+
+    Configures a standar Luxonis logger.
+    Optionally utilizes rich library, configures handling of warnings
+    (from warnings module) and saves the logs to a file.
+
+    Args:
+        file (str, optional): Path to a file where logs will be saved.
+          If None, logs will not be saved. Defaults to None.
+        use_rich (bool, optional): If True, rich library will be used for logging.
+          Defaults to False.
+        level (str, optional): Logging level. One of "DEBUG", "INFO", "WARNING",
+          "ERROR", and "CRITICAL". Defaults to "INFO".
+          If "DEBUG" is set in environment variables, the level is changed to "DEBUG".
+        configure_warnings (bool, optional): If True, warnings will be logged.
+          Defaults to True.
+    """
+    # NOTE: So we can simply run `DEBUG= python ...`
+    if "DEBUG" in os.environ:
+        level = "DEBUG"
+
+    handlers = []
+
+    format = file_format = "%(asctime)s [%(levelname)s] %(message)s"
+    datefmt = "[%Y-%m-%d %H:%M:%S]"
+    if use_rich:
+        format = "%(message)s"
+        # NOTE: The default rich logging colors are weird.
+        _theme = Theme(
+            {
+                "logging.level.debug": "magenta",
+                "logging.level.info": "green",
+                "logging.level.warning": "yellow",
+            }
+        )
+        _console = Console(theme=_theme)
+        handlers.append(
+            RichHandler(
+                rich_tracebacks=True, console=_console, omit_repeated_times=False
+            )
+        )
+    else:
+        handlers.append(logging.StreamHandler())
+
+    if file is not None:
+        file_handler = logging.FileHandler(file)
+        file_handler.setFormatter(logging.Formatter(file_format, datefmt=datefmt))
+        handlers.append(file_handler)
+
+    logging.basicConfig(level=level, format=format, datefmt=datefmt, handlers=handlers)
+
+    if configure_warnings:
+        logger = logging.getLogger("warnings.warn")
+
+        def custom_warning_handler(message, *_):
+            logger.warning(message)
+
+        warnings.showwarning = custom_warning_handler


### PR DESCRIPTION
Added a function to globally set up logging.
Can make use of rich logging and can configure handling of warnings from `warning.warn` (for warnings from other libraries).

<img width="812" alt="image" src="https://github.com/luxonis/luxonis-ml/assets/31243076/76626014-f438-43f2-8c5e-6c1f9ae0b671">
