### PR TITLE
loading with empty annotations

### DIFF
--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -323,4 +323,21 @@ class LuxonisLoader(BaseLoader):
 
             labels[task] = (array, anns[0]._label_type)
 
+        if not labels:
+            for task in self.classes_by_task.keys():
+                if task == LabelType.SEGMENTATION:
+                    empty_array = np.zeros(
+                        (len(self.class_mappings[task]), height, width),
+                        dtype=np.uint8,
+                    )
+                if task == LabelType.BOUNDINGBOX:
+                    empty_array = np.zeros((0, 6), dtype=np.float32)
+                if task == LabelType.KEYPOINTS:
+                    empty_array = np.zeros((0, 3), dtype=np.float32)
+                if task == LabelType.CLASSIFICATION:
+                    empty_array = np.zeros(
+                        (0, len(self.class_mappings[task])), dtype=np.float32
+                    )
+                labels[task] = (empty_array, task)
+
         return img, labels

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -324,7 +324,14 @@ class LuxonisLoader(BaseLoader):
             labels[task] = (array, anns[0]._label_type)
 
         missing_tasks = set(self.classes_by_task) - set(labels_by_task)
-        if missing_tasks:
+        if missing_tasks and missing_tasks.issubset(
+            {
+                LabelType.SEGMENTATION,
+                LabelType.BOUNDINGBOX,
+                LabelType.KEYPOINTS,
+                LabelType.CLASSIFICATION,
+            }
+        ):
             for task in missing_tasks:
                 class_mapping_len = len(self.class_mappings[task])
                 if task == LabelType.SEGMENTATION:

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -323,11 +323,13 @@ class LuxonisLoader(BaseLoader):
 
             labels[task] = (array, anns[0]._label_type)
 
-        if not labels:
-            for task in self.classes_by_task.keys():
+        missing_tasks = set(self.classes_by_task) - set(labels_by_task)
+        if missing_tasks:
+            for task in missing_tasks:
+                class_mapping_len = len(self.class_mappings[task])
                 if task == LabelType.SEGMENTATION:
                     empty_array = np.zeros(
-                        (len(self.class_mappings[task]), height, width),
+                        (class_mapping_len, height, width),
                         dtype=np.uint8,
                     )
                 elif task == LabelType.BOUNDINGBOX:
@@ -336,7 +338,7 @@ class LuxonisLoader(BaseLoader):
                     empty_array = np.zeros((0, 3), dtype=np.float32)
                 elif task == LabelType.CLASSIFICATION:
                     empty_array = np.zeros(
-                        (0, len(self.class_mappings[task])), dtype=np.float32
+                        (0, class_mapping_len), dtype=np.float32
                     )
                 labels[task] = (empty_array, task)
 

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -330,11 +330,11 @@ class LuxonisLoader(BaseLoader):
                         (len(self.class_mappings[task]), height, width),
                         dtype=np.uint8,
                     )
-                if task == LabelType.BOUNDINGBOX:
+                elif task == LabelType.BOUNDINGBOX:
                     empty_array = np.zeros((0, 6), dtype=np.float32)
-                if task == LabelType.KEYPOINTS:
+                elif task == LabelType.KEYPOINTS:
                     empty_array = np.zeros((0, 3), dtype=np.float32)
-                if task == LabelType.CLASSIFICATION:
+                elif task == LabelType.CLASSIFICATION:
                     empty_array = np.zeros(
                         (0, len(self.class_mappings[task])), dtype=np.float32
                     )


### PR DESCRIPTION
## Feature: Support for Images Without Annotations

This update adds support for loading images without annotations. When no annotations are present, empty arrays are initialized for each task (e.g., segmentation, bounding boxes, keypoints, and classification). 


>Please note that loading non-annotated images is only supported for basic tasks such as `segmentation`, `classification`, `boundingbox`, and `keypoints`. It is not supported for custom tasks.
