### PR TITLE
Custom Tasks in Parsers

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -287,7 +287,7 @@ def parse(
             show_default=False,
         ),
     ] = None,
-    task: Annotated[
+    task_name: Annotated[
         Optional[List[str]],
         typer.Option(
             ...,
@@ -299,14 +299,14 @@ def parse(
     ] = None,
 ):
     """Parses a directory with data and creates Luxonis dataset."""
-    task = task or []
+    task_name = task_name or []
     parser = LuxonisParser(
         dataset_dir,
         dataset_name=name,
         dataset_type=dataset_type,
         delete_existing=delete_existing,
         save_dir=save_dir,
-        task_mapping=dict(task),  # type: ignore
+        task_mapping=dict(task_name),  # type: ignore
     )
     dataset = parser.parse()
 

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -291,6 +291,8 @@ def parse(
         Optional[List[str]],
         typer.Option(
             ...,
+            "--task-name",
+            "-tn",
             show_default=False,
             callback=_parse_tasks,
             help="Custom task names to override the default ones. "

--- a/luxonis_ml/data/datasets/__init__.py
+++ b/luxonis_ml/data/datasets/__init__.py
@@ -3,6 +3,7 @@ from .annotation import (
     ArrayAnnotation,
     BBoxAnnotation,
     ClassificationAnnotation,
+    DatasetRecord,
     KeypointAnnotation,
     LabelAnnotation,
     PolylineSegmentationAnnotation,
@@ -20,6 +21,7 @@ from .source import LuxonisComponent, LuxonisSource
 __all__ = [
     "BaseDataset",
     "DatasetIterator",
+    "DatasetRecord",
     "LuxonisDataset",
     "LuxonisComponent",
     "LuxonisSource",

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -4,11 +4,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Literal, Optional, Tuple, Type, Union
 
-from luxonis_ml.data import (
-    DATASETS_REGISTRY,
-    BaseDataset,
-    LuxonisDataset,
-)
+from luxonis_ml.data import DATASETS_REGISTRY, BaseDataset, LuxonisDataset
+from luxonis_ml.data.utils.enums import LabelType
 from luxonis_ml.enums import DatasetType
 from luxonis_ml.utils import LuxonisFileSystem
 
@@ -54,6 +51,7 @@ class LuxonisParser:
         save_dir: Optional[Union[Path, str]] = None,
         dataset_plugin: Optional[str] = None,
         dataset_type: Optional[DatasetType] = None,
+        task_mapping: Optional[Dict[LabelType, str]] = None,
         **kwargs,
     ):
         """High-level abstraction over various parsers.
@@ -79,6 +77,8 @@ class LuxonisParser:
         @type kwargs: Dict[str, Any]
         @param kwargs: Additional C{kwargs} to be passed to the constructor of specific
             L{BaseDataset} implementation.
+        @type task_mapping: Optional[Dict[LabelType, str]]
+        @param task_mapping: Dictionary mapping label types to task names.
         """
         save_dir = Path(save_dir) if save_dir else None
         name = Path(dataset_dir).name
@@ -111,7 +111,7 @@ class LuxonisParser:
         dataset_name = dataset_name or name.replace(" ", "_").split(".")[0]
 
         self.dataset = self.dataset_constructor(dataset_name=dataset_name, **kwargs)
-        self.parser = self.parsers[self.dataset_type](self.dataset)
+        self.parser = self.parsers[self.dataset_type](self.dataset, task_mapping or {})
 
     def parse(self, **kwargs) -> BaseDataset:
         """Parses the dataset and returns it in LuxonisDataset format.

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -100,3 +100,17 @@ def test_dir_parser(
     label_types = {label_type for _, label_type in ann.values()}
     assert label_types == set(expected_label_types)
     dataset.delete_dataset()
+
+
+def test_custom_tasks():
+    parser = LuxonisParser(
+        f"{URL_PREFIX}/Thermal_Dogs_and_People.v1-resize-416x416.coco.zip",
+        dataset_name="test-custom-tasks",
+        delete_existing=True,
+        save_dir=WORK_DIR,
+        task_mapping={LabelType.BOUNDINGBOX: "object_detection"},
+    )
+    dataset = cast(LuxonisDataset, parser.parse())
+    assert len(dataset) > 0
+    tasks = dataset.get_tasks()
+    assert set(tasks) == {"object_detection", "classification"}


### PR DESCRIPTION
Added an option to add `task_mapping` attribute to the `LuxonisParser` for specifying custom task names.

**Example**:

```python
parser = LuxonisParser(..., task_mapping={LabelType.BOUNDINGBOX: "object_detection"})
dataset = parser.parse()
tasks = dataset.get_tasks()
print(dataset.get_tasks())
# >> ["object_detection", "classification"]
```

**CLI**:
```bash
luxonis_ml data parse path/to/data --task-name boundingbox=detection -tn segmentation=seg
```