### PR TITLE
feat: skip dataset re-download and ensure safe dataset syncing

### DIFF
--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -11,6 +11,7 @@ with guard_missing_extra("data"):
         LuxonisComponent,
         LuxonisDataset,
         LuxonisSource,
+        UpdateMode,
     )
     from .loaders import LOADERS_REGISTRY, BaseLoader, LuxonisLoader
     from .parsers import LuxonisParser
@@ -46,6 +47,7 @@ __all__ = [
     "ImageType",
     "LuxonisComponent",
     "LuxonisDataset",
+    "UpdateMode",
     "LuxonisLoader",
     "LuxonisParser",
     "LuxonisSource",

--- a/luxonis_ml/data/datasets/__init__.py
+++ b/luxonis_ml/data/datasets/__init__.py
@@ -8,7 +8,7 @@ from .annotation import (
     load_annotation,
 )
 from .base_dataset import DATASETS_REGISTRY, BaseDataset, DatasetIterator
-from .luxonis_dataset import LuxonisDataset
+from .luxonis_dataset import LuxonisDataset, UpdateMode
 from .source import LuxonisComponent, LuxonisSource
 
 __all__ = [
@@ -25,4 +25,5 @@ __all__ = [
     "load_annotation",
     "Detection",
     "ArrayAnnotation",
+    "UpdateMode",
 ]

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -433,8 +433,12 @@ class LuxonisDataset(BaseDataset):
         lock_path = local_dir / ".sync.lock"
 
         with FileLock(str(lock_path)):
+            any_subfolder_empty = any(
+                subfolder.is_dir() and not any(subfolder.iterdir())
+                for subfolder in (local_dir / self.dataset_name).iterdir()
+            )
             if (
-                (local_dir / self.dataset_name).exists()
+                not any_subfolder_empty
                 and skip_redownload_dataset
                 and not force
             ):

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -227,9 +227,16 @@ class LuxonisDataset(BaseDataset):
     def _load_df_offline(
         self, lazy: bool = False
     ) -> Optional[Union[pl.DataFrame, pl.LazyFrame]]:
-        path = get_dir(self.fs, "annotations", self.local_path)
+        path = (
+            self.base_path
+            / "data"
+            / self.team_id
+            / "datasets"
+            / self.dataset_name
+            / "annotations"
+        )
 
-        if path is None or not path.exists():
+        if not path.exists():
             return None
 
         if lazy:

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -418,15 +418,22 @@ class LuxonisDataset(BaseDataset):
     def get_tasks(self) -> List[str]:
         return self.metadata.get("tasks", [])
 
-    def sync_from_cloud(self, force: bool = False) -> None:
+    def sync_from_cloud(
+        self, force: bool = False, skip_redownload_dataset: bool = False
+    ) -> None:
         """Downloads data from a remote cloud bucket."""
-
         if not self.is_remote:
             logger.warning("This is a local dataset! Cannot sync")
         else:
+            local_dir = self.base_path / "data" / self.team_id / "datasets"
+            if local_dir.exists() and skip_redownload_dataset and not force:
+                logger.info(
+                    "Local dataset directory already exists. Skipping download."
+                )
+                return
+
             if not self._is_synced or force:
                 logger.info("Syncing from cloud...")
-                local_dir = self.base_path / "data" / self.team_id / "datasets"
                 local_dir.mkdir(exist_ok=True, parents=True)
 
                 self.fs.get_dir(remote_paths="", local_dir=local_dir)

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -18,6 +18,7 @@ from luxonis_ml.data.augmentations import (
 from luxonis_ml.data.datasets import (
     Annotation,
     LuxonisDataset,
+    UpdateMode,
     load_annotation,
 )
 from luxonis_ml.data.loaders.base_loader import BaseLoader
@@ -48,8 +49,7 @@ class LuxonisLoader(BaseLoader):
         keep_aspect_ratio: bool = True,
         out_image_format: Literal["RGB", "BGR"] = "RGB",
         *,
-        force_resync: bool = False,
-        skip_redownload_dataset: bool = False,
+        update_mode: UpdateMode = UpdateMode.ALWAYS,
     ) -> None:
         """A loader class used for loading data from L{LuxonisDataset}.
 
@@ -85,11 +85,9 @@ class LuxonisLoader(BaseLoader):
         @type width: Optional[int]
         @param width: The width of the output images. Defaults to
             C{None}.
-        @type force_resync: bool
-        @param force_resync: Flag to force resync from cloud. Defaults
-            to C{False}.
-        @param skip_redownload_dataset: If True, skip downloading when local dataset
-        already exists. If False, force redownload (unless force_resync is True).
+        @param update_mode: Enum that determines the sync mode:
+            - UpdateMode.ALWAYS: Force a fresh download
+            - UpdateMode.IF_EMPTY: Skip downloading if local data exists
         """
 
         self.logger = logging.getLogger(__name__)
@@ -99,10 +97,7 @@ class LuxonisLoader(BaseLoader):
         self.sync_mode = self.dataset.is_remote
 
         if self.sync_mode:
-            self.dataset.sync_from_cloud(
-                force=force_resync,
-                skip_redownload_dataset=skip_redownload_dataset,
-            )
+            self.dataset.sync_from_cloud(update_mode=update_mode)
 
         if isinstance(view, str):
             view = [view]

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -85,6 +85,7 @@ class LuxonisLoader(BaseLoader):
         @type width: Optional[int]
         @param width: The width of the output images. Defaults to
             C{None}.
+        @type update_mode: UpdateMode
         @param update_mode: Enum that determines the sync mode:
             - UpdateMode.ALWAYS: Force a fresh download
             - UpdateMode.IF_EMPTY: Skip downloading if local data exists

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -49,6 +49,7 @@ class LuxonisLoader(BaseLoader):
         out_image_format: Literal["RGB", "BGR"] = "RGB",
         *,
         force_resync: bool = False,
+        skip_redownload_dataset: bool = False,
     ) -> None:
         """A loader class used for loading data from L{LuxonisDataset}.
 
@@ -87,6 +88,8 @@ class LuxonisLoader(BaseLoader):
         @type force_resync: bool
         @param force_resync: Flag to force resync from cloud. Defaults
             to C{False}.
+        @param skip_redownload_dataset: If True, skip downloading when local dataset
+        already exists. If False, force redownload (unless force_resync is True).
         """
 
         self.logger = logging.getLogger(__name__)
@@ -96,7 +99,10 @@ class LuxonisLoader(BaseLoader):
         self.sync_mode = self.dataset.is_remote
 
         if self.sync_mode:
-            self.dataset.sync_from_cloud(force=force_resync)
+            self.dataset.sync_from_cloud(
+                force=force_resync,
+                skip_redownload_dataset=skip_redownload_dataset,
+            )
 
         if isinstance(view, str):
             view = [view]

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -1,5 +1,5 @@
 from .data_utils import infer_task, rgb_to_bool_masks, warn_on_duplicates
-from .enums import BucketStorage, BucketType, ImageType, MediaType
+from .enums import BucketStorage, BucketType, ImageType, MediaType, UpdateMode
 from .parquet import ParquetDetection, ParquetFileManager, ParquetRecord
 from .task_utils import (
     get_task_name,
@@ -24,6 +24,7 @@ __all__ = [
     "ImageType",
     "BucketType",
     "BucketStorage",
+    "UpdateMode",
     "get_task_name",
     "task_type_iterator",
     "task_is_metadata",

--- a/luxonis_ml/data/utils/enums.py
+++ b/luxonis_ml/data/utils/enums.py
@@ -31,3 +31,10 @@ class BucketStorage(Enum):
     S3 = "s3"
     GCS = "gcs"
     AZURE_BLOB = "azure"
+
+
+class UpdateMode(Enum):
+    """Update mode for the dataset."""
+
+    ALWAYS = "always"
+    IF_EMPTY = "if_empty"

--- a/luxonis_ml/tracker/tracker.py
+++ b/luxonis_ml/tracker/tracker.py
@@ -2,6 +2,7 @@ import glob
 import json
 import logging
 import os
+import time
 from functools import wraps
 from importlib.util import find_spec
 from pathlib import Path
@@ -139,6 +140,7 @@ class LuxonisTracker:
             if rank == 0:
                 self.run_name = self._get_run_name()
             else:
+                time.sleep(1)
                 self.run_name = self._get_latest_run_name()
 
         Path(f"{self.save_directory}/{self.run_name}").mkdir(

--- a/luxonis_ml/tracker/tracker.py
+++ b/luxonis_ml/tracker/tracker.py
@@ -140,7 +140,7 @@ class LuxonisTracker:
             if rank == 0:
                 self.run_name = self._get_run_name()
             else:
-                time.sleep(1)
+                time.sleep(1)  # DDP hotfix
                 self.run_name = self._get_latest_run_name()
 
         Path(f"{self.save_directory}/{self.run_name}").mkdir(

--- a/tests/test_data/test_task_ingestion.py
+++ b/tests/test_data/test_task_ingestion.py
@@ -7,7 +7,12 @@ import cv2
 import numpy as np
 import pytest
 
-from luxonis_ml.data import BucketStorage, LuxonisDataset, LuxonisLoader
+from luxonis_ml.data import (
+    BucketStorage,
+    LuxonisDataset,
+    LuxonisLoader,
+    UpdateMode,
+)
 from luxonis_ml.data.utils import get_task_name, get_task_type
 
 DATA_DIR = Path("tests/data/test_task_ingestion")
@@ -36,7 +41,7 @@ def make_image(i) -> Path:
 
 def compute_histogram(dataset: LuxonisDataset) -> Dict[str, int]:
     classes = defaultdict(int)
-    loader = LuxonisLoader(dataset, force_resync=True)
+    loader = LuxonisLoader(dataset, update_mode=UpdateMode.ALWAYS)
     for _, record in loader:
         for task, _ in record.items():
             if get_task_type(task) != "classification":


### PR DESCRIPTION
### Skip Redownload Dataset and Fix Potential Race Conditions

A new parameter, `update_mode`, has been introduced in the `LuxonisLoader`. This parameter allows more control over when the dataset from the cloud is already downloaded locally.

- If set to `UpdateMode.ALWAYS`, the loader will always re-download the dataset locally.
- If set to `UpdateMode.IF_EMPTY`, it will only download the dataset if it does not already exist locally.

**Example Usage:**

```python
from luxonis_loader import LuxonisLoader, UpdateMode

loader = LuxonisLoader(
    dataset,
    update_mode=UpdateMode.IF_EMPTY
)
```

This ensures that the loader uses the local dataset if one is already present, helping to avoid unnecessary downloads.

---

### FileLock Added for Safe Syncing

To address potential race conditions, a `FileLock` mechanism has been implemented in the following areas:

1. **`sync_from_cloud` Method:** This prevents multiple processes from attempting to sync the dataset simultaneously in a distributed environment (e.g., DDP on GCP).
2. **`_get_metadata` in Dataset Initialization:** Ensures safe concurrent access when multiple processes initialize the dataset and loader before setting up the DDP environment.

Additionally, the `_load_df_offline` method has been updated to:

- Only access local storage.
- Avoid attempting to download dataset annotations from the cloud, as `sync_from_cloud` already handles this.

These changes help to ensure safe and efficient operation in distributed environments by preventing redundant downloads and race conditions.