### PR TITLE
Allow int32 i/o

### DIFF
--- a/luxonis_ml/nn_archive/config_building_blocks/enums/data_type.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/enums/data_type.py
@@ -5,6 +5,7 @@ class DataType(Enum):
     """Represents all existing data types used in i/o streams of the model."""
 
     INT8 = "int8"
+    INT32 = "int32"
     UINT8 = "uint8"
     FLOAT32 = "float32"
     FLOAT16 = "float16"


### PR DESCRIPTION
Extending the list of the supported data types in i/o streams of the model with int32.