### PR TITLE
Pixel Masks Annotations

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -51,19 +51,9 @@ def check_exists(name: str):
 
 def get_dataset_info(name: str) -> Tuple[int, List[str], List[str]]:
     dataset = LuxonisDataset(name)
-    try:
-        size = len(dataset)
-    except KeyError:
-        size = -1
-
-    try:
-        loader = LuxonisLoader(dataset, view=SplitType.TRAIN.value)
-        _, ann = next(iter(loader))
-    except Exception:
-        ann = {}
+    size = len(dataset)
     classes, _ = dataset.get_classes()
-    tasks = list(ann.keys())
-    return size, classes, tasks
+    return size, classes, dataset.get_tasks()
 
 
 def print_info(name: str) -> None:

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -317,8 +317,8 @@ class MaskSegmentationAnnotation(SegmentationAnnotation):
         rle = mask_util.encode(mask)
 
         return {
-            "width": rle["size"][0],
-            "height": rle["size"][1],
+            "height": rle["size"][0],
+            "width": rle["size"][1],
             "counts": rle["counts"].decode("utf-8"),  # type: ignore
         }
 

--- a/luxonis_ml/data/parsers/segmentation_mask_directory_parser.py
+++ b/luxonis_ml/data/parsers/segmentation_mask_directory_parser.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import cv2
 import numpy as np
 import polars as pl
-import pycocotools.mask as mask_util
 
 from luxonis_ml.data import DatasetIterator
 
@@ -116,18 +115,12 @@ class SegmentationMaskDirectoryParser(BaseParser):
 
                     curr_seg_mask = np.zeros_like(mask)
                     curr_seg_mask[mask == id] = 1
-                    curr_seg_mask = np.asfortranarray(
-                        curr_seg_mask
-                    )  # pycocotools requirement
-                    curr_rle = mask_util.encode(curr_seg_mask)
                     yield {
                         "file": file,
                         "annotation": {
-                            "type": "rle",
+                            "type": "mask",
                             "class": class_name,
-                            "width": curr_rle["size"][0],
-                            "height": curr_rle["size"][1],
-                            "counts": curr_rle["counts"],
+                            "mask": curr_seg_mask,
                         },
                     }
 

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import cv2
 import numpy as np
-import pycocotools.mask as mask_util
 
 from luxonis_ml.data import DatasetIterator
 
@@ -215,17 +214,13 @@ class SOLOParser(BaseParser):
                                     curr_mask = np.zeros_like(mask)
                                     curr_mask[np.all(mask == [b, g, r], axis=2)] = 1
                                     curr_mask = np.max(curr_mask, axis=2)  # 3D->2D
-                                    curr_mask = np.asfortranarray(curr_mask)
-                                    curr_rle = mask_util.encode(curr_mask)
 
                                     yield {
                                         "file": img_path,
                                         "annotation": {
-                                            "type": "rle",
+                                            "type": "mask",
                                             "class": class_name,
-                                            "width": curr_rle["size"][0],
-                                            "height": curr_rle["size"][1],
-                                            "counts": curr_rle["counts"],
+                                            "mask": curr_mask,
                                         },
                                     }
 

--- a/luxonis_ml/embeddings/requirements.txt
+++ b/luxonis_ml/embeddings/requirements.txt
@@ -3,7 +3,8 @@ KDEpy>=1.1.5
 kmedoids>=0.4.3
 matplotlib>=3.7.2
 numpy>=1.22
-onnx>=1.14.0
+onnx>=1.14.0,<1.16.2; sys_platform == "win32"
+onnx>=1.14.0; sys_platform != "win32"
 onnxruntime-gpu>=1.15.1; sys_platform == 'linux'
 onnxruntime>=1.15.1; sys_platform != 'linux'
 opencv-python>=4.7.0.68


### PR DESCRIPTION
- Added support for using pixel mask annotations for segmentations
  - Masks are internally transformed to RLE format

**Example:**
```python
def generator():
    mask = np.zeros((256, 256))
    yield {
        "file": file,
        "annotation": {
            "type": "mask",
            "class": "person",
            "mask": mask,
        }
    }    

```