### PR TITLE
Set mdformat-gfm version explicitly to ensure compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,4 @@ repos:
     hooks:
       - id: mdformat
         additional_dependencies:
-          - mdformat-gfm
+          - mdformat-gfm==0.3.6


### PR DESCRIPTION
0.3.6 supports Python 3.8 and above whilst keeping our formatting rules the same.
Reference to [slack discussion](https://luxonis.slack.com/archives/C06D4HWU7SQ/p1734445220569169?thread_ts=1733509892.357179&cid=C06D4HWU7SQ).