### PR TITLE
Updated LuxonisFileSystem

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,8 @@ jobs:
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+        create_credentials_file: true
+        export_environment_variables: true
         token_format: access_token
 
     - name: Run pytest
@@ -77,7 +79,6 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
-        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google-auth.outputs.credentials_file_path }}
       with:
         emoji: false
         custom-arguments: --cov luxonis_ml --cov-report xml --junit-xml pytest.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.google-auth.outputs.credentials_file_path }}
       with:
         emoji: false
         custom-arguments: --cov luxonis_ml --cov-report xml --junit-xml pytest.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,8 +64,19 @@ jobs:
     - name: Install package
       run: pip install -e .[dev]
 
+    - name: Authenticate to Google Cloud
+      id: google-auth
+      uses: google-github-actions/auth@v2
+      with:
+        credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+        token_format: access_token
+
     - name: Run pytest
       uses: pavelzw/pytest-action@v2
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
       with:
         emoji: false
         custom-arguments: --cov luxonis_ml --cov-report xml --junit-xml pytest.xml

--- a/luxonis_ml/data/dataset.py
+++ b/luxonis_ml/data/dataset.py
@@ -745,7 +745,7 @@ class LuxonisDataset:
             else:
                 remote_path = "metadata/splits.json"
                 local_path = os.path.join(self.tmp_dir, "splits.json")
-                if self.fs.file_exists(remote_path):
+                if self.fs.exists(remote_path):
                     self.fs.get_file(remote_path, local_path)
                     with open(splits_path, "r") as file:
                         splits = json.load(file)

--- a/luxonis_ml/utils/environ.py
+++ b/luxonis_ml/utils/environ.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 from typing import Literal, Optional
 
-from pydantic import model_serializer
+from pydantic import Field, model_serializer
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import Annotated
 
 __all__ = ["Environ", "environ"]
 
@@ -35,7 +36,9 @@ class Environ(BaseSettings):
     LUXONISML_TEAM_ID: str = "offline"
     LUXONISML_TEAM_NAME: str = "offline"
 
-    GOOGLE_APPLICATION_CREDENTIALS: Optional[str] = None
+    GOOGLE_APPLICATION_CREDENTIALS: Annotated[
+        Optional[str], Field(alias="GCP_CREDENTIALS")
+    ] = None
 
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 

--- a/luxonis_ml/utils/environ.py
+++ b/luxonis_ml/utils/environ.py
@@ -35,6 +35,8 @@ class Environ(BaseSettings):
     LUXONISML_TEAM_ID: str = "offline"
     LUXONISML_TEAM_NAME: str = "offline"
 
+    GOOGLE_APPLICATION_CREDENTIALS: Optional[str] = None
+
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 
     @model_serializer(when_used="always", mode="plain", return_type=str)

--- a/luxonis_ml/utils/environ.py
+++ b/luxonis_ml/utils/environ.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 from typing import Literal, Optional
 
-from pydantic import Field, model_serializer
+from pydantic import model_serializer
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from typing_extensions import Annotated
 
 __all__ = ["Environ", "environ"]
 
@@ -36,9 +35,7 @@ class Environ(BaseSettings):
     LUXONISML_TEAM_ID: str = "offline"
     LUXONISML_TEAM_NAME: str = "offline"
 
-    GOOGLE_APPLICATION_CREDENTIALS: Annotated[
-        Optional[str], Field(alias="GCP_CREDENTIALS")
-    ] = None
+    GOOGLE_APPLICATION_CREDENTIALS: Optional[str] = None
 
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -518,7 +518,7 @@ class LuxonisFileSystem:
     def download(url: str, dest: Optional[PathType]) -> Path:
         """Downloads file or directory from remote storage.
 
-        Intended for downloading a single remove object, elevating the need to create an
+        Intended for downloading a single remote object, elevating the need to create an
         instance of L{LuxonisFileSystem}.
 
         @type url: str

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -155,9 +155,9 @@ class LuxonisFileSystem:
     ) -> str:
         """Copy a single file to remote storage.
 
-        @type local_path: str
+        @type local_path: PathType
         @param local_path: Path to local file
-        @type remote_path: str
+        @type remote_path: PathType
         @param remote_path: Relative path to remote file
         @type mlflow_instance: Optional[L{ModuleType}]
         @param mlflow_instance: MLFlow instance if uploading to active run. Defaults to
@@ -192,10 +192,10 @@ class LuxonisFileSystem:
     ) -> Optional[Dict[str, str]]:
         """Uploads files to remote storage.
 
-        @type local_paths: Union[str, List[str]]
+        @type local_paths: Union[PathType, List[PathType]]
         @param local_paths: Either a string specifying a directory to walk the files or
             a list of files which can be in different directories
-        @type remote_dir: str
+        @type remote_dir: PathType
         @param remote_dir: Relative path to remote directory
         @type uuid_dict: Optional[Dict[str, str]]
         @param uuid_dict: Stores paths as keys and corresponding UUIDs as values to
@@ -240,7 +240,7 @@ class LuxonisFileSystem:
 
         @type file_bytes: bytes
         @param file_bytes: the bytes for the file contents
-        @type remote_path: str
+        @type remote_path: PathType
         @param remote_path: Relative path to remote file
         @type mlflow_instance: Optional[L{ModuleType}]
         @param mlflow_instance: MLFlow instance if uploading to active run. Defaults to
@@ -261,13 +261,15 @@ class LuxonisFileSystem:
     ) -> Path:
         """Copy a single file from remote storage.
 
-        @type remote_path: str
+        @type remote_path: PathType
         @param remote_path: Relative path to remote file
