### PR TITLE
Fix Freezing `LuxonisFileSystem.walk_dir` for GCS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
       - 'luxonis_ml/**'
       - 'tests/**'
       - .github/workflows/ci.yaml
+  workflow_dispatch:
 
 jobs:
   pre-commit:
@@ -82,7 +83,7 @@ jobs:
         LUXONISML_BUCKET: luxonis-test-bucket
       with:
         emoji: false
-        custom-arguments: --cov luxonis_ml --cov-report xml --junit-xml pytest.xml
+        custom-arguments: --cov luxonis_ml --cov-report xml --junit-xml pytest.xml -s
 
     - name: Create Test Report
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
       - 'luxonis_ml/**'
       - 'tests/**'
       - .github/workflows/ci.yaml
-  workflow_dispatch:
 
 jobs:
   pre-commit:
@@ -83,7 +82,7 @@ jobs:
         LUXONISML_BUCKET: luxonis-test-bucket
       with:
         emoji: false
-        custom-arguments: --cov luxonis_ml --cov-report xml --junit-xml pytest.xml -s
+        custom-arguments: --cov luxonis_ml --cov-report xml --junit-xml pytest.xml
 
     - name: Create Test Report
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/luxonis_ml/utils/__main__.py
+++ b/luxonis_ml/utils/__main__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -10,6 +11,12 @@ from luxonis_ml.utils import LuxonisFileSystem
 app = typer.Typer()
 
 UrlArgument = Annotated[str, typer.Argument(..., help="URL of the file.")]
+
+
+class TypeEnum(str, Enum):
+    FILE = "file"
+    DIR = "directory"
+    ALL = "all"
 
 
 @app.command()
@@ -45,8 +52,17 @@ def ls(
     recursive: Annotated[
         bool, typer.Option(..., "--recursive", "-r", help="List files recursively.")
     ] = False,
+    typ: Annotated[
+        TypeEnum,
+        typer.Option(
+            ...,
+            "--type",
+            "-t",
+            help="Type of the files to list. If not provided, all files will be listed.",
+        ),
+    ] = TypeEnum.ALL,
 ):
     """Lists files in the remote directory."""
     fs = LuxonisFileSystem(url.rstrip("/"))
-    for file in fs.walk_dir("", recursive=recursive):
+    for file in fs.walk_dir("", recursive=recursive, typ=typ.value):
         print(file)

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -425,11 +425,12 @@ class LuxonisFileSystem:
             raise NotImplementedError
         elif self.is_fsspec:
             full_path = str(self.path / remote_dir)
-            for file in self.fs.glob(
-                full_path + f"/{'**' if recursive else '*'}", detail=True
-            ):
-                if typ == "all" or self.fs.info(file)["type"] == typ:
-                    yield str(PurePosixPath(str(file)).relative_to(self.path))
+            for file in self.fs.ls(full_path, detail=True):
+                name = str(PurePosixPath(str(file["name"])).relative_to(self.path))
+                if typ == "all" or file["type"] == typ:
+                    yield name
+                if recursive and file["type"] == "directory":
+                    yield from self.walk_dir(name, recursive, typ)
 
     def read_to_byte_buffer(self, remote_path: Optional[PathType] = None) -> BytesIO:
         """Reads a file into a byte buffer.


### PR DESCRIPTION
- Fixed `walk_dir` method that was freezing when used with GCS protocol
- Added option to list only certain file types to `luxonis_ml fs ls` command