### PR TITLE
Fix and Enhance Head Metadata Validation

### DIFF
--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 from .head_metadata import (
     HeadClassificationMetadata,
-    HeadCustomMetadata,
+    HeadMetadata,
     HeadObjectDetectionMetadata,
     HeadObjectDetectionSSDMetadata,
     HeadSegmentationMetadata,
@@ -36,7 +36,7 @@ class Head(BaseModel, ABC):
         HeadObjectDetectionSSDMetadata,
         HeadSegmentationMetadata,
         HeadYOLOMetadata,
-        HeadCustomMetadata,
+        HeadMetadata,
     ] = Field(description="Metadata of the parser.")
     outputs: Optional[List[str]] = Field(
         None,

--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field
 
 from .head_metadata import (
     HeadClassificationMetadata,
-    HeadMetadata,
+    HeadCustomMetadata,
     HeadObjectDetectionMetadata,
     HeadObjectDetectionSSDMetadata,
     HeadSegmentationMetadata,
@@ -36,7 +36,7 @@ class Head(BaseModel, ABC):
         HeadObjectDetectionSSDMetadata,
         HeadSegmentationMetadata,
         HeadYOLOMetadata,
-        HeadMetadata,
+        HeadCustomMetadata,
     ] = Field(description="Metadata of the parser.")
     outputs: Optional[List[str]] = Field(
         None,

--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/head.py
@@ -31,12 +31,12 @@ class Head(BaseModel, ABC):
         description="Name of the parser responsible for processing the models output."
     )
     metadata: Union[
-        HeadMetadata,
         HeadObjectDetectionMetadata,
         HeadClassificationMetadata,
         HeadObjectDetectionSSDMetadata,
         HeadSegmentationMetadata,
         HeadYOLOMetadata,
+        HeadMetadata,
     ] = Field(description="Metadata of the parser.")
     outputs: Optional[List[str]] = Field(
         None,

--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/head_metadata.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/head_metadata.py
@@ -202,6 +202,7 @@ class HeadYOLOMetadata(HeadObjectDetectionMetadata, HeadSegmentationMetadata):
         defined_params = defined_params.difference(common_fields)
 
         required_fields = {
+            "object_detection": [],
             "instance_segmentation": [
                 "n_prototypes",
                 "is_softmax",

--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/head_metadata.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/head_metadata.py
@@ -1,32 +1,22 @@
-from abc import ABC
 from typing import List, Optional
 
-from pydantic import ConfigDict, Field, model_validator
-
-from luxonis_ml.utils import BaseModelExtraForbid
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ..enums import ObjectDetectionSubtypeYOLO
 
 
-class HeadMetadata(BaseModelExtraForbid, ABC):
-    """Abstract class defining general metadata for heads.
+class HeadMetadata(BaseModel):
+    """Metadata for the basic head. It allows you to specify additional fields.
 
     @type postprocessor_path: str | None
     @ivar postprocessor_path: Path to the postprocessor.
     """
 
+    model_config = ConfigDict(extra="allow")
+
     postprocessor_path: Optional[str] = Field(
         None, description="Path to the postprocessor."
     )
-
-
-class HeadCustomMetadata(HeadMetadata):
-    """Metadata for the custom head.
-
-    It allows you to specify additional fields.
-    """
-
-    model_config: ConfigDict = ConfigDict(extra="allow")
 
 
 class HeadObjectDetectionMetadata(HeadMetadata):

--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/head_metadata.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/head_metadata.py
@@ -1,22 +1,32 @@
+from abc import ABC
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
+
+from luxonis_ml.utils import BaseModelExtraForbid
 
 from ..enums import ObjectDetectionSubtypeYOLO
 
 
-class HeadMetadata(BaseModel):
-    """Metadata for the basic head. It allows you to specify additional fields.
+class HeadMetadata(BaseModelExtraForbid, ABC):
+    """Abstract class defining general metadata for heads.
 
     @type postprocessor_path: str | None
     @ivar postprocessor_path: Path to the postprocessor.
     """
 
-    model_config = ConfigDict(extra="allow")
-
     postprocessor_path: Optional[str] = Field(
         None, description="Path to the postprocessor."
     )
+
+
+class HeadCustomMetadata(HeadMetadata):
+    """Metadata for the custom head.
+
+    It allows you to specify additional fields.
+    """
+
+    model_config: ConfigDict = ConfigDict(extra="allow")
 
 
 class HeadObjectDetectionMetadata(HeadMetadata):


### PR DESCRIPTION
This PR addresses a bug in head metadata validation and improves the overall validation process. The following changes are introduced:

1. **Addition of object_detection key under the task-specific requirements**:
The `object_detection` key is now included in the `required_fields` dict. This prevents errors that were previously occurring during the parameters combination check.

2. **Updated validation order**:
The validation order for head metadata has been modified to first consider all defined classes before defaulting to the open class. For example, this ensures that metadata for object detection is validated with the HeadObjectDetectionMetadata class as intended.

3. **Refactoring of HeadMetadata class**:
The `HeadMetadata` class has been converted into an abstract class. A new `HeadCustomMetadata` class has been introduced, allowing for the specification of additional custom fields in cases where no specific class is defined for a particular model. **EDIT: I see now our tests require that specified head metadata classes allow extra fields. Thus I am changing this back to original**.