-        @type local_path: str
+        @type local_path: PathType
         @param local_path: Path to local file
         @type mlflow_instance: Optional[L{ModuleType}]
         @param mlflow_instance: MLFlow instance if uploading to active run. Defaults to
-            None.
+            C{None}.
+        @rtype: Path
+        @return: Path to the downloaded file.
         """
 
         if self.is_mlflow:
@@ -281,7 +283,7 @@ class LuxonisFileSystem:
     def delete_file(self, remote_path: PathType) -> None:
         """Deletes a single file from remote storage.
 
-        @type remote_path: str
+        @type remote_path: PathType
         @param remote_path: Relative path to remote file
         """
         if self.is_fsspec:
@@ -293,7 +295,7 @@ class LuxonisFileSystem:
     def delete_files(self, remote_paths: List[PathType]) -> None:
         """Deletes multiple files from remote storage.
 
-        @type remote_paths: List[str]
+        @type remote_paths: List[PathType]
         @param remote_paths: Relative paths to remote files
         """
         if self.is_fsspec:
@@ -312,13 +314,15 @@ class LuxonisFileSystem:
     ) -> Path:
         """Copies many files from remote storage to local storage.
 
-        @type remote_dir: str
+        @type remote_dir: PathType
         @param remote_dir: Relative path to remote directory
-        @type local_dir: str
+        @type local_dir: PathType
         @param local_dir: Path to local directory
         @type mlflow_instance: Optional[L{ModuleType}]
         @param mlflow_instance: MLFlow instance if uploading to active run. Defaults to
-            None.
+            C{None}.
+        @rtype: Path
+        @return: Path to the downloaded directory.
         """
         if self.is_mlflow:
             raise NotImplementedError
@@ -343,7 +347,7 @@ class LuxonisFileSystem:
     def walk_dir(self, remote_dir: PathType) -> Iterator[str]:
         """Recursively walks through the individual files in a remote directory.
 
-        @type remote_dir: str
+        @type remote_dir: PathType
         @param remote_dir: Relative path to remote directory
         @rtype: Iterator[str]
         @return: Iterator over the paths.
@@ -365,7 +369,7 @@ class LuxonisFileSystem:
     def read_to_byte_buffer(self, remote_path: Optional[PathType] = None) -> BytesIO:
         """Reads a file into a byte buffer.
 
-        @type remote_path: Optional[str]
+        @type remote_path: Optional[PathType]
         @param remote_path: Relative path to remote file.
         @rtype: BytesIO
         @return: The byte buffer containing the file contents.
@@ -403,7 +407,7 @@ class LuxonisFileSystem:
     def get_file_uuid(self, path: PathType, local: bool = False) -> str:
         """Reads a file and returns the (unique) UUID generated from file bytes.
 
-        @type path: str
+        @type path: PathType
         @param path: Relative path to remote file.
         @type local: bool
         @param local: Specifies a local path as opposed to a remote path.
@@ -432,7 +436,7 @@ class LuxonisFileSystem:
     ) -> Dict[str, str]:
         """Computes the UUIDs for all files stored in the filesystem.
 
-        @type paths: List[str]
+        @type paths: List[PathType]
         @param paths: A list of relative remote paths if remote else local paths.
         @type local: bool
         @param local: Specifies local paths as opposed to remote paths.
@@ -466,7 +470,7 @@ class LuxonisFileSystem:
     def is_directory(self, remote_path: PathType) -> bool:
         """Checks whether the given remote path is a directory.
 
-        @type remote_path: str
+        @type remote_path: PathType
         @param remote_path: Relative path to remote file.
         @rtype: bool
         @return: True if the path is a directory.
@@ -479,7 +483,7 @@ class LuxonisFileSystem:
     def exists(self, remote_path: PathType) -> bool:
         """Checks whether the given remote path exists.
 
-        @type remote_path: str
+        @type remote_path: PathType
         @param remote_path: Relative path to remote file.
         @rtype: bool
         @return: True if the path exists.
@@ -491,7 +495,7 @@ class LuxonisFileSystem:
     def split_full_path(path: PathType) -> Tuple[str, str]:
         """Splits the full path into protocol and absolute path.
 
-        @type path: str
+        @type path: PathType
         @param path: Full path
         @rtype: Tuple[str, str]
         @return: Tuple of protocol and absolute path.
@@ -519,7 +523,7 @@ class LuxonisFileSystem:
 
         @type url: str
         @param url: URL to the file or directory
-        @type dest: Optional[str]
+        @type dest: Optional[PathType]
         @param dest: Destination directory. If unspecified, the current directory is
             used.
         @rtype: Path
@@ -535,15 +539,13 @@ class LuxonisFileSystem:
         fs = LuxonisFileSystem(absolute_path)
 
         if fs.is_directory(remote_path):
-            fs.get_dir(remote_path, local_path)
+            return fs.get_dir(remote_path, local_path)
 
         else:
-            fs.get_file(remote_path, str(local_path))
-
-        return local_path
+            return fs.get_file(remote_path, str(local_path))
 
     @staticmethod
