### PR TITLE
fix anchor values dtype

### DIFF
--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
@@ -63,7 +63,7 @@ class HeadObjectDetection(Head, ABC):
         description="Confidence score threshold above which a detected object is considered valid."
     )
     max_det: int = Field(description="Maximum detections per image.")
-    anchors: Optional[List[List[List[int]]]] = Field(
+    anchors: Optional[List[List[List[float]]]] = Field(
         None,
         description="Predefined bounding boxes of different sizes and aspect ratios. The innermost lists are length 2 tuples of box sizes. The middle lists are anchors for each output. The outmost lists go from smallest to largest output.",
     )


### PR DESCRIPTION
I'm proposing a dtype change `HeadObjectDetection` `anchors` field from `int` to `float` based on how we define archors in `luxonis-train`. For example, default anchors for predefined `KeypointDetectionModel` are:

```
tensor([[[ 0.8952,  1.3661],
         [ 1.3352,  3.2720],
         [ 4.6421,  5.7249]],

        [[ 2.0591,  4.6850],
         [ 2.6462,  8.5874],
         [ 4.0296,  5.8769]],

        [[ 2.3380,  4.9676],
         [ 5.4474,  8.4566],
         [16.6143,  7.7743]]])
```