### PR TITLE
SOLO Parser

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -13,7 +13,7 @@ from rich.table import Table
 from typing_extensions import Annotated
 
 from luxonis_ml.data import LuxonisDataset, LuxonisLoader, LuxonisParser
-from luxonis_ml.enums import LabelType, SplitType
+from luxonis_ml.enums import DatasetType, LabelType, SplitType
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +180,17 @@ def parse(
             "-n",
             autocompletion=complete_dataset_name,
             help="Name of the dataset.",
+            show_default=False,
+        ),
+    ] = None,
+    dataset_type: Annotated[
+        Optional[DatasetType],
+        typer.Option(
+            ...,
+            "--type",
+            "-t",
+            help="Type of the dataset. If not provided, the parser will try to recognize it automatically.",
+            show_default=False,
         ),
     ] = None,
     delete_existing: Annotated[
@@ -201,6 +212,7 @@ def parse(
             help="If a remote URL is provided in 'dataset_dir', the dataset will "
             "be downloaded to this directory. Otherwise, the dataset will be "
             "downloaded to the current working directory.",
+            show_default=False,
         ),
     ] = None,
 ):
@@ -208,6 +220,7 @@ def parse(
     parser = LuxonisParser(
         dataset_dir,
         dataset_name=name,
+        dataset_type=dataset_type,
         delete_existing=delete_existing,
         save_dir=save_dir,
     )

--- a/luxonis_ml/data/parsers/__init__.py
+++ b/luxonis_ml/data/parsers/__init__.py
@@ -5,6 +5,7 @@ from .create_ml_parser import CreateMLParser
 from .darknet_parser import DarknetParser
 from .luxonis_parser import LuxonisParser
 from .segmentation_mask_directory_parser import SegmentationMaskDirectoryParser
+from .solo_parser import SOLOParser
 from .tensorflow_csv_parser import TensorflowCSVParser
 from .voc_parser import VOCParser
 from .yolov4_parser import YoloV4Parser
@@ -22,4 +23,5 @@ __all__ = [
     "TensorflowCSVParser",
     "ClassificationDirectoryParser",
     "SegmentationMaskDirectoryParser",
+    "SOLOParser",
 ]

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -60,7 +60,7 @@ class BaseParser(ABC):
 
     @abstractmethod
     def from_split(self, **kwargs) -> ParserOutput:
-        """Parses a data in a split subdirectoru to L{LuxonisDataset} format.
+        """Parses a data in a split subdirectory to L{LuxonisDataset} format.
 
         @type kwargs: Dict[str, Any]
         @param kwargs: Additional kwargs for specific parser implementation.

--- a/luxonis_ml/data/parsers/classification_directory_parser.py
+++ b/luxonis_ml/data/parsers/classification_directory_parser.py
@@ -37,6 +37,9 @@ class ClassificationDirectoryParser(BaseParser):
         ]
         if not classes:
             return None
+        fnames = [f for f in split_path.iterdir() if f.is_file()]
+        if fnames:
+            return None
         return {"class_dir": split_path}
 
     @staticmethod

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -14,6 +14,7 @@ from .coco_parser import COCOParser
 from .create_ml_parser import CreateMLParser
 from .darknet_parser import DarknetParser
 from .segmentation_mask_directory_parser import SegmentationMaskDirectoryParser
+from .solo_parser import SOLOParser
 from .tensorflow_csv_parser import TensorflowCSVParser
 from .voc_parser import VOCParser
 from .yolov4_parser import YoloV4Parser
@@ -38,6 +39,7 @@ class LuxonisParser:
         DatasetType.TFCSV: TensorflowCSVParser,
         DatasetType.CLSDIR: ClassificationDirectoryParser,
         DatasetType.SEGMASK: SegmentationMaskDirectoryParser,
+        DatasetType.SOLO: SOLOParser,
     }
 
     def __init__(

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -50,6 +50,7 @@ class LuxonisParser:
         delete_existing: bool = False,
         save_dir: Optional[Union[Path, str]] = None,
         dataset_plugin: Optional[str] = None,
+        dataset_type: Optional[DatasetType] = None,
         **kwargs,
     ):
         """High-level abstraction over various parsers.
@@ -72,6 +73,9 @@ class LuxonisParser:
         @type dataset_plugin: Optional[str]
         @param dataset_plugin: Name of the dataset plugin to use. If C{None},
             C{LuxonisDataset} is used.
+        @type dataset_type: Optional[DatasetType]
+        @param dataset_type: If provided, the parser will use this dataset type instead
+            of trying to recognize it automatically.
         """
         save_dir = Path(save_dir) if save_dir else None
         name = Path(dataset_dir).name