-    def upload(local_path: PathType, url: str) -> str:
+    def upload(local_path: PathType, url: str) -> None:
         """Uploads file or directory to remote storage.
 
         Intended for uploading a single local object, elevating the need to create an
@@ -562,7 +564,7 @@ class LuxonisFileSystem:
         if Path(local_path).is_dir():
             fs.put_dir(local_path, remote_path)
         else:
-            return fs.put_file(str(local_path), remote_path)
+            fs.put_file(str(local_path), remote_path)
 
 
 def _get_protocol_and_path(path: str) -> Tuple[str, Optional[str]]:

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -1,12 +1,11 @@
 import os
 import os.path as osp
-import platform
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from io import BytesIO
 from logging import getLogger
-from pathlib import Path
+from pathlib import Path, WindowsPath
 from types import ModuleType
 from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast
 
@@ -577,8 +576,8 @@ class LuxonisFileSystem:
     def _sanitize_path(path: PathType) -> str:
         if isinstance(path, str):
             return path
-        if platform.system() == "Windows":
-            return path.as_posix().lstrip(path.drive).replace("\\", "/")
+        if isinstance(path, WindowsPath):
+            return path.as_posix().lstrip(path.drive)
         return str(path)
 
 

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -539,10 +539,11 @@ class LuxonisFileSystem:
         fs = LuxonisFileSystem(absolute_path)
 
         if fs.is_directory(remote_path):
-            return fs.get_dir(remote_path, local_path)
-
+            fs.get_dir(remote_path, local_path)
         else:
-            return fs.get_file(remote_path, str(local_path))
+            fs.get_file(remote_path, str(local_path))
+
+        return local_path
 
     @staticmethod
     def upload(local_path: PathType, url: str) -> None:

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -211,7 +211,9 @@ class LuxonisFileSystem:
         elif self.is_fsspec:
             if isinstance(local_paths, Path) and Path(local_paths).is_dir():
                 self.fs.put(
-                    str(local_paths), self._sanitize_path(self.path / remote_dir), recursive=True
+                    str(local_paths),
+                    self._sanitize_path(self.path / remote_dir),
+                    recursive=True,
                 )
             elif isinstance(local_paths, list):
                 upload_dict = {}

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -1,16 +1,26 @@
 import os
+import os.path as osp
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from enum import Enum
 from io import BytesIO
 from logging import getLogger
+from pathlib import Path
 from types import ModuleType
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union, cast
 
 import fsspec
 
 from .environ import environ
 
 logger = getLogger(__name__)
+
+PathType = Union[str, Path]
+
+
+class FSType(Enum):
+    MLFLOW = "mlflow"
+    FSSPEC = "fsspec"
 
 
 class LuxonisFileSystem:
@@ -44,7 +54,7 @@ class LuxonisFileSystem:
 
         self.cache_storage = cache_storage
 
-        self.protocol, self.path = _get_protocol_and_path(path)
+        self.protocol, _path = _get_protocol_and_path(path)
         supported_protocols = ["s3", "gcs", "file", "mlflow"]
         if self.protocol not in supported_protocols:
             raise ValueError(
@@ -55,21 +65,18 @@ class LuxonisFileSystem:
         if self.protocol == "file" and not self.allow_local:
             raise ValueError("Local filesystem is not allowed.")
 
-        self.is_mlflow = False
-        self.is_fsspec = False
-
         if self.protocol == "mlflow":
-            self.is_mlflow = True
+            self.fs_type = FSType.MLFLOW
 
             self.allow_active_mlflow_run = allow_active_mlflow_run
             self.is_mlflow_active_run = False
-            if len(self.path):
+            if _path is not None:
                 (
                     self.experiment_id,
                     self.run_id,
                     self.artifact_path,
-                ) = self._split_mlflow_path(self.path)
-            elif len(self.path) == 0 and self.allow_active_mlflow_run:
+                ) = self._split_mlflow_path(_path)
+            elif _path is None and self.allow_active_mlflow_run:
                 self.is_mlflow_active_run = True
             else:
                 raise ValueError(
@@ -82,8 +89,25 @@ class LuxonisFileSystem:
                     "There is no 'MLFLOW_TRACKING_URI' in environment variables"
                 )
         else:
-            self.is_fsspec = True
+            self.fs_type = FSType.FSSPEC
             self.fs = self.init_fsspec_filesystem()
+        self.path = Path(cast(str, _path))
+
+    @property
+    def is_mlflow(self) -> bool:
+        """Returns True if the filesystem is MLFlow.
+
+        @type: bool
+        """
+        return self.fs_type == FSType.MLFLOW
+
+    @property
+    def is_fsspec(self) -> bool:
+        """Returns True if the filesystem is fsspec.
+
+        @type: bool
+        """
+        return self.fs_type == FSType.FSSPEC
 
     @property
     def full_path(self) -> str:
@@ -125,10 +149,10 @@ class LuxonisFileSystem:
 
     def put_file(
         self,
-        local_path: str,
-        remote_path: str,
+        local_path: PathType,
+        remote_path: PathType,
         mlflow_instance: Optional[ModuleType] = None,
-    ) -> None:
+    ) -> str:
         """Copy a single file to remote storage.
 
         @type local_path: str
@@ -137,8 +161,11 @@ class LuxonisFileSystem:
         @param remote_path: Relative path to remote file
         @type mlflow_instance: Optional[L{ModuleType}]
         @param mlflow_instance: MLFlow instance if uploading to active run. Defaults to
