### PR TITLE
Simplified `make_splits` Parameters

### DIFF
--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union
 
 from typing_extensions import TypeAlias
 
@@ -125,29 +125,31 @@ class BaseDataset(
     @abstractmethod
     def make_splits(
         self,
+        splits: Optional[
+            Union[
+                Dict[str, Sequence[PathType]],
+                Dict[str, float],
+                Tuple[float, float, float],
+            ]
+        ] = None,
+        *,
         ratios: Optional[Union[Dict[str, float], Tuple[float, float, float]]] = None,
-        definitions: Optional[Mapping[str, Sequence[PathType]]] = None,
+        definitions: Optional[Dict[str, List[PathType]]] = None,
+        replace_old_splits: bool = False,
     ) -> None:
-        """Saves a splits json file that specified the train/val/test splis.
+        """Generates splits for the dataset.
 
+        @type splits: Optional[Union[Dict[str, Sequence[PathType]], Dict[str, float], Tuple[float, float, float]]]
+        @param splits: A dictionary of splits or a tuple of ratios for train, val, and test splits. Can be one of:
+            - A dictionary of splits with keys as split names and values as lists of filepaths
+            - A dictionary of splits with keys as split names and values as ratios
+            - A 3-tuple of ratios for train, val, and test splits
         @type ratios: Optional[Union[Dict[str, float], Tuple[float, float, float]]]
-        @param ratios: Dictionary specifying the ratios of the splits. Can be a tuple
-            of floats for "train", "val", and "test" respectively, or a dictionary
-            specifying the ratios for each split.
-            Defaults to C{{"train": 0.8, "val": 0.1, "test": 0.1}}.
-
-        @type definitions: Optional[Mapping[str, Sequence[PathType]]
-        @param definitions: Dictionary specifying split keys to lists
-            of filepath values. Note that this assumes unique filenames.
-            Example::
-
-                {
-                    "train": ["/path/to/cat.jpg", "/path/to/dog.jpg"],
-                    "val": [...],
-                    "test": [...]
-                }
-
-            Only overrides splits that are present in the dictionary.
+        @param ratios: Deprecated! A dictionary of splits with keys as split names and values as ratios.
+        @type definitions: Optional[Dict[str, List[PathType]]]
+        @param definitions: Deprecated! A dictionary of splits with keys as split names and values as lists of filepaths.
+        @type replace_old_splits: bool
+        @param replace_old_splits: Whether to remove old splits and generate new ones. If set to False, only new files will be added to the splits. Default is False.
         """
         pass
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -520,7 +520,7 @@ class LuxonisDataset(BaseDataset):
     @deprecated(
         "ratios",
         "definitions",
-        suggested={"ratios": "splits", "definitions": "splits"},
+        suggest={"ratios": "splits", "definitions": "splits"},
     )
     def make_splits(
         self,

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Dict,
     List,
-    Mapping,
     Optional,
     Sequence,
     Set,
@@ -25,7 +24,7 @@ from ordered_set import OrderedSet
 from typing_extensions import Self
 
 import luxonis_ml.data.utils.data_utils as data_utils
-from luxonis_ml.utils import LuxonisFileSystem, environ, make_progress_bar
+from luxonis_ml.utils import LuxonisFileSystem, deprecated, environ, make_progress_bar
 from luxonis_ml.utils.filesystem import PathType
 
 from ..utils.constants import LDF_VERSION
@@ -518,14 +517,42 @@ class LuxonisDataset(BaseDataset):
         with open(splits_path, "r") as file:
             return json.load(file)
 
+    @deprecated(
+        "ratios",
+        "definitions",
+        suggested={"ratios": "splits", "definitions": "splits"},
+    )
     def make_splits(
         self,
+        splits: Optional[
+            Union[
+                Dict[str, Sequence[PathType]],
+                Dict[str, float],
+                Tuple[float, float, float],
+            ]
+        ] = None,
+        *,
         ratios: Optional[Union[Dict[str, float], Tuple[float, float, float]]] = None,
-        definitions: Optional[Mapping[str, Sequence[PathType]]] = None,
+        definitions: Optional[Dict[str, List[PathType]]] = None,
         replace_old_splits: bool = False,
     ) -> None:
         if ratios is not None and definitions is not None:
             raise ValueError("Cannot provide both ratios and definitions")
+
+        if splits is None and ratios is None and definitions is None:
+            splits = {"train": 0.8, "val": 0.1, "test": 0.1}
+
+        if splits is not None:
+            if ratios is not None or definitions is not None:
+                raise ValueError("Cannot provide both splits and ratios/definitions")
+            if isinstance(splits, tuple):
+                ratios = splits
+            elif isinstance(splits, dict):
+                value = next(iter(splits.values()))
+                if isinstance(value, float):
+                    ratios = splits  # type: ignore
+                elif isinstance(value, list):
+                    definitions = splits  # type: ignore
 
         if ratios is not None:
             if isinstance(ratios, tuple):

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -121,9 +121,9 @@ class BaseParser(ABC):
         """
         added_images = self._parse_split(**kwargs)
         if split is not None:
-            self.dataset.make_splits(definitions={split: added_images})
+            self.dataset.make_splits({split: added_images})
         elif random_split:
-            self.dataset.make_splits(ratios=split_ratios)
+            self.dataset.make_splits(split_ratios)
         return self.dataset
 
     def parse_dir(self, dataset_dir: Path, **kwargs) -> BaseDataset:

--- a/luxonis_ml/utils/__init__.py
+++ b/luxonis_ml/utils/__init__.py
@@ -4,7 +4,7 @@ with guard_missing_extra("utils"):
     from .config import LuxonisConfig
     from .environ import Environ, environ
     from .filesystem import PUT_FILE_REGISTRY, LuxonisFileSystem
-    from .logging import reset_logging, setup_logging
+    from .logging import deprecated, reset_logging, setup_logging
     from .pydantic_utils import BaseModelExtraForbid
     from .registry import AutoRegisterMeta, Registry
     from .rich_utils import make_progress_bar
@@ -18,6 +18,7 @@ __all__ = [
     "Registry",
     "setup_logging",
     "reset_logging",
+    "deprecated",
     "environ",
     "Environ",
     "BaseModelExtraForbid",

--- a/luxonis_ml/utils/logging.py
+++ b/luxonis_ml/utils/logging.py
@@ -124,7 +124,7 @@ def reset_logging() -> None:
 
 def deprecated(
     *args: str,
-    suggested: Optional[Dict[str, str]] = None,
+    suggest: Optional[Dict[str, str]] = None,
     additional_message: Optional[str] = None,
     altogether: bool = False,
 ):
@@ -134,7 +134,7 @@ def deprecated(
 
         >>> @deprecated("old_arg",
         ...             "another_old_arg",
-        ...             suggested={"old_arg": "new_arg"},
+        ...             suggest={"old_arg": "new_arg"},
         ...             additional_message="Usage of 'old_arg' is discouraged.")
         )
         ...def my_func(old_arg, another_old_arg, new_arg=None):
@@ -148,8 +148,8 @@ def deprecated(
 
     @type args: str
     @param args: The names of the deprecated parameters.
-    @type suggested: Dict[str, str]
-    @param suggested: Suggested replacement parameters.
+    @type suggest: Dict[str, str]
+    @param suggest: Suggested replacement parameters.
     @type additional_message: str
     @param additional_message: Additional message to display.
         If provided, it will be appended to the warning message.
@@ -171,7 +171,7 @@ def deprecated(
             if args:
                 for arg in args:
                     if arg in f_kwargs:
-                        replacement = suggested.get(arg) if suggested else None
+                        replacement = suggest.get(arg) if suggest else None
                         msg = (
                             f"Argument '{arg}' in function '{fname}' "
                             "is deprecated and will be removed in "

--- a/luxonis_ml/utils/logging.py
+++ b/luxonis_ml/utils/logging.py
@@ -1,7 +1,8 @@
 import builtins
 import logging
 import warnings
-from typing import Optional
+from functools import wraps
+from typing import Dict, Optional, Type
 
 from rich import print as rprint
 from rich.console import Console
@@ -93,16 +94,97 @@ def setup_logging(
 
     logging.basicConfig(level=level, format=format, datefmt=datefmt, handlers=handlers)
 
+    def _custom_warning_handler(
+        message: str,
+        category: Type[Warning],
+        filename: str,
+        lineno: int,
+        _=None,
+        line: Optional[str] = None,
+    ):
+        logger = logging.getLogger(filename)
+        message = warnings.formatwarning(
+            message,
+            category,
+            filename,
+            lineno,
+            line,
+        )
+        logger.warning(message)
+
     if configure_warnings:
-        logger = logging.getLogger("warnings.warn")
-
-        def custom_warning_handler(message, *_):
-            logger.warning(message)
-
-        warnings.showwarning = custom_warning_handler
+        warnings.showwarning = _custom_warning_handler
 
 
 def reset_logging() -> None:
     """Resets the logging module back to its default state."""
     for handler in logging.root.handlers[:]:
         logging.root.removeHandler(handler)
+
+
+def deprecated(
+    *args: str,
+    suggested: Optional[Dict[str, str]] = None,
+    additional_message: Optional[str] = None,
+    altogether: bool = False,
+):
+    """Decorator to mark a function or its parameters as deprecated.
+
+    Example:
+
+        >>> @deprecated("old_arg",
+        ...             "another_old_arg",
+        ...             suggested={"old_arg": "new_arg"},
+        ...             additional_message="Usage of 'old_arg' is discouraged.")
+        )
+        ...def my_func(old_arg, another_old_arg, new_arg=None):
+        ...   pass
+        >>> my_func("foo")
+        >>> # DeprecationWarning: Argument 'old_arg'
+        ... # in function `my_func` is deprecated and
+        ... # will be removed in future versions.
+        ... # Use 'new_arg' instead.
+        ... # Usage of 'old_arg' is discouraged.
+
+    @type args: str
+    @param args: The names of the deprecated parameters.
+    @type suggested: Dict[str, str]
+    @param suggested: Suggested replacement parameters.
+    @type additional_message: str
+    @param additional_message: Additional message to display.
+        If provided, it will be appended to the warning message.
+    @type altogether: bool
+    @param altogether: If True, the whole function is
+        marked as deprecated. Defaults to False.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*f_args, **f_kwargs):
+            fname = func.__name__
+            if altogether:
+                msg = f"'{fname}' is deprecated and will be removed in future versions."
+                if additional_message:
+                    msg += f" {additional_message}"
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+            if args:
+                for arg in args:
+                    if arg in f_kwargs:
+                        replacement = suggested.get(arg) if suggested else None
+                        msg = (
+                            f"Argument '{arg}' in function '{fname}' "
+                            "is deprecated and will be removed in "
+                            "future versions."
+                        )
+                        if replacement:
+                            msg += f" Use '{replacement}' instead."
+                        if additional_message:
+                            msg += f" {additional_message}"
+                        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+            return func(*f_args, **f_kwargs)
+
+        return wrapper
+
+    return decorator

--- a/luxonis_ml/utils/logging.py
+++ b/luxonis_ml/utils/logging.py
@@ -136,7 +136,6 @@ def deprecated(
         ...             "another_old_arg",
         ...             suggest={"old_arg": "new_arg"},
         ...             additional_message="Usage of 'old_arg' is discouraged.")
-        )
         ...def my_func(old_arg, another_old_arg, new_arg=None):
         ...   pass
         >>> my_func("foo")

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">90%</text>
-        <text x="80" y="14">90%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
+        <text x="80" y="14">91%</text>
     </g>
 </svg>

--- a/media/coverage_badge.svg
+++ b/media/coverage_badge.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">91%</text>
-        <text x="80" y="14">91%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">90%</text>
+        <text x="80" y="14">90%</text>
     </g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ typeCheckingMode = "basic"
 [tool.coverage.run]
 omit = [
     "luxonis_ml/embeddings/*",
+    "luxonis_ml/utils/logging.py",
     "luxonis_ml/tracker/*",
     "**/__main__.py"
 ]

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -239,7 +239,7 @@ def test_make_splits(
     )
     dataset.add(generator())
     assert dataset.get_splits() is None
-    dataset.make_splits(definitions=definitions)
+    dataset.make_splits(definitions)
     splits = dataset.get_splits()
     assert splits is not None
     assert set(splits.keys()) == {"train", "val", "test"}
@@ -251,7 +251,7 @@ def test_make_splits(
     assert splits is not None
     for split, split_data in splits.items():
         assert len(split_data) == 5, f"Split {split} has {len(split_data)} samples"
-    dataset.make_splits(definitions=definitions)
+    dataset.make_splits(definitions)
     splits = dataset.get_splits()
     assert splits is not None
     for split, split_data in splits.items():
@@ -273,9 +273,7 @@ def test_make_splits(
         dataset.make_splits((0.7, 0.1, 0.1, 0.1))  # type: ignore
         dataset.make_splits((0.7, 0.1, 1), definitions=definitions)
         dataset.make_splits({"train": 1.5})
-        dataset.make_splits(
-            definitions={split: defs * 2 for split, defs in definitions.items()}
-        )
+        dataset.make_splits({split: defs * 2 for split, defs in definitions.items()})
 
     dataset.add(generator(10))
     dataset.make_splits({"custom_split": 1.0})

--- a/tests/test_data/test_task_ingestion.py
+++ b/tests/test_data/test_task_ingestion.py
@@ -112,7 +112,7 @@ def test_task_ingestion(
                 },
             }
 
-    dataset.add(generator1()).make_splits(ratios=(1, 0, 0))
+    dataset.add(generator1()).make_splits((1, 0, 0))
 
     classes_list, classes = dataset.get_classes()
 
@@ -151,7 +151,7 @@ def test_task_ingestion(
                 },
             }
 
-    dataset.add(generator2()).make_splits(ratios=(1, 0, 0))
+    dataset.add(generator2()).make_splits((1, 0, 0))
     classes_list, classes = dataset.get_classes()
 
     assert set(classes_list) == {"dog", "cat", "water", "grass"}
@@ -187,7 +187,7 @@ def test_task_ingestion(
                 },
             }
 
-    dataset.add(generator3()).make_splits(ratios=(1, 0, 0))
+    dataset.add(generator3()).make_splits((1, 0, 0))
     classes_list, classes = dataset.get_classes()
 
     assert set(classes_list) == {"dog", "cat", "water", "grass"}
@@ -231,7 +231,7 @@ def test_task_ingestion(
                 },
             }
 
-    dataset.add(generator4()).make_splits(ratios=(1, 0, 0))
+    dataset.add(generator4()).make_splits((1, 0, 0))
     classes_list, classes = dataset.get_classes()
 
     assert set(classes_list) == {"dog", "cat", "water", "grass", "bike", "body"}


### PR DESCRIPTION
- Added new parameter `splits` to the `make_splits` method that combines the `ratios` and `definitions`
  - `ratios` and `definitions` marked as deprecated
- Added `deprecated` decorater to `luxonis_ml.utils` to simplify marking deprecated functions and parameters
- Improved custom warning handler in `setup_logging` to show the line that triggered the warning.

**Example of using `@deprecated`**
```python
from luxonis_ml.utils import deprecated

@deprecated("a", suggest={"a": "b"})
def foo(a: Optional[str] = None, b: Optional[str] = None):
    ...

foo("foo")
DeprecationWarning: Argument 'a' in function 'foo' is deprecated and will be removed in future versions. Use 'b' instead.
```