### PR TITLE
Custom Splits

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -23,7 +23,7 @@ from luxonis_ml.data import (
     LuxonisParser,
 )
 from luxonis_ml.data.utils.visualizations import visualize
-from luxonis_ml.enums import DatasetType, SplitType
+from luxonis_ml.enums import DatasetType
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ def print_info(name: str) -> None:
     def get_sizes_panel():
         if splits is not None:
             for split, files in splits.items():
-                yield f"[magenta b]{split.capitalize()}: [not b cyan]{len(files)}"
+                yield f"[magenta b]{split}: [not b cyan]{len(files)}"
         else:
             yield "[red]No splits found"
         yield Rule()
@@ -154,15 +154,15 @@ def ls(
 def inspect(
     name: DatasetNameArgument,
     view: Annotated[
-        SplitType,
+        Optional[List[str]],
         typer.Option(
             ...,
             "--view",
             "-v",
-            help="Which split of the dataset to inspect.",
+            help="Which splits of the dataset to inspect.",
             case_sensitive=False,
         ),
-    ] = "train",  # type: ignore
+    ] = None,
     aug_config: Annotated[
         Optional[str],
         typer.Option(
@@ -190,8 +190,9 @@ def inspect(
 ):
     """Inspects images and annotations in a dataset."""
 
+    view = view or ["train"]
     dataset = LuxonisDataset(name)
-    h, w, _ = LuxonisLoader(dataset, view=view.value)[0][0].shape
+    h, w, _ = LuxonisLoader(dataset, view=view)[0][0].shape
     augmentations = None
 
     if aug_config is not None:
@@ -206,7 +207,7 @@ def inspect(
     if len(dataset) == 0:
         raise ValueError(f"Dataset '{name}' is empty.")
 
-    loader = LuxonisLoader(dataset, view=view.value, augmentations=augmentations)
+    loader = LuxonisLoader(dataset, view=view, augmentations=augmentations)
     class_names = dataset.get_classes()[1]
     for image, labels in loader:
         image = image.astype(np.uint8)

--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, Union
 
 from typing_extensions import TypeAlias
 
@@ -122,21 +122,22 @@ class BaseDataset(
         """
         pass
 
-    # TODO: Support arbitrary named splits
     @abstractmethod
     def make_splits(
         self,
-        ratios: Tuple[float, float, float] = (0.8, 0.1, 0.1),
-        definitions: Optional[Dict[str, Sequence[PathType]]] = None,
+        ratios: Optional[Union[Dict[str, float], Tuple[float, float, float]]] = None,
+        definitions: Optional[Mapping[str, Sequence[PathType]]] = None,
     ) -> None:
-        """Saves a splits json file that specified the train/val/test split. For use in
-        I{OFFLINE} mode only.
+        """Saves a splits json file that specified the train/val/test splis.
 
-        @type ratios: Tuple[float, float, float]
-            Defaults to (0.8, 0.1, 0.1).
+        @type ratios: Optional[Union[Dict[str, float], Tuple[float, float, float]]]
+        @param ratios: Dictionary specifying the ratios of the splits. Can be a tuple
+            of floats for "train", "val", and "test" respectively, or a dictionary
+            specifying the ratios for each split.
+            Defaults to C{{"train": 0.8, "val": 0.1, "test": 0.1}}.
 
-        @type definitions: Optional[Dict]
-        @param definitions [Optional[Dict]]: Dictionary specifying split keys to lists
+        @type definitions: Optional[Mapping[str, Sequence[PathType]]
+        @param definitions: Dictionary specifying split keys to lists
             of filepath values. Note that this assumes unique filenames.
             Example::
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -624,12 +624,13 @@ class LuxonisDataset(BaseDataset):
                     )
                 else:
                     ids = df.select("uuid").unique().get_column("uuid").to_list()
+                    old_splits = defaultdict(list)
 
             np.random.shuffle(ids)
             N = len(ids)
             lower_bound = 0
             for split, ratio in ratios.items():
-                upper_bound = lower_bound + round(N * ratio)
+                upper_bound = lower_bound + math.ceil(N * ratio)
                 new_splits[split] = ids[lower_bound:upper_bound]
                 splits_to_update.append(split)
                 lower_bound = upper_bound

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1,18 +1,30 @@
 import json
 import logging
+import math
 import shutil
 import tempfile
 from collections import defaultdict
 from contextlib import suppress
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 import polars as pl
 import pyarrow.parquet as pq
 from ordered_set import OrderedSet
 from pycocotools import mask as mask_utils
-from typing_extensions import Self
+from typing_extensions import Self, overload
 
 import luxonis_ml.data.utils.data_utils as data_utils
 from luxonis_ml.utils import LuxonisFileSystem, environ, make_progress_bar
@@ -156,6 +168,26 @@ class LuxonisDataset(BaseDataset):
         dfs = [pl.read_parquet(file) for file in path.glob("*.parquet")]
 
         return pl.concat(dfs) if dfs else None
+
+    @overload
+    def _find_filepath_uuid(
+        self,
+        filepath: Path,
+        index: Optional[pl.DataFrame],
+        *,
+        raise_on_missing: Literal[False] = False,
+    ) -> Optional[str]:
+        pass
+
+    @overload
+    def _find_filepath_uuid(
+        self,
+        filepath: Path,
+        index: Optional[pl.DataFrame],
+        *,
+        raise_on_missing: Literal[True] = True,
+    ) -> str:
+        pass
 
     def _find_filepath_uuid(
         self,
@@ -433,7 +465,7 @@ class LuxonisDataset(BaseDataset):
                 filepath = ann.file
                 file = filepath.name
                 uuid = uuid_dict[str(filepath)]
-                matched_id = self._find_filepath_uuid(filepath, index)
+                matched_id = self._find_filepath_uuid(Path(filepath), index)
                 if matched_id is not None:
                     if matched_id != uuid:
                         # TODO: not sure if this should be an exception or how we should really handle it
@@ -531,36 +563,85 @@ class LuxonisDataset(BaseDataset):
 
     def make_splits(
         self,
-        ratios: Tuple[float, float, float] = (0.8, 0.1, 0.1),
-        definitions: Optional[Dict[str, List[PathType]]] = None,
+        ratios: Optional[Union[Dict[str, float], Tuple[float, float, float]]] = None,
+        definitions: Optional[Mapping[str, Sequence[PathType]]] = None,
+        replace_old_splits: bool = False,
     ) -> None:
-        new_splits = {"train": [], "val": [], "test": []}
-        splits_to_update = []
+        if ratios is not None and definitions is not None:
+            raise ValueError("Cannot provide both ratios and definitions")
+
+        if ratios is not None:
+            if isinstance(ratios, tuple):
+                if not len(ratios) == 3:
+                    raise ValueError(
+                        "Ratios must be a tuple of 3 floats for train, val, and test splits"
+                    )
+                ratios = {"train": ratios[0], "val": ratios[1], "test": ratios[2]}
+            sum_ = sum(ratios.values())
+            if not math.isclose(sum_, 1.0):
+                raise ValueError(f"Ratios must sum to 1.0, got {sum_:0.4f}")
+
+        if definitions is not None:
+            n_files = sum(map(len, definitions.values()))
+            if n_files > len(self):
+                raise ValueError(
+                    "Dataset size is smaller than the total number of files in the definitions. "
+                    f"Dataset size: {len(self)}, Definitions: {n_files}."
+                )
+
+        splits_to_update: List[str] = []
+        new_splits: Dict[str, List[str]] = {}
+        old_splits: Dict[str, List[str]] = defaultdict(list)
+
+        splits_path = self._get_file(
+            "metadata/splits.json",
+            self.local_path,
+            default=self.metadata_path / "splits.json",
+        )
+        assert splits_path is not None
+        if splits_path.exists():
+            with open(splits_path, "r") as file:
+                old_splits = defaultdict(list, json.load(file))
+
+        defined_uuids = set(uuid for uuids in old_splits.values() for uuid in uuids)
 
         if definitions is None:
+            ratios = ratios or {"train": 0.8, "val": 0.1, "test": 0.1}
             df = self._load_df_offline()
             assert df is not None
-            ids = df.select("uuid").unique().get_column("uuid").to_list()
+            ids = (
+                df.filter(~pl.col("uuid").is_in(defined_uuids))
+                .select("uuid")
+                .unique()
+                .get_column("uuid")
+                .to_list()
+            )
+            if not ids:
+                if not replace_old_splits:
+                    raise ValueError(
+                        "No new files to add to splits. "
+                        "If you want to generate new splits, set `replace_old_splits=True`"
+                    )
+                else:
+                    ids = df.select("uuid").unique().get_column("uuid").to_list()
+
             np.random.shuffle(ids)
             N = len(ids)
-            b1 = round(N * ratios[0])
-            b2 = round(N * ratios[0]) + round(N * ratios[1])
-            new_splits["train"] = ids[:b1]
-            new_splits["val"] = ids[b1:b2]
-            new_splits["test"] = ids[b2:]
-            splits_to_update = ["train", "val", "test"]
+            lower_bound = 0
+            for split, ratio in ratios.items():
+                upper_bound = lower_bound + round(N * ratio)
+                new_splits[split] = ids[lower_bound:upper_bound]
+                splits_to_update.append(split)
+                lower_bound = upper_bound
 
         else:
             index = self._get_file_index()
             if index is None:
                 raise FileNotFoundError("File index not found")
-            for split in ["train", "val", "test"]:
-                if split not in definitions:
-                    continue
+            for split, filepaths in definitions.items():
                 splits_to_update.append(split)
-                filepaths = definitions[split]
                 if not isinstance(filepaths, list):
-                    raise ValueError("Must provide splits as a list of str")
+                    raise ValueError("Must provide splits as a list of filepaths")
                 ids = [
                     self._find_filepath_uuid(
                         Path(filepath), index, raise_on_missing=True
@@ -569,22 +650,10 @@ class LuxonisDataset(BaseDataset):
                 ]
                 new_splits[split] = ids
 
-        splits_path = self._get_file(
-            "metadata/splits.json",
-            self.local_path,
-            default=self.metadata_path / "splits.json",
-        )
-        assert splits_path is not None
+        for split, uuids in new_splits.items():
+            old_splits[split].extend(uuids)
 
-        if splits_path.exists():
-            with open(splits_path, "r") as file:
-                splits = json.load(file)
-            for split in splits_to_update:
-                splits[split] = new_splits[split]
-        else:
-            splits = new_splits
-
-        splits_path.write_text(json.dumps(splits, indent=4))
+        splits_path.write_text(json.dumps(old_splits, indent=4))
 
         with suppress(shutil.SameFileError):
             self.fs.put_file(splits_path, "metadata/splits.json")

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from luxonis_ml.data import BaseDataset, DatasetIterator
 from luxonis_ml.data.datasets import DatasetRecord
@@ -98,14 +98,14 @@ class BaseParser(ABC):
 
     def parse_split(
         self,
-        split: Optional[Literal["train", "val", "test"]] = None,
+        split: Optional[str] = None,
         random_split: bool = False,
-        split_ratios: Tuple[float, float, float] = (0.8, 0.1, 0.1),
+        split_ratios: Optional[Dict[str, float]] = None,
         **kwargs,
     ) -> BaseDataset:
         """Parses data in a split subdirectory to L{LuxonisDataset} format.
 
-        @type split: Optional[Literal["train", "val", "test"]]
+        @type split: Optional[str]
         @param split: As what split the data will be added to LDF. If set,
             C{split_ratios} and C{random_split} are ignored.
         @type random_split: bool
@@ -123,7 +123,7 @@ class BaseParser(ABC):
         if split is not None:
             self.dataset.make_splits(definitions={split: added_images})
         elif random_split:
-            self.dataset.make_splits(split_ratios)
+            self.dataset.make_splits(ratios=split_ratios)
         return self.dataset
 
     def parse_dir(self, dataset_dir: Path, **kwargs) -> BaseDataset:

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -2,7 +2,7 @@ import logging
 import zipfile
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Literal, Optional, Tuple, Type, Union
+from typing import Dict, Optional, Tuple, Type, Union
 
 from luxonis_ml.data import DATASETS_REGISTRY, BaseDataset, LuxonisDataset
 from luxonis_ml.data.utils.enums import LabelType
@@ -173,9 +173,9 @@ class LuxonisParser:
 
     def _parse_split(
         self,
-        split: Optional[Literal["train", "val", "test"]] = None,
+        split: Optional[str] = None,
         random_split: bool = True,
-        split_ratios: Tuple[float, float, float] = (0.8, 0.1, 0.1),
+        split_ratios: Optional[Dict[str, float]] = None,
         **kwargs,
     ) -> BaseDataset:
         """Parses data from a subdirectory representing a single split.
@@ -189,9 +189,9 @@ class LuxonisParser:
         @type random_split: bool
         @param random_split: If random splits should be made. If C{True},
             C{split_ratios} are used.
-        @type split_ratios: Optional[Tuple[float, float, float]]
+        @type split_ratios: Optional[Dict[str, float]]
         @param split_ratios: Ratios for random splits. Only used if C{random_split} is
-            C{True}. Defaults to C{(0.8, 0.1, 0.1)}.
+            C{True}. Defaults to C{{"train": 0.8, "val": 0.1, "test": 0.1}}.
         @type kwargs: Dict[str, Any]
         @param kwargs: Additional kwargs for specific parser implementation.
         @rtype: LuxonisDataset

--- a/luxonis_ml/enums/__init__.py
+++ b/luxonis_ml/enums/__init__.py
@@ -1,3 +1,3 @@
-from .enums import DatasetType, SplitType
+from .enums import DatasetType
 
-__all__ = ["DatasetType", "SplitType"]
+__all__ = ["DatasetType"]

--- a/luxonis_ml/enums/enums.py
+++ b/luxonis_ml/enums/enums.py
@@ -13,9 +13,3 @@ class DatasetType(str, Enum):
     CLSDIR = "clsdir"
     SEGMASK = "segmask"
     SOLO = "solo"
-
-
-class SplitType(str, Enum):
-    TRAIN = "train"
-    VAL = "val"
-    TEST = "test"

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -224,9 +224,9 @@ def test_make_splits(
     splits = dataset.get_splits()
     assert splits is not None
     for split, split_data in splits.items():
-        expected_length = 61 if split == "train" else 14
+        expected_length = {"train": 36, "val": 5, "test": 4}
         assert (
-            len(split_data) == expected_length
+            len(split_data) == expected_length[split]
         ), f"Split {split} has {len(split_data)} samples"
 
 

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -93,7 +93,7 @@ def make_image(i) -> Path:
     [
         (BucketStorage.LOCAL,),
         (BucketStorage.S3,),
-        # (BucketStorage.GCS,),
+        (BucketStorage.GCS,),
     ],
 )
 def test_dataset(

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -1,9 +1,11 @@
 import json
+import shutil
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Final, Set
+from typing import Dict, Final, List, Set
 
 import cv2
+import numpy as np
 import pytest
 
 from luxonis_ml.data import (
@@ -65,6 +67,25 @@ URL_PREFIX: Final[str] = "gs://luxonis-test-bucket/luxonis-ml-test-data"
 WORK_DIR: Final[str] = "tests/data/parser_datasets"
 DATASET_NAME: Final[str] = "test-dataset"
 TASKS: Final[Set[str]] = {"segmentation", "classification", "keypoints", "boundingbox"}
+DATA_DIR = Path("tests/data/test_dataset")
+
+
+@pytest.fixture(autouse=True, scope="module")
+def prepare_dir():
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+    yield
+
+    shutil.rmtree(DATA_DIR)
+
+
+def make_image(i) -> Path:
+    path = DATA_DIR / f"img_{i}.jpg"
+    if not path.exists():
+        img = np.zeros((512, 512, 3), dtype=np.uint8)
+        img[0:10, 0:10] = np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)
+        cv2.imwrite(str(path), img)
+    return path
 
 
 @pytest.mark.parametrize(
@@ -72,7 +93,7 @@ TASKS: Final[Set[str]] = {"segmentation", "classification", "keypoints", "boundi
     [
         (BucketStorage.LOCAL,),
         (BucketStorage.S3,),
-        (BucketStorage.GCS,),
+        # (BucketStorage.GCS,),
     ],
 )
 def test_dataset(
@@ -129,6 +150,84 @@ def test_dataset(
     with subtests.test("test_delete", bucket_storage=bucket_storage):
         dataset.delete_dataset(delete_remote=True)
         assert not LuxonisDataset.exists(dataset_name, bucket_storage=bucket_storage)
+
+
+@pytest.mark.parametrize(
+    ("bucket_storage",),
+    [
+        (BucketStorage.LOCAL,),
+        (BucketStorage.GCS,),
+    ],
+)
+def test_make_splits(
+    bucket_storage: BucketStorage, platform_name: str, python_version: str
+):
+    definitions: Dict[str, List[str]] = defaultdict(list)
+
+    def generator(start_index: int = 0):
+        definitions.clear()
+        for i in range(start_index, start_index + 15):
+            path = make_image(i)
+            yield {
+                "file": str(path),
+                "annotation": {
+                    "type": "classification",
+                    "class": ["dog", "cat"][i % 2],
+                },
+            }
+            definitions[["train", "val", "test"][i % 3]].append(str(path))
+
+    dataset = LuxonisDataset(
+        f"_test_split-{bucket_storage.value}-{platform_name}-{python_version}",
+        delete_existing=True,
+        delete_remote=True,
+        bucket_storage=bucket_storage,
+    )
+    dataset.add(generator())
+    assert dataset.get_splits() is None
+    dataset.make_splits(definitions=definitions)
+    splits = dataset.get_splits()
+    assert splits is not None
+    for split, split_data in splits.items():
+        assert len(split_data) == 5, f"Split {split} has {len(split_data)} samples"
+
+    dataset.add(generator(15))
+    splits = dataset.get_splits()
+    assert splits is not None
+    for split, split_data in splits.items():
+        assert len(split_data) == 5, f"Split {split} has {len(split_data)} samples"
+    dataset.make_splits(definitions=definitions)
+    splits = dataset.get_splits()
+    assert splits is not None
+    for split, split_data in splits.items():
+        assert len(split_data) == 10, f"Split {split} has {len(split_data)} samples"
+
+    dataset.add(generator(30))
+    dataset.make_splits((1, 0, 0))
+    splits = dataset.get_splits()
+    assert splits is not None
+    for split, split_data in splits.items():
+        expected_length = 25 if split == "train" else 10
+        assert (
+            len(split_data) == expected_length
+        ), f"Split {split} has {len(split_data)} samples"
+
+    with pytest.raises(ValueError):
+        dataset.make_splits()
+        dataset.make_splits((0.7, 0.1, 1))
+        dataset.make_splits({"train": 1.5})
+        dataset.make_splits(
+            definitions={split: defs * 2 for split, defs in definitions.items()}
+        )
+
+    dataset.make_splits(replace_old_splits=True)
+    splits = dataset.get_splits()
+    assert splits is not None
+    for split, split_data in splits.items():
+        expected_length = 61 if split == "train" else 14
+        assert (
+            len(split_data) == expected_length
+        ), f"Split {split} has {len(split_data)} samples"
 
 
 def test_complex_dataset():


### PR DESCRIPTION
- Updated `make_splits` to support custom split names instead of only `"train"`, `"val"`, and `"test"`.
  - Kept backwards compatibility with passing `ratios` as a 3-tuple for  `"train"`, `"val"`, and `"test"`
- Added tests for `make_splits`
- Fixed making new splits for a dataset that already has splits 
  - When `make_splits` is called on a dataset that already have split definitions, the old definitions stay the same and only newly added data are processed
  - Before; all the splits were generated again when `make_splits` was called