-            None.
+            C{None}.
+        @rtype: str
+        @return: The full remote path of the uploded file.
         """
+        local_path = str(local_path)
         if self.is_mlflow:
             # NOTE: remote_path not used in mlflow since it creates new folder each time
             if self.is_mlflow_active_run:
@@ -153,12 +180,13 @@ class LuxonisFileSystem:
                 client.log_artifact(run_id=self.run_id, local_path=local_path)
 
         elif self.is_fsspec:
-            self.fs.put_file(local_path, os.path.join(self.path, remote_path))
+            self.fs.put_file(local_path, str(self.path / remote_path))
+        return self.protocol + "://" + str(self.path / remote_path)
 
     def put_dir(
         self,
-        local_paths: Union[str, List[str]],
-        remote_dir: str,
+        local_paths: Union[PathType, Sequence[PathType]],
+        remote_dir: PathType,
         uuid_dict: Optional[Dict[str, str]] = None,
         mlflow_instance: Optional[ModuleType] = None,
     ) -> Optional[Dict[str, str]]:
@@ -181,29 +209,31 @@ class LuxonisFileSystem:
         if self.is_mlflow:
             raise NotImplementedError
         elif self.is_fsspec:
-            if isinstance(local_paths, str) and os.path.isdir(local_paths):
+            if isinstance(local_paths, Path) and Path(local_paths).is_dir():
                 self.fs.put(
-                    local_paths, os.path.join(self.path, remote_dir), recursive=True
+                    str(local_paths), str(self.path / remote_dir), recursive=True
                 )
-            else:
+            elif isinstance(local_paths, list):
                 upload_dict = {}
                 with ThreadPoolExecutor() as executor:
                     for local_path in local_paths:
-                        if uuid_dict:
+                        local_path = str(local_path)
+                        if uuid_dict is not None:
                             file_uuid = uuid_dict[local_path]
-                            ext = os.path.splitext(local_path)[1]
+                            ext = osp.splitext(local_path)[1]
                             basename = file_uuid + ext
                         else:
-                            basename = os.path.basename(local_path)
-                        remote_path = os.path.join(remote_dir, basename)
+                            basename = Path(local_path).name
+                        remote_path = str(Path(remote_dir) / basename)
                         upload_dict[local_path] = remote_path
+                        print(str(local_path), str(remote_path))
                         executor.submit(self.put_file, local_path, remote_path)
                 return upload_dict
 
     def put_bytes(
         self,
         file_bytes: bytes,
-        remote_path: str,
+        remote_path: PathType,
         mlflow_instance: Optional[ModuleType] = None,
     ) -> None:
         """Uploads a file to remote storage directly from file bytes.
@@ -219,16 +249,16 @@ class LuxonisFileSystem:
         if self.is_mlflow:
             raise NotImplementedError
         elif self.is_fsspec:
-            full_path = os.path.join(self.path, remote_path)
-            with self.fs.open(full_path, "wb") as file:
-                file.write(file_bytes)
+            full_path = self.path / remote_path
+            with self.fs.open(str(full_path), "wb") as file:
+                file.write(file_bytes)  # type: ignore
 
     def get_file(
         self,
-        remote_path: str,
-        local_path: str,
+        remote_path: PathType,
+        local_path: PathType,
         mlflow_instance: Optional[ModuleType] = None,
-    ) -> None:
+    ) -> Path:
         """Copy a single file from remote storage.
 
         @type remote_path: str
@@ -244,22 +274,23 @@ class LuxonisFileSystem:
             raise NotImplementedError
         elif self.is_fsspec:
             self.fs.download(
-                os.path.join(self.path, remote_path), local_path, recursive=False
+                str(self.path / remote_path), str(local_path), recursive=False
             )
+        return Path(local_path) / Path(remote_path).name
 
-    def delete_file(self, remote_path: str) -> None:
+    def delete_file(self, remote_path: PathType) -> None:
         """Deletes a single file from remote storage.
 
         @type remote_path: str
         @param remote_path: Relative path to remote file
         """
         if self.is_fsspec:
-            full_remote_path = os.path.join(self.path, remote_path)
-            self.fs.rm(full_remote_path)
+            full_remote_path = self.path / remote_path
+            self.fs.rm(str(full_remote_path))
         else:
             raise NotImplementedError
 
-    def delete_files(self, remote_paths: List[str]) -> None:
+    def delete_files(self, remote_paths: List[PathType]) -> None:
         """Deletes multiple files from remote storage.
 
         @type remote_paths: List[str]
@@ -267,7 +298,7 @@ class LuxonisFileSystem:
         """
         if self.is_fsspec:
             full_remote_paths = [
-                os.path.join(self.path, remote_path) for remote_path in remote_paths
+                str(self.path / remote_path) for remote_path in remote_paths
             ]
             self.fs.rm(full_remote_paths)
         else:
@@ -275,10 +306,10 @@ class LuxonisFileSystem:
 
     def get_dir(
         self,
-        remote_dir: str,
-        local_dir: str,
+        remote_dir: PathType,
+        local_dir: PathType,
         mlflow_instance: Optional[ModuleType] = None,
-    ) -> None:
+    ) -> Path:
         """Copies many files from remote storage to local storage.
 
         @type remote_dir: str
@@ -293,22 +324,23 @@ class LuxonisFileSystem:
             raise NotImplementedError
         elif self.is_fsspec:
             self.fs.download(
-                os.path.join(self.path, remote_dir), local_dir, recursive=True
+                str(self.path / remote_dir), str(local_dir), recursive=True
             )
+        return Path(local_dir) / Path(remote_dir).name
 
-    def delete_dir(self, remote_dir: str) -> None:
+    def delete_dir(self, remote_dir: PathType) -> None:
         """Deletes a directory and all its contents from remote storage.
 
-        @type remote_dir: str
+        @type remote_dir: PathType
         @param remote_dir: Relative path to remote directory
         """
         if self.is_fsspec:
-            full_remote_dir = os.path.join(self.path, remote_dir)
+            full_remote_dir = str(self.path / remote_dir)
             self.fs.rm(full_remote_dir, recursive=True)
         else:
             raise NotImplementedError
 
