### PR TITLE
Fixed `guard_extras` to raise `ImportError`

### DIFF
--- a/luxonis_ml/guard_extras.py
+++ b/luxonis_ml/guard_extras.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
@@ -9,13 +8,12 @@ logger = logging.getLogger(__name__)
 def guard_missing_extra(name: str):
     try:
         yield
-    except ImportError:
-        logger.exception(
+    except ImportError as e:
+        raise ImportError(
             f"Error importing `luxonis-ml.{name}`. This can mean that some of the dependencies of `luxonis-ml[{name}]` are not installed. "
             f"Ensure you installed the package with the `[{name}]` or `[all]` extra specified. "
             f"Use `pip install luxonis-ml[{name}]` to install dependencies for the `{name}` submodule."
-        )
-        sys.exit(1)
+        ) from e
 
 
 __all__ = ["guard_missing_extra"]


### PR DESCRIPTION
`guard_extras` now raises an `ImportError` instead of just exiting. This fixes an issue with failing CLI commands when not all submodules of `luxonis-ml` are installed.