### PR TITLE
Added `__iter__` to BaseLoader

### DIFF
--- a/luxonis_ml/data/loaders/base_loader.py
+++ b/luxonis_ml/data/loaders/base_loader.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Tuple
+from typing import Dict, Iterator, Tuple
 
 import numpy as np
 from typing_extensions import TypeAlias
@@ -47,3 +47,12 @@ class BaseLoader(
         @return: Sample's data in L{LuxonisLoaderOutput} format.
         """
         pass
+
+    def __iter__(self) -> Iterator[LuxonisLoaderOutput]:
+        """Iterates over the dataset.
+
+        @rtype: Iterator
+        @return: Iterator over the dataset.
+        """
+        for i in range(len(self)):
+            yield self[i]

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -152,6 +152,26 @@ def test_dataset(
         assert not LuxonisDataset.exists(dataset_name, bucket_storage=bucket_storage)
 
 
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
+def test_loader_iterator():
+    dataset = LuxonisParser(
+        f"{URL_PREFIX}/COCO_people_subset.zip",
+        dataset_name="_iterator_test",
+        save_dir=WORK_DIR,
+        dataset_type=DatasetType.COCO,
+        delete_existing=True,
+    ).parse()
+    loader = LuxonisLoader(dataset)
+
+    def _raise(*_):
+        raise IndexError
+
+    loader._load_image_with_annotations = _raise
+    with pytest.raises(IndexError):
+        for _ in loader:
+            pass
+
+
 @pytest.mark.parametrize(
     ("bucket_storage",),
     [


### PR DESCRIPTION
Added the `__iter__` method to `BaseLoader` so it doesn't stop on `IndexError` when iterated over.