### PR TITLE
Pydantic Settings for env variables

### DIFF
--- a/src/luxonis_ml/tracker/mlflow_plugins.py
+++ b/src/luxonis_ml/tracker/mlflow_plugins.py
@@ -3,6 +3,7 @@ from mlflow import __version__
 from mlflow.tracking.request_header.abstract_request_header_provider import (
     RequestHeaderProvider,
 )
+from luxonis_ml.utils import environ
 
 _USER_AGENT = "User-Agent"
 _DEFAULT_HEADERS = {_USER_AGENT: "mlflow-python-client/%s" % __version__}
@@ -14,6 +15,6 @@ class LuxonisRequestHeaderProvider(RequestHeaderProvider):
 
     def request_headers(self):
         headers = dict(**_DEFAULT_HEADERS)
-        headers["CF-Access-Client-Id"] = os.environ.get("MLFLOW_CLOUDFLARE_ID")
-        headers["CF-Access-Client-Secret"] = os.environ.get("MLFLOW_CLOUDFLARE_SECRET")
+        headers["CF-Access-Client-Id"] = environ.MLFLOW_CLOUDFLARE_ID
+        headers["CF-Access-Client-Secret"] = environ.MLFLOW_CLOUDFLARE_SECRET
         return headers

--- a/src/luxonis_ml/utils/__init__.py
+++ b/src/luxonis_ml/utils/__init__.py
@@ -2,6 +2,14 @@ from .config import Config
 from .filesystem import LuxonisFileSystem
 from .registry import Registry
 from .logging import setup_logging, reset_logging
+from .environ import environ
 
 
-__all__ = ["Config", "LuxonisFileSystem", "Registry", "setup_logging", "reset_logging"]
+__all__ = [
+    "Config",
+    "LuxonisFileSystem",
+    "Registry",
+    "setup_logging",
+    "reset_logging",
+    "environ",
+]

--- a/src/luxonis_ml/utils/__init__.py
+++ b/src/luxonis_ml/utils/__init__.py
@@ -2,7 +2,7 @@ from .config import Config
 from .filesystem import LuxonisFileSystem
 from .registry import Registry
 from .logging import setup_logging, reset_logging
