### PR TITLE
Fixes for nested labels

### DIFF
--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -6,7 +6,6 @@ from typing_extensions import TypeAlias
 
 from luxonis_ml.data.datasets.annotation import DatasetRecord
 from luxonis_ml.data.datasets.source import LuxonisSource
-from luxonis_ml.data.utils.task_utils import get_task_name
 from luxonis_ml.typing import PathType
 from luxonis_ml.utils import AutoRegisterMeta, Registry
 
@@ -41,11 +40,11 @@ class BaseDataset(
         ...
 
     @abstractmethod
-    def get_tasks(self) -> List[str]:
-        """Returns the list of tasks in the dataset.
+    def get_tasks(self) -> Dict[str, str]:
+        """Returns a dictionary mapping task names to task types.
 
-        @rtype: List[str]
-        @return: List of task names.
+        @rtype: Dict[str, str]
+        @return: A dictionary mapping task names to task types.
         """
         ...
 
@@ -202,4 +201,4 @@ class BaseDataset(
         @rtype: List[str]
         @return: List of task names.
         """
-        return [get_task_name(task) for task in self.get_tasks()]
+        return list(self.get_tasks().keys())

--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -74,13 +74,12 @@ class BaseDataset(
         ...
 
     @abstractmethod
-    def get_classes(self) -> Tuple[List[str], Dict[str, List[str]]]:
-        """Gets overall classes in the dataset and classes according to
-        computer vision task.
+    def get_classes(self) -> Dict[str, List[str]]:
+        """Get classes according to computer vision tasks.
 
-        @rtype: Tuple[List[str], Dict]
-        @return: A combined list of classes for all tasks and a
-            dictionary mapping tasks to the classes used in each task.
+        @rtype: Dict[str, List[str]]
+        @return: A dictionary mapping tasks to the classes used in each
+            task.
         """
         ...
 

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -85,6 +85,12 @@ class LuxonisLoader(BaseLoader):
         @type width: Optional[int]
         @param width: The width of the output images. Defaults to
             C{None}.
+        @type keep_aspect_ratio: bool
+        @param keep_aspect_ratio: Whether to keep the aspect ratio of the
+            images. Defaults to C{True}.
+        @type out_image_format: Literal["RGB", "BGR"]
+        @param out_image_format: The format of the output images. Defaults
+            to C{"RGB"}.
         @type update_mode: UpdateMode
         @param update_mode: Enum that determines the sync mode:
             - UpdateMode.ALWAYS: Force a fresh download

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -104,10 +104,7 @@ class LuxonisLoader(BaseLoader):
             view = [view]
         self.view = view
 
-        df = self.dataset._load_df_offline()
-        if df is None:
-            raise FileNotFoundError("No data found in the dataset.")
-        self.df = df
+        self.df = self.dataset._load_df_offline(raise_when_empty=True)
 
         if not self.dataset.is_remote:
             file_index = self.dataset._get_file_index()
@@ -115,7 +112,7 @@ class LuxonisLoader(BaseLoader):
                 raise FileNotFoundError("Cannot find file index")
             self.df = self.df.join(file_index, on="uuid").drop("file_right")
 
-        self.classes, self.classes_by_task = self.dataset.get_classes()
+        self.classes = self.dataset.get_classes()
         self.augmentations = self._init_augmentations(
             augmentation_engine,
             augmentation_config or [],
@@ -147,7 +144,7 @@ class LuxonisLoader(BaseLoader):
                 class_: i
                 for i, class_ in enumerate(
                     sorted(
-                        self.classes_by_task.get(task, []),
+                        self.classes.get(task, []),
                         key=lambda x: {"background": -1}.get(x, 0),
                     )
                 )
@@ -173,8 +170,8 @@ class LuxonisLoader(BaseLoader):
                         "assigned to one class or rename your background class."
                     )
                     self.tasks_without_background.add(task)
-                    if "background" not in self.classes_by_task[task_name]:
-                        self.classes_by_task[task_name].append("background")
+                    if "background" not in self.classes[task_name]:
+                        self.classes[task_name].append("background")
                         self.class_mappings[task_name] = {
                             class_: idx + 1
                             for class_, idx in self.class_mappings[
@@ -235,7 +232,7 @@ class LuxonisLoader(BaseLoader):
         if not self.dataset.is_remote:
             img_path = ann_rows[0][-1]
         else:
-            uuid = ann_rows[0][8]
+            uuid = ann_rows[0][7]
             file_extension = ann_rows[0][0].rsplit(".", 1)[-1]
             img_path = self.dataset.media_path / f"{uuid}.{file_extension}"
 
@@ -250,10 +247,10 @@ class LuxonisLoader(BaseLoader):
 
         for annotation_data in ann_rows:
             task_name: str = annotation_data[2]
-            class_name: Optional[str] = annotation_data[4]
-            instance_id: int = annotation_data[5]
-            task_type: str = annotation_data[6]
-            ann_str: Optional[str] = annotation_data[7]
+            class_name: Optional[str] = annotation_data[3]
+            instance_id: int = annotation_data[4]
+            task_type: str = annotation_data[5]
+            ann_str: Optional[str] = annotation_data[6]
 
             if ann_str is None:
                 continue
@@ -302,7 +299,7 @@ class LuxonisLoader(BaseLoader):
             array = anns[0].combine_to_numpy(
                 anns,
                 class_ids_by_task[task],
-                len(self.classes_by_task[task_name]),
+                len(self.classes[task_name]),
             )
             if task in self.tasks_without_background:
                 unassigned_pixels = ~np.any(array, axis=0)
@@ -363,7 +360,9 @@ class LuxonisLoader(BaseLoader):
             return None
 
         targets = {
-            task: get_task_type(task) for task in self.dataset.get_tasks()
+            f"{task_name}/{task_type}": task_type
+            for task_name, task_types in self.dataset.get_tasks().items()
+            for task_type in task_types
         }
 
         return AUGMENTATION_ENGINES.get(augmentation_engine)(

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -1,6 +1,6 @@
 from .data_utils import infer_task, rgb_to_bool_masks, warn_on_duplicates
 from .enums import BucketStorage, BucketType, ImageType, MediaType, UpdateMode
-from .parquet import ParquetDetection, ParquetFileManager, ParquetRecord
+from .parquet import ParquetFileManager, ParquetRecord
 from .task_utils import (
     get_task_name,
     get_task_type,
@@ -18,7 +18,6 @@ __all__ = [
     "warn_on_duplicates",
     "rgb_to_bool_masks",
     "ParquetRecord",
-    "ParquetDetection",
     "ParquetFileManager",
     "MediaType",
     "ImageType",

--- a/luxonis_ml/data/utils/parquet.py
+++ b/luxonis_ml/data/utils/parquet.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from pathlib import Path
 from typing import Optional, TypedDict
 
@@ -7,18 +6,14 @@ import polars as pl
 from luxonis_ml.typing import PathType
 
 
-class ParquetDetection(TypedDict):
+class ParquetRecord(TypedDict):
+    file: str
+    source_name: str
+    task_name: str
     class_name: Optional[str]
     instance_id: Optional[int]
     task_type: Optional[str]
     annotation: Optional[str]
-
-
-class ParquetRecord(ParquetDetection):
-    file: str
-    source_name: str
-    task_name: str
-    created_at: datetime
 
 
 class ParquetFileManager:

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -516,11 +516,12 @@ def test_clone_dataset(
 
 
 def test_merge_datasets(
-    dataset_name: str,
     bucket_storage: BucketStorage,
+    dataset_name: str,
     tempdir: Path,
     subtests: SubTests,
 ):
+    dataset_name = f"{dataset_name}_{bucket_storage.value}"
     dataset1_name = f"{dataset_name}_1"
     dataset1 = LuxonisDataset(
         dataset1_name,
@@ -583,8 +584,8 @@ def test_merge_datasets(
             new_dataset_name=f"{dataset1_name}_{dataset2_name}_merged",
         )
 
-        classes = dataset1_merged_with_dataset2.get_classes()
-        assert set(classes[""]) == {"person", "dog"}
+    classes = dataset1_merged_with_dataset2.get_classes()
+    assert set(classes[""]) == {"person", "dog"}
 
     df_merged = dataset1_merged_with_dataset2._load_df_offline()
     df_cloned_merged = dataset1.merge_with(

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -308,7 +308,6 @@ def test_metadata(
     dataset.make_splits()
     loader = LuxonisLoader(dataset)
     for _, labels in loader:
-        print(labels.keys())
         labels = {get_task_type(k): v for k, v in labels.items()}
         assert {
             "metadata/color",

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -517,8 +517,8 @@ def test_clone_dataset(
 
 
 def test_merge_datasets(
-    bucket_storage: BucketStorage,
     dataset_name: str,
+    bucket_storage: BucketStorage,
     tempdir: Path,
     subtests: SubTests,
 ):
@@ -581,7 +581,7 @@ def test_merge_datasets(
         dataset1_merged_with_dataset2 = dataset1.merge_with(
             dataset2,
             inplace=False,
-            new_dataset_name=dataset1_name + "_" + dataset2_name + "_merged",
+            new_dataset_name=f"{dataset1_name}_{dataset2_name}_merged",
         )
 
         classes = dataset1_merged_with_dataset2.get_classes()

--- a/tests/test_data/test_dataset_integration.py
+++ b/tests/test_data/test_dataset_integration.py
@@ -1,7 +1,7 @@
 import json
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 import cv2
 import numpy as np
@@ -10,6 +10,14 @@ from luxonis_ml.data import BucketStorage, LuxonisDataset, LuxonisLoader
 from luxonis_ml.utils import LuxonisFileSystem, setup_logging
 
 setup_logging(use_rich=True, rich_print=True)
+
+
+def gather_tasks(dataset: LuxonisDataset) -> Set[str]:
+    return {
+        f"{task_name}/{task_type}"
+        for task_name, task_types in dataset.get_tasks().items()
+        for task_type in task_types
+    }
 
 
 def get_annotations(sequence_path):
@@ -41,7 +49,7 @@ def test_parking_lot_generate(
     )
     dataset.add(generator(data_path, tempdir))
     dataset.make_splits((0.8, 0.1, 0.1))
-    assert set(dataset.get_tasks()) == {
+    assert gather_tasks(dataset) == {
         "car/array",
         "car/boundingbox",
         "car/classification",
@@ -71,7 +79,7 @@ def test_parking_lot_generate(
     for _, labels in loader:
         accumulated_tasks.update(labels.keys())
 
-    assert accumulated_tasks == set(dataset.get_tasks())
+    assert accumulated_tasks == gather_tasks(dataset)
 
 
 # TODO: Simplify the dataset so the code can be cleaner

--- a/tests/test_data/utils.py
+++ b/tests/test_data/utils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+def create_image(i: int, dir: Path) -> Path:
+    path = dir / f"img_{i}.jpg"
+    if not path.exists():
+        img = np.zeros((512, 512, 3), dtype=np.uint8)
+        img[0:10, 0:10] = np.random.randint(
+            0, 255, (10, 10, 3), dtype=np.uint8
+        )
+        cv2.imwrite(str(path), img)
+    return path


### PR DESCRIPTION
- Changed return type of `BaseDataset.get_tasks` to a dictionary mapping task names to task types (before it was just a list of combined task names)
- Changed return type of `BaseDataset.get_classes` from a tuple of all classes and a dictionary mapping task names to classes to just the later. The list of all classes doesn't make semantic sense with the new tasks, and also it was rarely even used anywhere
- Removed the `created_at` timestamp from parquet files - wasn't used anywhere
- Fixed `task_name` and `task_type` values for annotations with nested sub-detections
  - Names of the sub-detections are now part of the `task_name` instead of `task_type`
  - `{"car/driver": "boundingbox"}` instead of `{"car": "driver/boundingbox"}`
- Added additional overloads to methods loading parquet files 
- Simplified some tests 