### PR TITLE
hotifx: adding file names to be ignored by the COCO parser

### DIFF
--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -323,6 +323,16 @@ class COCOParser(BaseParser):
 
 
 def clean_annotations(annotation_path: Path) -> Path:
+    """Cleans annotations by removing images that are known to cause
+    issues.
+
+    @type annotation_path: Path
+    @param annotation_path: Path to the annotation JSON file.
+    @rtype: Path
+    @return: Path to the cleaned annotation JSON file
+        ("labels_fixed.json").
+    """
+
     files_to_avoid = [
         "000000341448.jpg",
         "000000279522.jpg",
@@ -347,6 +357,10 @@ def clean_annotations(annotation_path: Path) -> Path:
         for img in annotation_data["images"]
         if img["file_name"] not in files_to_avoid
     ]
+
+    if len(filtered_images) == len(annotation_data["images"]):
+        return annotation_path
+
     filtered_image_ids = {img["id"] for img in filtered_images}
     filtered_annotations = [
         ann

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -357,7 +357,6 @@ def clean_annotations(annotation_path: Path) -> Path:
     annotation_data["images"] = filtered_images
     annotation_data["annotations"] = filtered_annotations
 
-    # Save the cleaned annotation file
     cleaned_annotation_path = annotation_path.with_name("labels_fixed.json")
     with open(cleaned_annotation_path, "w") as f:
         json.dump(annotation_data, f)

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -199,6 +199,24 @@ class COCOParser(BaseParser):
         @return: Annotation generator, list of classes names, skeleton
             dictionary for keypoints and list of added images.
         """
+        # Files that are in the training split and also have copies in the validation split
+        files_to_avoid = [
+            "000000341448.jpg",
+            "000000279522.jpg",
+            "000000090169.jpg",
+            "000000321238.jpg",
+            "000000242807.jpg",
+            "000000297126.jpg",
+            "000000411274.jpg",
+            "000000407259.jpg",
+            "000000446141.jpg",
+            "000000373199.jpg",
+            "000000410810.jpg",
+            "000000397819.jpg",
+            "000000578492.jpg",
+            "000000531721.jpg",
+        ]
+
         with open(annotation_path) as f:
             annotation_data = json.load(f)
 
@@ -227,7 +245,7 @@ class COCOParser(BaseParser):
 
             for img_id, img in img_dict.items():
                 path = image_dir.absolute().resolve() / img["file_name"]
-                if not path.exists():
+                if not path.exists() or img["file_name"] in files_to_avoid:
                     continue
                 path = str(path)
 
@@ -236,6 +254,8 @@ class COCOParser(BaseParser):
                 img_w = img["width"]
 
                 for i, ann in enumerate(img_anns):
+                    if ann.get("iscrowd", True):
+                        continue
                     class_name = categories[ann["category_id"]]
                     yield {
                         "file": path,


### PR DESCRIPTION
Hotfix to ignore files that are in the training split and have exact copies with different names in the validation split