-    def walk_dir(self, remote_dir: str) -> Iterator[str]:
+    def walk_dir(self, remote_dir: PathType) -> Iterator[str]:
         """Recursively walks through the individual files in a remote directory.
 
         @type remote_dir: str
@@ -320,17 +352,17 @@ class LuxonisFileSystem:
         if self.is_mlflow:
             raise NotImplementedError
         elif self.is_fsspec:
-            full_path = os.path.join(self.path, remote_dir)
+            full_path = str(self.path / remote_dir)
             for file in self.fs.glob(full_path + "/**", detail=True):
                 if self.fs.info(file)["type"] == "file":
                     assert isinstance(file, str)
 
-                    file_without_path = file.replace(self.path, "")
+                    file_without_path = file.replace(str(self.path), "")
                     if file_without_path.startswith("/"):
                         file_without_path = file_without_path[1:]
-                    yield os.path.relpath(file, self.path)
+                    yield str(Path(file).relative_to(self.path))
 
-    def read_to_byte_buffer(self, remote_path: Optional[str] = None) -> BytesIO:
+    def read_to_byte_buffer(self, remote_path: Optional[PathType] = None) -> BytesIO:
         """Reads a file into a byte buffer.
 
         @type remote_path: Optional[str]
@@ -350,6 +382,7 @@ class LuxonisFileSystem:
                 import mlflow
 
                 client = mlflow.MlflowClient(tracking_uri=self.tracking_uri)
+                assert self.run_id is not None
                 download_path = client.download_artifacts(
                     run_id=self.run_id, path=self.artifact_path, dst_path="."
                 )
@@ -357,17 +390,17 @@ class LuxonisFileSystem:
                 buffer = BytesIO(f.read())
             os.remove(download_path)  # remove local file
 
-        elif self.is_fsspec:
-            if remote_path:
-                download_path = os.path.join(self.path, remote_path)
+        else:
+            if remote_path is not None:
+                download_path = str(self.path / remote_path)
             else:
                 download_path = self.path
             with self.fs.open(download_path, "rb") as f:
-                buffer = BytesIO(f.read())
+                buffer = BytesIO(cast(bytes, f.read()))
 
         return buffer
 
-    def get_file_uuid(self, path: str, local: bool = False) -> str:
+    def get_file_uuid(self, path: PathType, local: bool = False) -> str:
         """Reads a file and returns the (unique) UUID generated from file bytes.
 
         @type path: str
@@ -380,21 +413,23 @@ class LuxonisFileSystem:
 
         if local:
             with open(path, "rb") as f:
-                file_contents = f.read()
+                file_contents = cast(bytes, f.read())
         else:
             if self.is_mlflow:
                 raise NotImplementedError
 
-            elif self.is_fsspec:
-                download_path = os.path.join(self.path, path)
+            else:
+                download_path = str(self.path / path)
                 with self.fs.open(download_path, "rb") as f:
-                    file_contents = f.read()
+                    file_contents = cast(bytes, f.read())
 
         file_hash_uuid = str(uuid.uuid5(uuid.NAMESPACE_URL, file_contents.hex()))
 
         return file_hash_uuid
 
-    def get_file_uuids(self, paths: List[str], local: bool = False) -> Dict[str, str]:
+    def get_file_uuids(
+        self, paths: List[PathType], local: bool = False
+    ) -> Dict[str, str]:
         """Computes the UUIDs for all files stored in the filesystem.
 
         @type paths: List[str]
@@ -410,23 +445,25 @@ class LuxonisFileSystem:
         if self.is_fsspec:
             with ThreadPoolExecutor() as executor:
                 for path in paths:
+                    path = str(path)
                     future = executor.submit(self.get_file_uuid, path, local)
                     result[path] = future.result()
 
         return result
 
-    def _split_mlflow_path(self, path: str) -> List[Optional[str]]:
+    def _split_mlflow_path(self, path: PathType) -> List[Optional[str]]:
         """Splits mlflow path into 3 parts."""
-        parts = path.split("/")
+        path = Path(path)
+        parts: List[Optional[str]] = list(path.parts)
         if len(parts) < 3:
             while len(parts) < 3:
                 parts.append(None)
         elif len(parts) > 3:
-            parts[2] = "/".join(parts[2:])
+            parts[2] = "/".join(cast(List[str], parts[2:]))
             parts = parts[:3]
         return parts
 
-    def is_directory(self, remote_path: str) -> bool:
+    def is_directory(self, remote_path: PathType) -> bool:
         """Checks whether the given remote path is a directory.
 
         @type remote_path: str
@@ -435,14 +472,11 @@ class LuxonisFileSystem:
         @return: True if the path is a directory.
         """
 
-        full_path = os.path.join(self.path, remote_path)
+        full_path = self.path / remote_path
         file_info = self.fs.info(full_path)
-        if file_info["type"] == "directory":
-            return True
-        else:
-            return False
+        return file_info["type"] == "directory"
 
-    def file_exists(self, remote_path: str) -> bool:
+    def exists(self, remote_path: PathType) -> bool:
         """Checks whether the given remote path exists.
 
         @type remote_path: str
@@ -450,11 +484,11 @@ class LuxonisFileSystem:
         @rtype: bool
         @return: True if the path exists.
         """
-        full_path = os.path.join(self.path, remote_path)
+        full_path = str(self.path / remote_path)
         return self.fs.exists(full_path)
 
     @staticmethod
-    def split_full_path(path: str) -> Tuple[str, str]:
+    def split_full_path(path: PathType) -> Tuple[str, str]:
         """Splits the full path into protocol and absolute path.
 
         @type path: str
@@ -462,8 +496,8 @@ class LuxonisFileSystem:
         @rtype: Tuple[str, str]
         @return: Tuple of protocol and absolute path.
         """
-        path = path.rstrip("/\\")
-        return os.path.split(path)
+        path = str(path).rstrip("/\\")
+        return osp.split(path)
 
     @staticmethod
     def get_protocol(path: str) -> str:
@@ -476,8 +510,62 @@ class LuxonisFileSystem:
         """
         return _get_protocol_and_path(path)[0]
 
+    @staticmethod
+    def download(url: str, dest: Optional[PathType]) -> Path:
+        """Downloads file or directory from remote storage.
 
