### PR TITLE
Speedup in picking batched aug indices

### DIFF
--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -126,17 +126,23 @@ class LuxonisLoader(BaseLoader):
 
         indices = [idx]
         if self.augmentations.is_batched:
-            other_indices = [i for i in range(len(self)) if i != idx]
             if self.augmentations.aug_batch_size > len(self):
                 warnings.warn(
                     f"Augmentations batch_size ({self.augmentations.aug_batch_size}) is larger than dataset size ({len(self)}), samples will include repetitions."
                 )
-                random_fun = random.choices
+                other_indices = [i for i in range(len(self)) if i != idx]
+                picked_indices = random.choices(
+                    other_indices, k=self.augmentations.aug_batch_size - 1
+                )
             else:
-                random_fun = random.sample
-            picked_indices = random_fun(
-                other_indices, k=self.augmentations.aug_batch_size - 1
-            )
+                picked_indices = set()
+                max_val = len(self)
+                while len(picked_indices) < self.augmentations.aug_batch_size - 1:
+                    rand_idx = random.randint(0, max_val - 1)
+                    if rand_idx != idx and rand_idx not in picked_indices:
+                        picked_indices.add(rand_idx)
+                picked_indices = list(picked_indices)
+
             indices.extend(picked_indices)
 
         out_dict: Dict[str, Tuple[np.ndarray, LabelType]] = {}


### PR DESCRIPTION
Previous method for picking random indices for batched augs included creating a list with all possible indices. This can get slow when datasets are large since it happens on every getitem() call.
If the dataset size is smaller than size of batches we can still do it this way since it means that the dataset is of max size 4.

But if this is not the case then it's better to just pick random values in the range until we have enought of them. The speedup is seen on the image bellow comparing times for picking 4 random indices from datasets of different sizes (times averaged across  10 runs).
![comparison](https://github.com/user-attachments/assets/2dcd3ba9-3752-4d5f-8c6f-af9fe8a5df6c)