@@ -84,7 +88,15 @@ class LuxonisParser:
                 zip_ref.extractall(unzip_dir)
                 self.dataset_dir = unzip_dir
 
-        self.dataset_type, self.parser_type = self._recognize_dataset()
+        if dataset_type:
+            self.dataset_type = dataset_type
+            self.parser_type = (
+                ParserType.DIR
+                if Path(self.dataset_dir / "train").exists()
+                else ParserType.SPLIT
+            )
+        else:
+            self.dataset_type, self.parser_type = self._recognize_dataset()
 
         if dataset_plugin:
             self.dataset_constructor = DATASETS_REGISTRY.get(dataset_plugin)
@@ -140,12 +152,15 @@ class LuxonisParser:
                     extra={"markup": True},
                 )
                 return typ, ParserType.DIR
+
+        for typ, parser in self.parsers.items():
             if parser.validate_split(self.dataset_dir):
                 logger.info(
                     f"[cyan]Recognized dataset format as a split of [red]<{typ.name}>",
                     extra={"markup": True},
                 )
                 return typ, ParserType.SPLIT
+
         raise ValueError(
             f"Dataset {self.dataset_dir} is not in expected format for any of the parsers."
         )

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -1,11 +1,12 @@
-import os
-import cv2
-import json
 import glob
-import numpy as np
+import json
+import os
 from pathlib import Path
-import pycocotools.mask as mask_util
 from typing import Any, Dict, List, Optional, Tuple
+
+import cv2
+import numpy as np
+import pycocotools.mask as mask_util
 
 from luxonis_ml.data import DatasetGenerator
 
@@ -107,12 +108,14 @@ class SOLOParser(BaseParser):
         self,
         split_path: Path,
     ) -> ParserOutput:
-        """Parses data in a split subdirectory from SOLO format to L{LuxonisDataset} format.
+        """Parses data in a split subdirectory from SOLO format to L{LuxonisDataset}
+        format.
 
         @type split_path: Path
         @param split_path: Path to directory with sequences of images and annotations.
         @rtype: L{ParserOutput}
