### PR TITLE
Ensure base path directory exists

### DIFF
--- a/luxonis_ml/data/dataset.py
+++ b/luxonis_ml/data/dataset.py
@@ -133,6 +133,8 @@ class LuxonisDataset:
             )
 
         self.base_path = environ.LUXONISML_BASE_PATH
+        os.makedirs(self.base_path, exist_ok=True)
+
         credentials_cache_file = osp.join(self.base_path, "credentials.json")
         if osp.exists(credentials_cache_file):
             with open(credentials_cache_file) as file:


### PR DESCRIPTION
Fixes an issue when creating a dataset for the first time. Before the fix, the `datasets.json` file would write to a directory that does not yet exist. This fix ensures the base path always exists first.