### PR TITLE
Hotfix No Commit To Branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,11 @@ repos:
         additional_dependencies: [tomli]
         args: [--in-place, --black, --style=epytext]
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-    - id: no-commit-to-branch
-      args: ['--branch', 'main', '--branch', 'dev']
+  # - repo: https://github.com/pre-commit/pre-commit-hooks
+  #   rev: v4.4.0
+  #   hooks:
+  #   - id: no-commit-to-branch
+  #     args: ['--branch', 'main', '--branch', 'dev']
 
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.10


### PR DESCRIPTION
Temporarily removing `no-commit-to-branch` rule from `.pre-commit-config.yaml`. 
When merging `dev` branch to `main`, the `pre-commit` check fails because of this rule. 