### PR TITLE
COCO Parser Speedup

### DIFF
--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -140,18 +140,21 @@ class COCOParser(BaseParser):
                 }
 
         def generator() -> DatasetIterator:
-            for img in coco_images:
-                img_id = img["id"]
+            img_dict = {img["id"]: img for img in coco_images}
+            ann_dict = {}
+            for ann in coco_annotations:
+                img_id = ann["image_id"]
+                if img_id not in ann_dict:
+                    ann_dict[img_id] = []
+                ann_dict[img_id].append(ann)
 
+            for img_id, img in img_dict.items():
                 path = image_dir.absolute() / img["file_name"]
                 if not path.exists():
                     continue
                 path = str(path)
 
-                img_anns = [
-                    ann for ann in coco_annotations if ann["image_id"] == img_id
-                ]
-
+                img_anns = ann_dict.get(img_id, [])
                 img_h = img["height"]
                 img_w = img["width"]
 


### PR DESCRIPTION
Modified the code for building the COCO dataset by using dictionaries for quick lookups, rather than repeatedly scanning the entire list of images and annotations.

Dictionaries provide an average-case constant time complexity (O(1)) for lookups, in contrast to the linear time complexity (O(n)) of list scans. This optimization considerably reduces the overall time complexity of the code.

The time required to create the **_COCO train dataset_**—prior to sending the batch to the bucket—decreased **_from 2 hours to 20 minutes_**.