-        @return: C{LDF} generator, list of class names, skeleton dictionary for keypoints and list of added images.
+        @return: C{LDF} generator, list of class names, skeleton dictionary for
+            keypoints and list of added images.
         """
 
         if not os.path.exists(split_path):
@@ -137,25 +140,24 @@ class SOLOParser(BaseParser):
 
         keypoint_labels = self._get_solo_keypoint_names(annotation_definitions_dict)
 
-        skeletons = {class_name: {"labels": keypoint_labels} for class_name in class_names}
+        skeletons = {
+            class_name: {"labels": keypoint_labels} for class_name in class_names
+        }
         # TODO: setting skeletons by assigning all keypoint names to each class_name. Is this OK?
         # if NOT, set them manually with LuxonisDataset.set_skeletons() as SOLO format does not
         # encode which keypoint_name belongs to which class
 
         def generator() -> DatasetGenerator:
-
             for dir_path, dir_names, _ in os.walk(split_path):
-
                 for dir_name in dir_names:
-
                     if not dir_name.startswith("sequence"):
                         continue
 
                     sequence_path = os.path.join(dir_path, dir_name)
-                    
+
                     for frame_fname in glob.glob(
                         os.path.join(sequence_path, "*.frame_data.json")
-                    ): # single sequence can have multiple steps
+                    ):  # single sequence can have multiple steps
                         frame_path = os.path.join(sequence_path, frame_fname)
                         if not os.path.exists(frame_path):
                             raise FileNotFoundError(f"{frame_path} not existent.")
@@ -221,7 +223,7 @@ class SOLOParser(BaseParser):
                                         curr_rle["size"][1],
                                         curr_rle["counts"],
                                     )
-                                    
+
                                     yield {
                                         "file": img_path,
                                         "class": class_name,

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -59,15 +59,15 @@ class SOLOParser(BaseParser):
         with open(os.path.join(split_path, "metadata.json")) as json_file:
             metadata_dict = json.load(json_file)
         # check if all sequences are present
-        totalSequences_expected = metadata_dict["totalSequences"]
-        totalSequences = len(
+        total_sequences_expected = metadata_dict["totalSequences"]
+        total_sequences = len(
             [
                 d
                 for d in glob.glob(os.path.join(split_path, "sequence*"))
                 if os.path.isdir(d)
             ]
         )
-        if not totalSequences == totalSequences_expected:
+        if not total_sequences == total_sequences_expected:
             return None
         return {"split_path": split_path}
 

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -20,14 +20,14 @@ class SOLOParser(BaseParser):
 
         dataset_dir/
         ├── train/
-            ├── metadata.json
-            ├── sensor_definitions.json
-            ├── annotation_definitions.json
-            ├── metric_definitions.json
-            ├── sequence.<SequenceNUM>/
-            │   ├── step<StepNUM>.camera.jpg
-            │   ├── step<StepNUM>.frame_data.json
-            │   ├── (OPTIONAL: step<StepNUM>.camera.semantic segmentation.jpg)
+        │   ├── metadata.json
+        │   ├── sensor_definitions.json
+        │   ├── annotation_definitions.json
+        │   ├── metric_definitions.json
+        │   └── sequence.<SequenceNUM>/
+        │       ├── step<StepNUM>.camera.jpg
+        │       ├── step<StepNUM>.frame_data.json
+        │       └── (OPTIONAL: step<StepNUM>.camera.semantic segmentation.jpg)
         ├── valid/
         └── test/
 

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -1,0 +1,320 @@
+import os
+import cv2
+import json
+import glob
+import numpy as np
+from pathlib import Path
+import pycocotools.mask as mask_util
+from typing import Any, Dict, List, Optional, Tuple
+
+from luxonis_ml.data import DatasetGenerator
+
+from .base_parser import BaseParser, ParserOutput
+
+
+class SOLOParser(BaseParser):
+    """Parses directory with SOLO annotations to LDF.
+
+    Expected format::
+
+        dataset_dir/
+        ├── train/
+            ├── metadata.json
+            ├── sensor_definitions.json
+            ├── annotation_definitions.json
+            ├── metric_definitions.json
+            ├── sequence.<SequenceNUM>/
+            │   ├── step<StepNUM>.camera.jpg
+            │   ├── step<StepNUM>.frame_data.json
+            │   ├── (OPTIONAL: step<StepNUM>.camera.semantic segmentation.jpg)
+        ├── valid/
+        └── test/
+
+    This is the default format returned by Unity simulation engine.
+    """
+
+    @staticmethod
+    def validate_split(split_path: Path) -> Optional[Dict[str, Any]]:
+        """Validates if a split subdirectory is in an expected format.
+
+        @type split_path: Path
+        @param split_path: Path to split directory.
+        @rtype: Optional[Dict[str, Any]]
+        @return: Dictionary with kwargs to pass to L{from_split} method or C{None} if
+            the split is not in the expected format.
+        """
+        if not split_path.exists():
+            return None
+        # check if all json files are present
+        for json_fname in [
+            "annotation_definitions.json",
+            "metadata.json",
+            "metric_definitions.json",
+            "sensor_definitions.json",
+        ]:
+            json_path = next(split_path.glob(json_fname), None)
+            if not json_path:
+                return None
+        with open(os.path.join(split_path, "metadata.json")) as json_file:
+            metadata_dict = json.load(json_file)
+        # check if all sequences are present
+        totalSequences_expected = metadata_dict["totalSequences"]
+        totalSequences = len(
+            [
+                d
+                for d in glob.glob(os.path.join(split_path, "sequence*"))
+                if os.path.isdir(d)
+            ]
+        )
+        if not totalSequences == totalSequences_expected:
+            return None
+        return {"split_path": split_path}
+
+    @staticmethod
+    def validate(dataset_dir: Path) -> bool:
+        """Validates if the dataset is in an expected format.
+
+        @type dataset_dir: Path
+        @param dataset_dir: Path to source dataset directory.
+        @rtype: bool
+        @return: True if the dataset is in the expected format.
+        """
+        for split in ["train", "valid", "test"]:
+            split_path = dataset_dir / split
+            if SOLOParser.validate_split(split_path) is None:
+                return False
+        return True
+
+    def from_dir(
+        self,
+        dataset_dir: Path,
+    ) -> Tuple[List[str], List[str], List[str]]:
+        """Parses all present data to L{LuxonisDataset} format.
+
+        @type dataset_dir: str
+        @param dataset_dir: Path to source dataset directory.
+        @rtype: Tuple[List[str], List[str], List[str]]
+        @return: Tuple with added images for train, valid and test splits.
+        """
+
+        added_train_imgs = self._parse_split(split_path=dataset_dir / "train")
+        added_valid_imgs = self._parse_split(split_path=dataset_dir / "valid")
+        added_test_imgs = self._parse_split(split_path=dataset_dir / "test")
+
+        return added_train_imgs, added_valid_imgs, added_test_imgs
+
+    def from_split(
+        self,
+        split_path: Path,
+    ) -> ParserOutput:
+        """Parses data in a split subdirectory from SOLO format to L{LuxonisDataset} format.
+
+        @type split_path: Path
+        @param split_path: Path to directory with sequences of images and annotations.
+        @rtype: L{ParserOutput}
+        @return: C{LDF} generator, list of class names, skeleton dictionary for keypoints and list of added images.
+        """
+
+        if not os.path.exists(split_path):
+            raise Exception(f"{split_path} path non-existent.")
+
+        annotation_definitions_path = os.path.join(
+            split_path, "annotation_definitions.json"
+        )
+        if os.path.exists(annotation_definitions_path):
+            with open(annotation_definitions_path) as json_file:
+                annotation_definitions_dict = json.load(json_file)
+        else:
+            raise Exception(f"{annotation_definitions_path} path non-existent.")
+
+        annotation_types = self._get_solo_annotation_types(annotation_definitions_dict)
+
+        class_names = self._get_solo_bbox_class_names(annotation_definitions_dict)
+        # TODO: We make an assumption here that bbox class_names are also valid for all other annotation types in the dataset. Is this OK?
+        # TODO: Can we imagine a case where classes between annotation types are different? Which class names to return in this case?
+        if class_names == []:
+            raise Exception("No class_names identified. ")
+
+        keypoint_labels = self._get_solo_keypoint_names(annotation_definitions_dict)
+
+        skeletons = {class_name: {"labels": keypoint_labels} for class_name in class_names}
+        # TODO: setting skeletons by assigning all keypoint names to each class_name. Is this OK?
+        # if NOT, set them manually with LuxonisDataset.set_skeletons() as SOLO format does not
+        # encode which keypoint_name belongs to which class
+
+        def generator() -> DatasetGenerator:
+
+            for dir_path, dir_names, _ in os.walk(split_path):
+
+                for dir_name in dir_names:
+
+                    if not dir_name.startswith("sequence"):
+                        continue
+
+                    sequence_path = os.path.join(dir_path, dir_name)
+                    
+                    for frame_fname in glob.glob(
+                        os.path.join(sequence_path, "*.frame_data.json")
+                    ): # single sequence can have multiple steps
+                        frame_path = os.path.join(sequence_path, frame_fname)
+                        if not os.path.exists(frame_path):
+                            raise FileNotFoundError(f"{frame_path} not existent.")
+                        with open(frame_path) as f:
+                            frame = json.load(f)
+
+                        for capture in frame["captures"]:
+                            img_fname = capture["filename"]
+                            img_w, img_h = capture["dimension"]
+                            annotations = capture["annotations"]
+                            img_path = os.path.join(sequence_path, img_fname)
+                            if not os.path.exists(img_path):
+                                raise FileNotFoundError(f"{img_path} not existent.")
+
+                            if "BoundingBox2DAnnotation" in annotation_types:
+                                for anno in annotations:
+                                    if anno["@type"].endswith(
+                                        "BoundingBox2DAnnotation"
+                                    ):
+                                        bbox_annotations = anno["values"]
+
+                                for bbox_annotation in bbox_annotations:
+                                    class_name = bbox_annotation["labelName"]
+
+                                    origin = bbox_annotation["origin"]
+                                    dimension = bbox_annotation["dimension"]
+                                    xmin, ymin = origin
+                                    bbox_w, bbox_h = dimension
+
+                                    yield {
+                                        "file": img_path,
+                                        "class": class_name,
+                                        "type": "box",
+                                        "value": (
+                                            xmin / img_w,
+                                            ymin / img_h,
+                                            bbox_w / img_w,
+                                            bbox_h / img_h,
+                                        ),
+                                    }
+
+                            if "SemanticSegmentationAnnotation" in annotation_types:
+                                for anno in annotations:
+                                    if anno["@type"].endswith(
+                                        "SemanticSegmentationAnnotation"
+                                    ):
+                                        sseg_annotations = anno
+
+                                mask_fname = sseg_annotations["filename"]
+                                mask_path = os.path.join(sequence_path, mask_fname)
+                                mask = cv2.imread(mask_path)
+
+                                for instance in sseg_annotations["instances"]:
+                                    class_name = instance["labelName"]
+                                    r, g, b, _ = instance["pixelValue"]
+                                    curr_mask = np.zeros_like(mask)
+                                    curr_mask[np.all(mask == [b, g, r], axis=2)] = 1
+                                    curr_mask = np.max(curr_mask, axis=2)  # 3D->2D
+                                    curr_mask = np.asfortranarray(curr_mask)
+                                    curr_rle = mask_util.encode(curr_mask)
+                                    value = (
+                                        curr_rle["size"][0],
+                                        curr_rle["size"][1],
+                                        curr_rle["counts"],
+                                    )
+                                    
+                                    yield {
+                                        "file": img_path,
+                                        "class": class_name,
+                                        "type": "segmentation",
+                                        "value": value,
+                                    }
+
+                            if "KeypointAnnotation" in annotation_types:
+                                for anno in annotations:
+                                    if anno["@type"].endswith("KeypointAnnotation"):
+                                        keypoint_annotations = anno["values"]
+
+                                for keypoints_annotation in keypoint_annotations:
+                                    label_id = keypoints_annotation["labelId"]
+                                    keypoints = []
+                                    for keypoint in keypoints_annotation["keypoints"]:
+                                        x, y = keypoint["location"]
+                                        visibility = keypoint["state"]
+                                        keypoints.append(
+                                            (x / img_w, y / img_h, visibility)
+                                        )
+
+                                    class_name = class_names[label_id]
+
+                                    yield {
+                                        "file": img_path,
+                                        "class": class_name,
+                                        "type": "keypoints",
+                                        "value": keypoints,
+                                    }
+
+        added_images = self._get_added_images(generator)
+
+        return (
+            generator,
+            class_names,
+            skeletons,
+            added_images,
+        )
+
+    def _get_solo_annotation_types(self, annotation_definitions_dict: dict) -> list:
+        """List all annotation types present in the dataset.
+
+        @type annotation_definitions_dict: dict
+        @param annotation_definitions_dict: annotation_definitions.json read as dict.
+        @rtype: List[str]
+        @return: List of annotation types (e.g. ["BoundingBox2DAnnotation", "SemanticSegmentationAnnotation", ...]).
+        """
+
+        annotation_types = []
+        for definition in annotation_definitions_dict["annotationDefinitions"]:
+            annotation_types.append(
+                definition["@type"].replace("type.unity.com/unity.solo.", "")
+            )
+        return annotation_types
+
+    def _get_solo_bbox_class_names(self, annotation_definitions_dict):
+        """List class names for BoundingBox2DAnnotation type.
+
+        @type annotation_definitions_dict: dict
+        @param annotation_definitions_dict: annotation_definitions.json read as dict.
+        @rtype: List[str]
+        @return: List of class names (e.g. ["car", "motorbike", ...]).
+        """
+
+        class_names = []
+        for definition in annotation_definitions_dict["annotationDefinitions"]:
+            annotation_type = definition["@type"].replace(
+                "type.unity.com/unity.solo.", ""
+            )
+            if annotation_type == "BoundingBox2DAnnotation":
+                names = [spec["label_name"] for spec in definition["spec"]]
+                ids = [spec["label_id"] for spec in definition["spec"]]
+                class_names = [c for _, c in sorted(zip(ids, names))]
+        return class_names
+
+    def _get_solo_keypoint_names(self, annotation_definitions_dict):
+        """List keypoint labels for all classes.
+
+        @type annotation_definitions_dict: dict
+        @param annotation_definitions_dict: annotation_definitions.json read as dict.
+        @rtype: List[str]
+        @return: List of keypoint labels (e.g. ["wheel_front_motorbike", "wheel_back_motorbike", ...]).
+        """
+
+        keypoint_labels = []
+        for definition in annotation_definitions_dict["annotationDefinitions"]:
+            annotation_type = definition["@type"].replace(
+                "type.unity.com/unity.solo.", ""
+            )
+            if annotation_type == "KeypointAnnotation":
+                keypoints = definition["template"]["keypoints"]
+                labels = [keypoint["label"] for keypoint in keypoints]
+                ids = [keypoint["index"] for keypoint in keypoints]
+                keypoint_labels = [c for _, c in sorted(zip(ids, labels))]
+        return keypoint_labels

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -114,8 +114,8 @@ class SOLOParser(BaseParser):
         @type split_path: Path
         @param split_path: Path to directory with sequences of images and annotations.
         @rtype: L{ParserOutput}
-        @return: C{LuxonisDataset} generator, list of class names, skeleton dictionary for
-            keypoints and list of added images.
+        @return: C{LuxonisDataset} generator, list of class names, skeleton dictionary
+            for keypoints and list of added images.
         """
 
         if not os.path.exists(split_path):

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -114,7 +114,7 @@ class SOLOParser(BaseParser):
         @type split_path: Path
         @param split_path: Path to directory with sequences of images and annotations.
         @rtype: L{ParserOutput}
