### PR TITLE
Updated `fsspec` Version

### DIFF
--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -647,9 +647,9 @@ def _check_package_installed(protocol: str) -> None:
         )
 
     if protocol in ["gs", "gcs"] and find_spec("gcsfs") is None:
-        _pip_install("gcsfs", "2023.1.0")
+        _pip_install("gcsfs", "2023.3.0")
     elif protocol == "s3" and find_spec("s3fs") is None:
-        _pip_install("s3fs", "2023.1.0")
+        _pip_install("s3fs", "2023.3.0")
     elif protocol == "mlflow" and find_spec("mlflow") is None:
         _pip_install("mlflow", "2.10.0")
 

--- a/luxonis_ml/utils/requirements.txt
+++ b/luxonis_ml/utils/requirements.txt
@@ -1,10 +1,10 @@
 pydantic>=2.4.0
 pydantic-settings>=2.1.0
 PyYAML>=6.0
-fsspec>=2023.1.0
+fsspec>=2023.3.0
 rich>=13.6.0
 typer>=0.12.0
 # The following packages are installed dynamically when required
-# s3fs>=2023.1.0
-# gcsfs>=2023.1.0
+# s3fs>=2023.3.0
+# gcsfs>=2023.3.0
 # mlflow>=2.10.0


### PR DESCRIPTION
Increased the minimum required versions of `fsspec` libraries to avoid bugs with downloading files.

The `fsspec.get` method in version `2023.1.0` doesn't work correctly when a directory is passed as a destination. Instead of the file getting downloaded to the provided directory, it silently fails instead. Version `2023.3.0` fixes this. 