### PR TITLE
fewer reconnections

### DIFF
--- a/luxonis_ml/tracker/tracker.py
+++ b/luxonis_ml/tracker/tracker.py
@@ -84,6 +84,8 @@ class LuxonisTracker:
         @param rank: Rank of the process, used when running on multiple threads.
             Defaults to 0.
         """
+        os.environ["MLFLOW_HTTP_REQUEST_MAX_RETRIES"] = "1"
+
         self.project_name = project_name
         self.project_id = project_id
         self.save_directory = save_directory

--- a/luxonis_ml/tracker/tracker.py
+++ b/luxonis_ml/tracker/tracker.py
@@ -84,7 +84,7 @@ class LuxonisTracker:
         @param rank: Rank of the process, used when running on multiple threads.
             Defaults to 0.
         """
-        os.environ["MLFLOW_HTTP_REQUEST_MAX_RETRIES"] = "1"
+        os.environ["MLFLOW_HTTP_REQUEST_MAX_RETRIES"] = "2"
 
         self.project_name = project_name
         self.project_id = project_id


### PR DESCRIPTION
Fewer reconnections when a connection fails. This is useful, as metrics like training loss are logged after each epoch, and the previous 5 reconnection attempts were slowing down the process.