### PR TITLE
Added `--only-local` to `pytest`

### DIFF
--- a/tests/test_data/conftest.py
+++ b/tests/test_data/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+
+from luxonis_ml.data import BucketStorage
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--only-local",
+        action="store_true",
+        default=False,
+        help="Run tests only for local storage",
+    )
+
+
+@pytest.fixture
+def only_local(request):
+    return request.config.getoption("--only-local")
+
+
+@pytest.fixture
+def storage_options(only_local: bool):
+    if only_local:
+        return [BucketStorage.LOCAL]
+    return [BucketStorage.LOCAL, BucketStorage.GCS, BucketStorage.S3]
+
+
+def pytest_generate_tests(metafunc):
+    if "bucket_storage" in metafunc.fixturenames:
+        only_local = metafunc.config.getoption("--only-local")
+        storage_options = (
+            [BucketStorage.LOCAL]
+            if only_local
+            else [BucketStorage.LOCAL, BucketStorage.S3, BucketStorage.GCS]
+        )
+        metafunc.parametrize("bucket_storage", storage_options)

--- a/tests/test_data/conftest.py
+++ b/tests/test_data/conftest.py
@@ -1,9 +1,9 @@
-import pytest
+from pytest import Metafunc, Parser
 
 from luxonis_ml.data import BucketStorage
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: Parser):
     parser.addoption(
         "--only-local",
         action="store_true",
@@ -12,19 +12,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture
-def only_local(request):
-    return request.config.getoption("--only-local")
-
-
-@pytest.fixture
-def storage_options(only_local: bool):
-    if only_local:
-        return [BucketStorage.LOCAL]
-    return [BucketStorage.LOCAL, BucketStorage.GCS, BucketStorage.S3]
-
-
-def pytest_generate_tests(metafunc):
+def pytest_generate_tests(metafunc: Metafunc):
     if "bucket_storage" in metafunc.fixturenames:
         only_local = metafunc.config.getoption("--only-local")
         storage_options = (

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -502,6 +502,8 @@ def test_complex_dataset():
         "color_segmentation": ["background", "blue", "green", "red"],
         "vehicle_segmentation": ["vehicle"],
     }
+
+
 def test_uncommon_label_types(
     bucket_storage: BucketStorage, platform_name: str, python_version: str
 ):

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -96,14 +96,6 @@ def make_image(i) -> Path:
     return path
 
 
-@pytest.mark.parametrize(
-    ("bucket_storage",),
-    [
-        (BucketStorage.LOCAL,),
-        (BucketStorage.S3,),
-        (BucketStorage.GCS,),
-    ],
-)
 def test_dataset(
     bucket_storage: BucketStorage,
     platform_name: str,
@@ -214,13 +206,6 @@ def test_loader_iterator():
         _ = loader[0]
 
 
-@pytest.mark.parametrize(
-    ("bucket_storage",),
-    [
-        (BucketStorage.LOCAL,),
-        (BucketStorage.GCS,),
-    ],
-)
 def test_make_splits(
     bucket_storage: BucketStorage, platform_name: str, python_version: str
 ):
@@ -517,15 +502,6 @@ def test_complex_dataset():
         "color_segmentation": ["background", "blue", "green", "red"],
         "vehicle_segmentation": ["vehicle"],
     }
-
-
-@pytest.mark.parametrize(
-    ("bucket_storage",),
-    [
-        (BucketStorage.LOCAL,),
-        (BucketStorage.GCS,),
-    ],
-)
 def test_uncommon_label_types(
     bucket_storage: BucketStorage, platform_name: str, python_version: str
 ):

--- a/tests/test_data/test_task_ingestion.py
+++ b/tests/test_data/test_task_ingestion.py
@@ -44,14 +44,6 @@ def compute_histogram(dataset: LuxonisDataset) -> Dict[str, int]:
     return dict(classes)
 
 
-@pytest.mark.parametrize(
-    ("bucket_storage",),
-    [
-        (BucketStorage.LOCAL,),
-        (BucketStorage.S3,),
-        (BucketStorage.GCS,),
-    ],
-)
 def test_task_ingestion(
     bucket_storage: BucketStorage, platform_name: str, python_version: str
 ):

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -39,7 +39,9 @@ def get_os_python_specific_url(
 
 
 @pytest.fixture
-def fs(request, python_version: str, platform_name: str):
+def fs(
+    request: pytest.FixtureRequest, python_version: str, platform_name: str
+):
     url_path = get_os_python_specific_url(
         request.param, platform_name, python_version
     )


### PR DESCRIPTION
Added the option to pass `--only-local` flag to the `pytest` command to only test using `BucketStorage.LOCAL` instead of parametrizing over all the storage options.