### PR TITLE
Redefine Constraint on Duplicate Filenames

### DIFF
--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -239,6 +239,7 @@ class LuxonisDataset(BaseDataset):
         if index is None:
             return None
 
+        filepath = osp.abspath(filepath)
         if filepath in list(index["original_filepath"]):
             matched = index[index["original_filepath"] == filepath]
             if len(matched):

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -527,7 +527,7 @@ class LuxonisDataset(BaseDataset):
                 file = osp.basename(filepath)
                 instance_id = uuid_dict[filepath]
                 # check for duplicate instance_ids to get a one-to-one relationship
-                matched_id = self._find_filepath_instance_id(filepath, index)  
+                matched_id = self._find_filepath_instance_id(filepath, index)
                 if matched_id is not None:
                     if matched_id == instance_id:
                         raise Exception(
@@ -644,7 +644,10 @@ class LuxonisDataset(BaseDataset):
                 filepaths = definitions[split]
                 if not isinstance(filepaths, list):
                     raise Exception("Must provide splits as a list of str")
-                ids = [self._find_filepath_instance_id(filepath, index) for filepath in filepaths]
+                ids = [
+                    self._find_filepath_instance_id(filepath, index)
+                    for filepath in filepaths
+                ]
                 new_splits[split] = ids
 
         if self.bucket_storage == BucketStorage.LOCAL:


### PR DESCRIPTION
**Description**:
Currently in LuxonisDataset, we have a constraint that the base filename of a path to media being added to a dataset must be unique. However, in cases like the SOLO format, we naturally have many different images with the same filenames. We redefine here this constraint to decide duplication based on the original_filepath instead of the filename.