-        @return: C{LDF} generator, list of class names, skeleton dictionary for
+        @return: C{LuxonisDataset} generator, list of class names, skeleton dictionary for
             keypoints and list of added images.
         """
 

--- a/luxonis_ml/enums/enums.py
+++ b/luxonis_ml/enums/enums.py
@@ -19,6 +19,7 @@ class DatasetType(str, Enum):
     TFCSV = "tfcsv"
     CLSDIR = "clsdir"
     SEGMASK = "segmask"
+    SOLO = "solo"
 
 
 class SplitType(str, Enum):

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">47%</text>
-        <text x="80" y="14">47%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">46%</text>
+        <text x="80" y="14">46%</text>
     </g>
 </svg>


### PR DESCRIPTION
Adding parser support for Unity's SOLO dataset format. I've also prepared a two-class MRE to test it out (**[HERE](https://drive.google.com/file/d/1-T0LmymIHwHYXPH6-24C9RRY0lob2-Y2/view?usp=sharing)**). The MRE is functional but there remain some open issues:

1. **Setting class names [[HERE](https://github.com/luxonis/luxonis-ml/blob/feature/solo-parser/luxonis_ml/data/parsers/solo_parser.py#L135)]**. The SOLO `annotation_definitions.json` file (containing definitions of all annotations in the dataset) only lists class names for bounding box annotations. I'm thus making an assumption that bbox class names are also valid for all other annotation types in the dataset. Is this OK? Can we imagine a case where classes between annotation types are different? Which class names to return in that case?

2. **Setting keypoint skeletons [[HERE](https://github.com/luxonis/luxonis-ml/blob/feature/solo-parser/luxonis_ml/data/parsers/solo_parser.py#L143)]** (dicts mapping class names to keypoint "labels" and "edges" between keypoints). SOLO `annotation_definitions.json` file doesn't encode which keypoint labels belong to which class (at least as far as I'm concerned). I'm thus setting skeletons by assigning all existing keypoint labels to each class name. Is this OK? Setting it this way also helps overcoming the **problem of multi-class keypoint instances where nk's are not equal ([HERE](https://github.com/luxonis/luxonis-ml/blob/feature/solo-parser/luxonis_ml/data/loader.py#L272))** as the the length of the "labels" determines the official number of keypoints which becomes equal for each class. But I'm not sure if its desirable because it forces us to store all existing keypoints (even if most are null) for each object instance.

3. **Repeating image file names error**. When running `LuxonisDataset.add()` we check (**[HERE](https://github.com/luxonis/luxonis-ml/blob/feature/solo-parser/luxonis_ml/data/datasets/luxonis_dataset.py#L534)**) if fnames of any of the TBA instances matches those of the already added instances. The problem is that in SOLO format image files have uniform names between sequences (`step<NUM>.camera.jpg`) which raises an error (I changed the fnames in MRE to overcome that). Any thoughts on how to fix this? One option is to remove this check (there are some comments in the code suggesting this already) or compare instance ids instead (as is already suggested by the name of the `self._try_instance_id` method).