-def _get_protocol_and_path(path: str) -> Tuple[str, str]:
+        Intended for downloading a single remove object, elevating the need to create an
+        instance of L{LuxonisFileSystem}.
+
+        @type url: str
+        @param url: URL to the file or directory
+        @type dest: Optional[str]
+        @param dest: Destination directory. If unspecified, the current directory is
+            used.
+        @rtype: Path
+        @return: Path to the downloaded file or directory.
+        """
+
+        dest = Path(dest or ".")
+        absolute_path, remote_path = LuxonisFileSystem.split_full_path(url)
+        if dest.suffix:
+            local_path = dest
+        else:
+            local_path = dest / remote_path
+        fs = LuxonisFileSystem(absolute_path)
+
+        if fs.is_directory(remote_path):
+            fs.get_dir(remote_path, local_path)
+
+        else:
+            fs.get_file(remote_path, str(local_path))
+
+        return local_path
+
+    @staticmethod
+    def upload(local_path: PathType, url: str) -> str:
+        """Uploads file or directory to remote storage.
+
+        Intended for uploading a single local object, elevating the need to create an
+        instance of L{LuxonisFileSystem}.
+
+        @type local_path: PathType
+        @param local_path: Path to the local file or directory
+        @type url: str
+        @param url: URL to the remote file or directory
+        @rtype: str
+        @return: URL to the uploaded file or directory.
+        """
+
+        absolute_path, remote_path = LuxonisFileSystem.split_full_path(url)
+        fs = LuxonisFileSystem(absolute_path)
+        if Path(local_path).is_dir():
+            fs.put_dir(local_path, remote_path)
+        else:
+            return fs.put_file(str(local_path), remote_path)
+
+
+def _get_protocol_and_path(path: str) -> Tuple[str, Optional[str]]:
     """Gets the protocol and absolute path of a full path."""
 
     if "://" in path:
@@ -489,4 +577,4 @@ def _get_protocol_and_path(path: str) -> Tuple[str, str]:
         # assume that it is local path
         protocol = "file"
 
-    return protocol, path
+    return protocol, path if path else None

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -192,7 +192,7 @@ class LuxonisFileSystem:
     ) -> Optional[Dict[str, str]]:
         """Uploads files to remote storage.
 
-        @type local_paths: Union[PathType, List[PathType]]
+        @type local_paths: Union[PathType, Sequence[PathType]]
         @param local_paths: Either a string specifying a directory to walk the files or
             a list of files which can be in different directories
         @type remote_dir: PathType
@@ -359,8 +359,7 @@ class LuxonisFileSystem:
             full_path = str(self.path / remote_dir)
             for file in self.fs.glob(full_path + "/**", detail=True):
                 if self.fs.info(file)["type"] == "file":
-                    assert isinstance(file, str)
-
+                    file = str(file)
                     file_without_path = file.replace(str(self.path), "")
                     if file_without_path.startswith("/"):
                         file_without_path = file_without_path[1:]
@@ -386,7 +385,8 @@ class LuxonisFileSystem:
                 import mlflow
 
                 client = mlflow.MlflowClient(tracking_uri=self.tracking_uri)
-                assert self.run_id is not None
+                if self.run_id is None:
+                    raise RuntimeError("`run_id` cannot be `None` when using `mlflow`")
                 download_path = client.download_artifacts(
                     run_id=self.run_id, path=self.artifact_path, dst_path="."
                 )

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -573,11 +573,12 @@ class LuxonisFileSystem:
         else:
             fs.put_file(str(local_path), remote_path)
 
-    def _sanitize_path(self, path: PathType) -> str:
+    @staticmethod
+    def _sanitize_path(path: PathType) -> str:
         if isinstance(path, str):
             return path
         if platform.system() == "Windows":
-            return path.as_posix().lstrip(path.drive)
+            return path.as_posix().lstrip(path.drive).replace("\\", "/")
         return str(path)
 
 

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -1,6 +1,6 @@
 import os
-import platform
 import os.path as osp
+import platform
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
@@ -277,7 +277,9 @@ class LuxonisFileSystem:
             raise NotImplementedError
         elif self.is_fsspec:
             self.fs.download(
-                self._sanitize_path(self.path / remote_path), str(local_path), recursive=False
+                self._sanitize_path(self.path / remote_path),
+                str(local_path),
+                recursive=False,
             )
         return Path(local_path) / Path(remote_path).name
 