-from .environ import environ
+from .environ import environ, Environ
 
 
 __all__ = [
@@ -12,4 +12,5 @@ __all__ = [
     "setup_logging",
     "reset_logging",
     "environ",
+    "Environ",
 ]

--- a/src/luxonis_ml/utils/config.py
+++ b/src/luxonis_ml/utils/config.py
@@ -44,10 +44,6 @@ class Config(BaseModel):
             cls.instance = super().__new__(cls)
             cls._fs = None
             if isinstance(cfg, str):
-                from dotenv import load_dotenv
-
-                load_dotenv()
-
                 cls._fs = LuxonisFileSystem(cfg)
 
         return cls.instance

--- a/src/luxonis_ml/utils/environ.py
+++ b/src/luxonis_ml/utils/environ.py
@@ -16,8 +16,6 @@ class Environ(BaseSettings):
     AWS_SECRET_ACCESS_KEY: Optional[str] = None
     AWS_S3_ENDPOINT_URL: Optional[str] = None
 
-    MONGO_URI: Optional[str] = None
-
     MLFLOW_CLOUDFLARE_ID: Optional[str] = None
     MLFLOW_CLOUDFLARE_SECRET: Optional[str] = None
     MLFLOW_S3_BUCKET: Optional[str] = None

--- a/src/luxonis_ml/utils/environ.py
+++ b/src/luxonis_ml/utils/environ.py
@@ -1,0 +1,45 @@
+from typing import Optional, Literal
+from pydantic import model_serializer
+from pathlib import Path
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+__all__ = ["Environ", "environ"]
+
+
+class Environ(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
+
+    AWS_ACCESS_KEY_ID: Optional[str] = None
+    AWS_SECRET_ACCESS_KEY: Optional[str] = None
+    AWS_S3_ENDPOINT_URL: Optional[str] = None
+
+    MONGO_URI: Optional[str] = None
+
+    MLFLOW_CLOUDFLARE_ID: Optional[str] = None
+    MLFLOW_CLOUDFLARE_SECRET: Optional[str] = None
+    MLFLOW_S3_BUCKET: Optional[str] = None
+    MLFLOW_S3_ENDPOINT_URL: Optional[str] = None
+    MLFLOW_TRACKING_URI: Optional[str] = None
+
+    POSTGRES_USER: Optional[str] = None
+    POSTGRES_PASSWORD: Optional[str] = None
+    POSTGRES_HOST: Optional[str] = None
+    POSTGRES_PORT: Optional[str] = None
+    POSTGRES_DB: Optional[str] = None
+
+    LUXONISML_BUCKET: Optional[str] = None
+    LUXONISML_BASE_PATH: str = str(Path.home() / "luxonis_ml")
+    LUXONISML_TEAM_ID: str = "offline"
+    LUXONISML_TEAM_NAME: str = "offline"
+
+    LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
+
+    @model_serializer(when_used="always", mode="plain", return_type=str)
+    def _serialize_environ(self) -> str:
+        return "[Content hidden ...]"
+
+
+environ = Environ()

--- a/src/luxonis_ml/utils/filesystem.py
+++ b/src/luxonis_ml/utils/filesystem.py
@@ -5,7 +5,7 @@ from types import ModuleType
 import fsspec
 from io import BytesIO
 from concurrent.futures import ThreadPoolExecutor
-
+from .environ import environ
 
 class LuxonisFileSystem:
     def __init__(
@@ -61,7 +61,7 @@ class LuxonisFileSystem:
                 raise ValueError(
                     "Using active MLFlow run is not allowed. Specify full MLFlow path."
                 )
-            self.tracking_uri = os.getenv("MLFLOW_TRACKING_URI")
+            self.tracking_uri = environ.MLFLOW_TRACKING_URI
 
             if self.tracking_uri is None:
                 raise KeyError(
@@ -81,9 +81,9 @@ class LuxonisFileSystem:
             # NOTE: In theory boto3 should look in environment variables automatically but it doesn't seem to work
             return fsspec.filesystem(
                 self.protocol,
-                key=os.getenv("AWS_ACCESS_KEY_ID"),
-                secret=os.getenv("AWS_SECRET_ACCESS_KEY"),
-                endpoint_url=os.getenv("AWS_S3_ENDPOINT_URL"),
+                key=environ.AWS_ACCESS_KEY_ID,
+                secret=environ.AWS_SECRET_ACCESS_KEY,
+                endpoint_url=environ.AWS_S3_ENDPOINT_URL,
             )
         elif self.protocol == "gcs":
             # NOTE: This should automatically read from GOOGLE_APPLICATION_CREDENTIALS

--- a/src/luxonis_ml/utils/logging.py
+++ b/src/luxonis_ml/utils/logging.py
@@ -1,6 +1,6 @@
 import logging
-import os
 import warnings
+from typing import Optional
 
 from rich.console import Console
 from rich.logging import RichHandler

--- a/src/luxonis_ml/utils/logging.py
+++ b/src/luxonis_ml/utils/logging.py
@@ -5,13 +5,14 @@ import warnings
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.theme import Theme
+from .environ import environ
 
 
 def setup_logging(
     *,
-    file: str | None = None,
+    file: Optional[str] = None,
     use_rich: bool = False,
-    level: str = "INFO",
+    level: Optional[str] = None,
     configure_warnings: bool = True,
 ) -> None:
     """Globally configures logging.
@@ -27,12 +28,12 @@ def setup_logging(
           Defaults to False.
         level (str, optional): Logging level. One of "DEBUG", "INFO", "WARNING",
           "ERROR", and "CRITICAL". Defaults to "INFO".
-          The log level can be changed using "LUXONIS_LOG_LEVEL" environment variable.
+          The log level can be changed using "LOG_LEVEL" environment variable.
         configure_warnings (bool, optional): If True, warnings will be logged.
           Defaults to True.
     """
-    # NOTE: So we can simply run e.g. `LUXONIS_LOG_LEVEL=DEBUG python ...`
-    level = os.getenv("LUXONIS_LOG_LEVEL", level)
+    # NOTE: So we can simply run e.g. `LOG_LEVEL=DEBUG python ...`
+    level = level or environ.LOG_LEVEL
 
     if level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
         raise ValueError(

--- a/src/luxonis_ml/utils/requirements.txt
+++ b/src/luxonis_ml/utils/requirements.txt
@@ -1,4 +1,5 @@
 pydantic>=2.4.0
+pydantic-settings>=2.1.0
 PyYAML>=6.0
 fsspec>=2023.1.0
 # s3fs # if using S3 filesystem


### PR DESCRIPTION
Added a new `pydantic-settings` model that loads env variables. This way we also enforce standardized naming. 
It also handles .env files so we can drop dependency on `dotenv-python`.

The `Environ` class can be added as a section to a subclassed `Config` for the ability to specify env variables there. 