### PR TITLE
Loaders Registry

### DIFF
--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -12,7 +12,12 @@ with guard_missing_extra("data"):
         LuxonisDataset,
         LuxonisSource,
     )
-    from .loaders import BaseLoader, LuxonisLoader, LuxonisLoaderOutput
+    from .loaders import (
+        LOADERS_REGISTRY,
+        BaseLoader,
+        LuxonisLoader,
+        LuxonisLoaderOutput,
+    )
     from .parsers import LuxonisParser
     from .utils.enums import (
         BucketStorage,
@@ -30,7 +35,15 @@ def load_dataset_plugins() -> None:
         DATASETS_REGISTRY.register_module(module=plugin_class)
 
 
+def load_loader_plugins() -> None:
+    """Registers any external dataset BaseLoader class plugins."""
+    for entry_point in pkg_resources.iter_entry_points("loader_plugins"):
+        plugin_class = entry_point.load()
+        DATASETS_REGISTRY.register_module(module=plugin_class)
+
+
 load_dataset_plugins()
+load_loader_plugins()
 
 __all__ = [
     "Augmentations",
@@ -40,6 +53,7 @@ __all__ = [
     "BucketType",
     "DatasetIterator",
     "DATASETS_REGISTRY",
+    "LOADERS_REGISTRY",
     "ImageType",
     "LabelType",
     "LuxonisComponent",

--- a/luxonis_ml/data/loaders/__init__.py
+++ b/luxonis_ml/data/loaders/__init__.py
@@ -1,4 +1,10 @@
-from .base_loader import BaseLoader, Labels, LuxonisLoaderOutput
+from .base_loader import LOADERS_REGISTRY, BaseLoader, Labels, LuxonisLoaderOutput
 from .luxonis_loader import LuxonisLoader
 
-__all__ = ["BaseLoader", "Labels", "LuxonisLoader", "LuxonisLoaderOutput"]
+__all__ = [
+    "BaseLoader",
+    "Labels",
+    "LuxonisLoader",
+    "LuxonisLoaderOutput",
+    "LOADERS_REGISTRY",
+]

--- a/luxonis_ml/data/loaders/base_loader.py
+++ b/luxonis_ml/data/loaders/base_loader.py
@@ -4,6 +4,8 @@ from typing import Dict, Tuple
 import numpy as np
 from typing_extensions import TypeAlias
 
+from luxonis_ml.utils import AutoRegisterMeta, Registry
+
 from ..utils.enums import LabelType
 
 Labels: TypeAlias = Dict[str, Tuple[np.ndarray, LabelType]]
@@ -15,8 +17,12 @@ LuxonisLoaderOutput: TypeAlias = Tuple[np.ndarray, Labels]
 """C{LuxonisLoaderOutput} is a tuple of an image as a L{numpy array<np.ndarray>} and a
 dictionary of task group names and their annotations as L{Annotations}."""
 
+LOADERS_REGISTRY = Registry(name="loaders")
 
-class BaseLoader(ABC):
+
+class BaseLoader(
+    ABC, metaclass=AutoRegisterMeta, registry=LOADERS_REGISTRY, register=False
+):
     """Base abstract loader class.
 
     Enforces the L{LuxonisLoaderOutput} output label structure.


### PR DESCRIPTION
Similar to https://github.com/luxonis/luxonis-ml/pull/84, this PR introduces a `LOADERS_REGISTRY` for the loaders using `BaseLoader`. This allows for custom loader plugins that inherit from `BaseLoader`.