@@ -301,7 +303,8 @@ class LuxonisFileSystem:
         """
         if self.is_fsspec:
             full_remote_paths = [
-                self._sanitize_path(self.path / remote_path) for remote_path in remote_paths
+                self._sanitize_path(self.path / remote_path)
+                for remote_path in remote_paths
             ]
             self.fs.rm(full_remote_paths)
         else:
@@ -329,7 +332,9 @@ class LuxonisFileSystem:
             raise NotImplementedError
         elif self.is_fsspec:
             self.fs.download(
-                self._sanitize_path(self.path / remote_dir), str(local_dir), recursive=True
+                self._sanitize_path(self.path / remote_dir),
+                str(local_dir),
+                recursive=True,
             )
         return Path(local_dir) / Path(remote_dir).name
 

--- a/luxonis_ml/utils/requirements.txt
+++ b/luxonis_ml/utils/requirements.txt
@@ -3,6 +3,6 @@ pydantic-settings>=2.1.0
 PyYAML>=6.0
 fsspec>=2023.1.0
 rich>=13.6.0
-# s3fs # if using S3 filesystem
-# gcsfs # if using GCS filesystem
-# mlflow # if using MLflow
+s3fs>=2023.1.0
+gcsfs>=2023.1.0
+mlflow>=2.10.0

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">9%</text>
-        <text x="80" y="14">9%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">11%</text>
+        <text x="80" y="14">11%</text>
     </g>
 </svg>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pre-commit>=3.2.1
 pytest-cov>=4.1.0
+pytest-dependency>=0.6.0
 pytest-md>=0.2.0
 gdown>=4.7.1
 coverage-badge>=1.1.0

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -1,4 +1,3 @@
-import random
 import shutil
 import tempfile
 from pathlib import Path
@@ -79,11 +78,11 @@ def clean(fs: LuxonisFileSystem, name: str):
 def setup_remote_tests():
     LOCAL_ROOT.mkdir(parents=True, exist_ok=True)
     LOCAL_DIR_PATH.mkdir(parents=True, exist_ok=True)
-    LOCAL_FILE_PATH.write_text(f"test {random.randint(0, 100)}")
+    LOCAL_FILE_PATH.write_text("test 42")
 
     for i in range(5):
         file_path = LOCAL_DIR_PATH / f"file_{i}.txt"
-        file_path.write_text(f"file {random.randint(0, 100)}")
+        file_path.write_text(f"file {i + 21}")
 
     yield
 

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -1,4 +1,6 @@
+import platform
 import shutil
+import sys
 import tempfile
 from pathlib import Path
 from typing import List, Optional
@@ -27,9 +29,29 @@ skip_if_no_gcs_credentials = pytest.mark.skipif(
 )
 
 
+# NOTE: needed for tests running in GitHub Actions using the matrix strategy
+#       to avoid race conditions when running tests in parallel
+def get_python_version():
+    version = sys.version_info
+    formatted_version = f"{version.major}{version.minor}"
+    return formatted_version
+
+
+def get_os():
+    os_name = platform.system().lower()
+    if "darwin" in os_name:
+        return "mac"
+    elif "linux" in os_name:
+        return "lin"
+    elif "windows" in os_name:
+        return "win"
+    else:
+        raise ValueError(f"Unsupported operating system: {os_name}")
+
+
 @pytest.fixture
 def fs(request):
-    url_path = f"{request.param}://{URL_PATH}"
+    url_path = f"{request.param}://{URL_PATH}_{get_os()}_{get_python_version()}"
     yield LuxonisFileSystem(url_path)
 
 

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -1,6 +1,93 @@
+import random
+import shutil
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
 import pytest
 
+from luxonis_ml.utils import environ
 from luxonis_ml.utils.filesystem import LuxonisFileSystem, _get_protocol_and_path
+
+URL_PATH = "luxonis-test-bucket/luxonis-ml-test-data/fs_test_data"
+
+LOCAL_ROOT = Path("tests/data/test_filesystem")
+LOCAL_FILE_PATH = LOCAL_ROOT / "_file.txt"
+LOCAL_DIR_PATH = LOCAL_ROOT / "_dir"
+
+skip_if_no_s3_credentials = pytest.mark.skipif(
+    environ.AWS_ACCESS_KEY_ID is None
+    or environ.AWS_SECRET_ACCESS_KEY is None
+    or environ.AWS_S3_ENDPOINT_URL is None,
+    reason="S3 credentials not set",
+)
+
+skip_if_no_gcs_credentials = pytest.mark.skipif(
+    environ.GOOGLE_APPLICATION_CREDENTIALS is None,
+    reason="GCS credentials not set",
+)
+
+
+@pytest.fixture
+def fs(request):
+    url_path = f"{request.param}://{URL_PATH}"
+    yield LuxonisFileSystem(url_path)
+
+
+def parametrize_dependent_fixture(
+    name: str = "fs",
+    depends: Optional[List[str]] = None,
+):
+    depends = depends or []
+    skips = {
+        "gs": skip_if_no_gcs_credentials,
+        "s3": skip_if_no_s3_credentials,
+    }
+
+    def decorator(func):
+        protocols = ["gs", "s3"]
+        return pytest.mark.parametrize(
+            name,
+            [
+                pytest.param(
+                    protocol,
+                    marks=[
+                        pytest.mark.dependency(
+                            depends=[f"{d}_{protocol}" for d in depends],
+                            name=f"{func.__name__}_{protocol}",
+                        ),
+                        skips[protocol],
+                    ],
+                )
+                for protocol in protocols
+            ],
+            indirect=name == "fs",
+        )(func)
+
+    return decorator
+
+
+def clean(fs: LuxonisFileSystem, name: str):
+    if Path(name).suffix:
+        fs.delete_file(name)
+    else:
+        fs.delete_dir(name)
+    assert not fs.exists(name)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_remote_tests():
+    LOCAL_ROOT.mkdir(parents=True, exist_ok=True)
+    LOCAL_DIR_PATH.mkdir(parents=True, exist_ok=True)
+    LOCAL_FILE_PATH.write_text(f"test {random.randint(0, 100)}")
+
+    for i in range(5):
+        file_path = LOCAL_DIR_PATH / f"file_{i}.txt"
+        file_path.write_text(f"file {random.randint(0, 100)}")
+
+    yield
+
+    shutil.rmtree(LOCAL_ROOT)
 
 
 def test_protocol():
@@ -13,3 +100,151 @@ def test_protocol():
 
     with pytest.raises(ValueError):
         LuxonisFileSystem("foo://bar")
+
+
+def test_fail():
+    with pytest.raises(ValueError):
+        LuxonisFileSystem(None)  # type: ignore
+        LuxonisFileSystem(str(LOCAL_FILE_PATH), allow_local=False)
+
+
+@parametrize_dependent_fixture()
+def test_file_download(fs: LuxonisFileSystem):
+    with tempfile.TemporaryDirectory() as tempdir:
+        file_path = fs.get_file("file.txt", tempdir)
+        assert file_path.exists()
+        assert file_path.read_text() == "file\n"
+
+
+@parametrize_dependent_fixture()
+def test_bytes(fs: LuxonisFileSystem):
+    fs.put_bytes(b"bytes_test", "test_bytes.txt")
+    assert fs.exists("test_bytes.txt")
+    buffer = fs.read_to_byte_buffer("test_bytes.txt")
+    assert buffer.read() == b"bytes_test"
+
+    clean(fs, "test_bytes.txt")
+
+
+@parametrize_dependent_fixture(depends=["test_file_download"])
+def test_file_upload(fs: LuxonisFileSystem):
+    fs.put_file(LOCAL_FILE_PATH, "_file_upload_test.txt")
+    assert fs.exists("_file_upload_test.txt")
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        file_path = fs.get_file("_file_upload_test.txt", tempdir)
+        assert file_path.exists()
+        assert file_path.read_text() == LOCAL_FILE_PATH.read_text()
+
+    clean(fs, "_file_upload_test.txt")
+
+
+@parametrize_dependent_fixture()
+def test_dir_download(fs: LuxonisFileSystem):
+    with tempfile.TemporaryDirectory() as tempdir:
+        dir_path = fs.get_dir("dir", tempdir)
+
+        assert dir_path.exists()
+        for i in range(1, 6):
+            file_path = Path(dir_path, f"file_{i}.txt")
+            assert file_path.exists()
+            assert file_path.read_text() == f"file_{i}\n"
+
+
+@parametrize_dependent_fixture(depends=["test_dir_download"])
+def test_dir_upload(fs: LuxonisFileSystem):
+    if fs.exists("_dir_upload_test"):
+        fs.delete_dir("_dir_upload_test")
+    assert not fs.exists("_dir_upload_test")
+
+    fs.put_dir(LOCAL_DIR_PATH, "_dir_upload_test")
+    assert fs.exists("_dir_upload_test")
+    assert fs.is_directory("_dir_upload_test")
+
+    def check_contents(dir_path: Path):
+        assert dir_path.exists()
+        for i in range(5):
+            file_path = Path(dir_path, f"file_{i}.txt")
+            assert file_path.exists()
+            assert (
+                file_path.read_text() == (LOCAL_DIR_PATH / f"file_{i}.txt").read_text()
+            )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        dir_path = fs.get_dir("_dir_upload_test", tempdir)
+        check_contents(dir_path)
+
+    fs.delete_files([f"_dir_upload_test/file_{i}.txt" for i in range(4)])
+    clean(fs, "_dir_upload_test")
+
+    fs.put_dir([str(p) for p in LOCAL_DIR_PATH.iterdir()], "__dir_upload_test")
+    assert fs.exists("__dir_upload_test")
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        dir_path = fs.get_dir("__dir_upload_test", tempdir)
+        check_contents(dir_path)
+
+    clean(fs, "__dir_upload_test")
+
+
+@parametrize_dependent_fixture()
+def test_walk_dir(fs: LuxonisFileSystem):
+    walked_files = [Path(file).name for file in fs.walk_dir("dir")]
+    assert set(walked_files) == {f"file_{i}.txt" for i in range(1, 6)}
+
+
+@parametrize_dependent_fixture(
+    "protocol",
+    [
+        "test_file_download",
+        "test_dir_download",
+    ],
+)
+def test_static_download(protocol: str):
+    with tempfile.TemporaryDirectory() as tempdir:
+        url = f"{protocol}://{URL_PATH}/file.txt"
+        path = LuxonisFileSystem.download(url, tempdir)
+        assert path.exists()
+        assert path.read_text() == "file\n"
+
+        url = f"{protocol}://{URL_PATH}/dir"
+        path = LuxonisFileSystem.download(url, tempdir)
+        assert path.exists()
+        for i in range(1, 6):
+            file_path = Path(path, f"file_{i}.txt")
+            assert file_path.exists()
+            assert file_path.read_text() == f"file_{i}\n"
+
+
+@parametrize_dependent_fixture(
+    "protocol",
+    [
+        "test_file_upload",
+        "test_dir_upload",
+        "test_static_download",
+    ],
+)
+def test_static_upload(protocol: str):
+    with tempfile.TemporaryDirectory() as tempdir:
+        url = f"{protocol}://{URL_PATH}/_file_upload_test.txt"
+        LuxonisFileSystem.upload(LOCAL_FILE_PATH, url)
+
+        file_path = LuxonisFileSystem.download(url, tempdir)
+        assert file_path.exists()
+        assert file_path.read_text() == LOCAL_FILE_PATH.read_text()
+
+        url = f"{protocol}://{URL_PATH}/_dir_upload_test"
+        LuxonisFileSystem.upload(LOCAL_DIR_PATH, url)
+
+        dir_path = LuxonisFileSystem.download(url, tempdir)
+        assert dir_path.exists()
+        for i in range(5):
+            file_path = Path(dir_path, f"file_{i}.txt")
+            assert file_path.exists()
+            assert (
+                file_path.read_text() == (LOCAL_DIR_PATH / f"file_{i}.txt").read_text()
+            )
+
+    fs = LuxonisFileSystem(f"{protocol}://{URL_PATH}")
+    clean(fs, "_file_upload_test.txt")
+    clean(fs, "_dir_upload_test")


### PR DESCRIPTION
# Updated `LuxonisFileSystem`

- Methods now accept both `str` and `pathlib.Path` arguments
- Added static method for single-use download/upload
  - Without the need to instantiate `LuxonisFileSystem` and then access the single file I want relatively to the root
```python
        LuxonisFileSystem.download(url, path)
        LuxonisFileSystem.upload(path, url)
```
- Fixed all type errors
- Added unittests 