### PR TITLE
Fix empty labels

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -9,7 +9,7 @@ import numpy as np
 from typing_extensions import TypeAlias, override
 
 from luxonis_ml.data.utils.task_utils import get_task_name, task_is_metadata
-from luxonis_ml.typing import ConfigItem, LoaderOutput, TaskType
+from luxonis_ml.typing import ConfigItem, LoaderOutput, Params, TaskType
 
 from .base_engine import AugmentationEngine
 from .batch_compose import BatchCompose
@@ -246,7 +246,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         height: int,
         width: int,
         targets: Dict[str, TaskType],
-        config: Iterable[Dict[str, Any]],
+        config: Iterable[Params],
         keep_aspect_ratio: bool = True,
         is_validation_pipeline: bool = False,
         min_bbox_visibility: float = 0.0,
@@ -328,7 +328,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             config = (a for a in config if a["name"] == "Normalize")
 
         for config_item in config:
-            cfg = AlbumentationConfigItem(**config_item)
+            cfg = AlbumentationConfigItem(**config_item)  # type: ignore
 
             transform = self.create_transformation(cfg)
 

--- a/luxonis_ml/data/augmentations/base_engine.py
+++ b/luxonis_ml/data/augmentations/base_engine.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, List, Mapping, Type
+from typing import Iterable, List, Mapping, Type
 
-from luxonis_ml.typing import LoaderOutput
+from luxonis_ml.typing import LoaderOutput, Params
 from luxonis_ml.utils import AutoRegisterMeta, Registry
 
 AUGMENTATION_ENGINES: Registry[Type["AugmentationEngine"]] = Registry(
@@ -21,7 +21,7 @@ class AugmentationEngine(
         height: int,
         width: int,
         targets: Mapping[str, str],
-        config: Iterable[Dict[str, Any]],
+        config: Iterable[Params],
         keep_aspect_ratio: bool,
         is_validation_pipeline: bool,
         min_bbox_visibility: float = 0,
@@ -41,7 +41,7 @@ class AugmentationEngine(
                     "detection/segmentation": "mask",
                 }
 
-        @type config: List[Dict[str, Any]]
+        @type config: List[Params]
         @param config: List of dictionaries with configuration for each
             augmentation. It is up to the augmentation engine to parse
             and interpret this configuration.

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import albumentations as A
 import numpy as np
@@ -62,7 +62,7 @@ class BatchCompose(A.Compose):
         return self.postprocess(data)
 
     @staticmethod
-    def make_contiguous(data: Dict[str, Any]) -> Dict[str, Any]:
+    def make_contiguous(data: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
         for key, value in data.items():
             if isinstance(value, np.ndarray):
                 value = np.ascontiguousarray(value)

--- a/luxonis_ml/data/augmentations/batch_transform.py
+++ b/luxonis_ml/data/augmentations/batch_transform.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import albumentations as A
 import numpy as np
@@ -20,7 +20,7 @@ class BatchTransform(ABC, A.DualTransform):
 
     @property
     @override
-    def targets(self) -> Dict[str, Any]:
+    def targets(self) -> Dict[str, Callable]:
         targets = super().targets
         targets.update(
             {

--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -201,3 +201,7 @@ class BaseDataset(
         @return: List of task names.
         """
         return list(self.get_tasks().keys())
+
+    def get_n_keypoints(self) -> Dict[str, int]:
+        skeletons = self.get_skeletons()
+        return {task: len(skeletons[task][0]) for task in skeletons}

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -4,7 +4,7 @@ import random
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union, cast
+from typing import Dict, List, Literal, Optional, Tuple, Union, cast
 
 import cv2
 import numpy as np
@@ -29,7 +29,7 @@ from luxonis_ml.data.utils import (
     task_type_iterator,
 )
 from luxonis_ml.data.utils.task_utils import task_is_metadata
-from luxonis_ml.typing import Labels, LoaderOutput, PathType
+from luxonis_ml.typing import Labels, LoaderOutput, Params, PathType
 
 logger = logging.getLogger(__name__)
 
@@ -42,9 +42,7 @@ class LuxonisLoader(BaseLoader):
         augmentation_engine: Union[
             Literal["albumentations"], str
         ] = "albumentations",
-        augmentation_config: Optional[
-            Union[List[Dict[str, Any]], PathType]
-        ] = None,
+        augmentation_config: Optional[Union[List[Params], PathType]] = None,
         height: Optional[int] = None,
         width: Optional[int] = None,
         keep_aspect_ratio: bool = True,
@@ -63,10 +61,10 @@ class LuxonisLoader(BaseLoader):
         @type augmentation_engine: Union[Literal["albumentations"], str]
         @param augmentation_engine: The augmentation engine to use.
             Defaults to C{"albumentations"}.
-        @type augmentation_config: Optional[Union[List[Dict[str, Any]],
+        @type augmentation_config: Optional[Union[List[Params],
             PathType]]
         @param augmentation_config: The configuration for the
-            augmentations. This can be either a list of C{Dict[str, Any]} or
+            augmentations. This can be either a list of C{Dict[str, JsonValue]} or
             a path to a configuration file.
             The config member is a dictionary with two keys: C{name} and
             C{params}. C{name} is the name of the augmentation to
@@ -391,7 +389,7 @@ class LuxonisLoader(BaseLoader):
     def _init_augmentations(
         self,
         augmentation_engine: Union[Literal["albumentations"], str],
-        augmentation_config: Union[List[Dict[str, Any]], PathType],
+        augmentation_config: Union[List[Params], PathType],
         height: Optional[int],
         width: Optional[int],
         keep_aspect_ratio: bool,
@@ -399,7 +397,7 @@ class LuxonisLoader(BaseLoader):
         if isinstance(augmentation_config, (Path, str)):
             with open(augmentation_config) as file:
                 augmentation_config = cast(
-                    List[Dict[str, Any]], yaml.safe_load(file) or []
+                    List[Params], yaml.safe_load(file) or []
                 )
         if augmentation_config and (width is None or height is None):
             raise ValueError(

--- a/luxonis_ml/typing.py
+++ b/luxonis_ml/typing.py
@@ -2,8 +2,7 @@ from pathlib import Path
 from typing import Dict, Literal, Tuple, Union
 
 import numpy as np
-from pydantic import BaseModel
-from pydantic.config import JsonDict
+from pydantic import BaseModel, JsonValue
 from typing_extensions import TypeAlias
 
 PathType: TypeAlias = Union[str, Path]
@@ -38,6 +37,9 @@ or a single value (in which case it is interpreted as a grayscale
 value).
 """
 
+Params: TypeAlias = Dict[str, JsonValue]
+"""A JSON-like dictionary of additioanl parameters."""
+
 
 class ConfigItem(BaseModel):
     """Configuration schema for dynamic object instantiation. Typically
@@ -48,10 +50,11 @@ class ConfigItem(BaseModel):
     @type name: str
     @ivar name: The name of the object this configuration applies to.
         Required.
-    @type params: JsonDict
+    @type params: Dict[str, JsonDict]
     @ivar params: Additional parameters for instantiating the object.
         Not required.
     """
 
     name: str
-    params: JsonDict = {}
+
+    params: Params = {}

--- a/luxonis_ml/typing.py
+++ b/luxonis_ml/typing.py
@@ -2,7 +2,8 @@ from pathlib import Path
 from typing import Dict, Literal, Tuple, Union
 
 import numpy as np
-from pydantic import BaseModel, JsonValue
+from pydantic import BaseModel
+from pydantic.config import JsonDict
 from typing_extensions import TypeAlias
 
 PathType: TypeAlias = Union[str, Path]
@@ -53,4 +54,4 @@ class ConfigItem(BaseModel):
     """
 
     name: str
-    params: Dict[str, JsonValue] = {}
+    params: JsonDict = {}

--- a/luxonis_ml/utils/config.py
+++ b/luxonis_ml/utils/config.py
@@ -3,6 +3,8 @@ from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import yaml
 
+from luxonis_ml.typing import Params
+
 from .filesystem import LuxonisFileSystem
 from .pydantic_utils import BaseModelExtraForbid
 
@@ -15,10 +17,8 @@ class LuxonisConfig(BaseModelExtraForbid):
     @classmethod
     def get_config(
         cls: Type[T],
-        cfg: Optional[Union[str, Dict[str, Any]]] = None,
-        overrides: Optional[
-            Union[Dict[str, Any], List[str], Tuple[str, ...]]
-        ] = None,
+        cfg: Optional[Union[str, Params]] = None,
+        overrides: Optional[Union[Params, List[str], Tuple[str, ...]]] = None,
     ) -> T:
         """Loads config from a yaml file or a dictionary.
 
@@ -56,7 +56,7 @@ class LuxonisConfig(BaseModelExtraForbid):
             data = cfg
 
         cls._merge_overrides(data, overrides)
-        return cls(**data)
+        return cls(**data)  # type: ignore
 
     def __str__(self) -> str:
         return self.model_dump_json(indent=4)
@@ -64,7 +64,7 @@ class LuxonisConfig(BaseModelExtraForbid):
     def __repr__(self) -> str:
         return self.__str__()
 
-    def get_json_schema(self) -> Dict[str, Any]:
+    def get_json_schema(self) -> Params:
         """Retuns dict representation of the config json schema.
 
         @rtype: dict
@@ -117,9 +117,7 @@ class LuxonisConfig(BaseModelExtraForbid):
         return value
 
     @staticmethod
-    def _merge_overrides(
-        data: Dict[str, Any], overrides: Dict[str, Any]
-    ) -> None:
+    def _merge_overrides(data: Params, overrides: Params) -> None:
         """Merges the config dictionary with the CLI overrides.
 
         The overrides are a dictionary mapping "dotted" keys to either

--- a/luxonis_ml/utils/environ.py
+++ b/luxonis_ml/utils/environ.py
@@ -1,8 +1,10 @@
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional
+from typing import Literal, Optional
 
 from pydantic import model_serializer
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from luxonis_ml.typing import Params
 
 __all__ = ["Environ", "environ"]
 
@@ -43,7 +45,7 @@ class Environ(BaseSettings):
     )
 
     @model_serializer(when_used="always", mode="plain")
-    def _serialize_environ(self) -> Dict[str, Any]:
+    def _serialize_environ(self) -> Params:
         return {}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import random
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import numpy as np
 import pytest
@@ -11,6 +11,7 @@ from _pytest.fixtures import SubRequest
 from pytest import FixtureRequest, Function, Metafunc, Parser
 
 from luxonis_ml.data import BucketStorage
+from luxonis_ml.typing import Params
 from luxonis_ml.utils import setup_logging
 from luxonis_ml.utils.environ import environ
 
@@ -98,7 +99,7 @@ def augmentation_data(
 
 
 @pytest.fixture(scope="session")
-def augmentation_config() -> List[Dict[str, Any]]:
+def augmentation_config() -> List[Params]:
     return [
         {
             "name": "Mosaic4",

--- a/tests/test_data/test_annotations.py
+++ b/tests/test_data/test_annotations.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import List
 
 import cv2
 import numpy as np
@@ -19,6 +19,7 @@ from luxonis_ml.data.datasets.annotation import (
     check_valid_identifier,
     load_annotation,
 )
+from luxonis_ml.data.utils.parquet import ParquetRecord
 
 
 def test_valid_identifier():
@@ -49,12 +50,9 @@ def test_load_annotation():
 
 def test_dataset_record(tempdir: Path):
     def compare_parquet_rows(
-        record: DatasetRecord, expected_rows: List[Dict[str, Any]]
+        record: DatasetRecord, expected_rows: List[ParquetRecord]
     ):
-        rows = list(record.to_parquet_rows())
-        for row in rows:
-            row["file"] = Path(row["file"])  # type: ignore
-        assert rows == expected_rows
+        assert list(record.to_parquet_rows()) == expected_rows
 
     cv2.imwrite(str(tempdir / "left.jpg"), np.zeros((100, 100, 3)))
     cv2.imwrite(str(tempdir / "right.jpg"), np.zeros((100, 100, 3)))
@@ -65,7 +63,7 @@ def test_dataset_record(tempdir: Path):
         record,
         [
             {
-                "file": Path("tests/data/tempdir/left.jpg"),
+                "file": "tests/data/tempdir/left.jpg",
                 "source_name": "image",
                 "task_name": "",
                 "class_name": None,
@@ -87,7 +85,7 @@ def test_dataset_record(tempdir: Path):
         record,
         [
             {
-                "file": Path("tests/data/tempdir/left.jpg"),
+                "file": "tests/data/tempdir/left.jpg",
                 "source_name": "image",
                 "task_name": "",
                 "class_name": "person",
@@ -96,7 +94,7 @@ def test_dataset_record(tempdir: Path):
                 "annotation": '{"x":0.1,"y":0.2,"w":0.3,"h":0.4}',
             },
             {
-                "file": Path("tests/data/tempdir/left.jpg"),
+                "file": "tests/data/tempdir/left.jpg",
                 "source_name": "image",
                 "task_name": "",
                 "class_name": "person",

--- a/tests/test_data/test_annotations.py
+++ b/tests/test_data/test_annotations.py
@@ -52,7 +52,11 @@ def test_dataset_record(tempdir: Path):
     def compare_parquet_rows(
         record: DatasetRecord, expected_rows: List[ParquetRecord]
     ):
-        assert list(record.to_parquet_rows()) == expected_rows
+        rows = list(record.to_parquet_rows())
+        for row in rows:
+            # for compatibility with Windows
+            row["file"] = str(Path(row["file"]))
+        assert rows == expected_rows
 
     cv2.imwrite(str(tempdir / "left.jpg"), np.zeros((100, 100, 3)))
     cv2.imwrite(str(tempdir / "right.jpg"), np.zeros((100, 100, 3)))

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import numpy as np
 import pytest
@@ -16,12 +16,13 @@ from luxonis_ml.data import (
 )
 from luxonis_ml.data.utils.task_utils import get_task_type
 from luxonis_ml.enums import DatasetType
+from luxonis_ml.typing import Params
 
 
 def test_dataset(
     bucket_storage: BucketStorage,
     dataset_name: str,
-    augmentation_config: List[Dict[str, Any]],
+    augmentation_config: List[Params],
     subtests: SubTests,
     storage_url: str,
     tempdir: Path,
@@ -392,7 +393,7 @@ def test_no_labels(dataset_name: str, tempdir: Path, subtests: SubTests):
 
 @pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
 def test_deep_nested_labels(
-    dataset_name: str, augmentation_config: List[Dict[str, Any]], tempdir: Path
+    dataset_name: str, augmentation_config: List[Params], tempdir: Path
 ):
     def generator():
         for i in range(10):

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -379,6 +379,16 @@ def test_no_labels(dataset_name: str, tempdir: Path, subtests: SubTests):
             for _, labels in augmented_loader:
                 assert set(labels.keys()) == expected_tasks
 
+        if total is False:
+            with subtests.test("test_almost_empty_exclude_empty"):
+                for i, (_, labels) in enumerate(
+                    LuxonisLoader(dataset, exclude_empty_annotations=True)
+                ):
+                    if i == 0:
+                        assert set(labels.keys()) == expected_tasks
+                    else:
+                        assert not labels
+
 
 @pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
 def test_deep_nested_labels(

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List
 
 import numpy as np
 import pytest
 from pytest_subtests.plugin import SubTests
-from utils import create_image
+from utils import compare_loader_output, create_dataset, create_image
 
 from luxonis_ml.data import (
     BucketStorage,
@@ -18,13 +18,6 @@ from luxonis_ml.data.utils.task_utils import get_task_type
 from luxonis_ml.enums import DatasetType
 
 
-def compare_loader_output(loader: LuxonisLoader, tasks: Set[str]):
-    all_labels = set()
-    for _, labels in loader:
-        all_labels.update(labels.keys())
-    assert all_labels == tasks
-
-
 def test_dataset(
     bucket_storage: BucketStorage,
     dataset_name: str,
@@ -34,7 +27,7 @@ def test_dataset(
     tempdir: Path,
 ):
     with subtests.test("test_create", bucket_storage=bucket_storage):
-        parser = LuxonisParser(
+        dataset = LuxonisParser(
             f"{storage_url}/COCO_people_subset.zip",
             dataset_name=dataset_name,
             save_dir=tempdir,
@@ -43,9 +36,8 @@ def test_dataset(
             delete_existing=True,
             delete_remote=True,
             task_name="coco",
-        )
-        parser.parse()
-        dataset = LuxonisDataset(dataset_name, bucket_storage=bucket_storage)
+        ).parse()
+
         assert LuxonisDataset.exists(
             dataset_name, bucket_storage=bucket_storage
         )
@@ -95,6 +87,7 @@ def test_dataset(
                 ],
             ),
         }
+        assert dataset.get_n_keypoints() == {"coco": 17}
 
         assert dataset.identifier == dataset_name
 
@@ -136,9 +129,7 @@ def test_dataset(
 
 
 @pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
-def test_dataset_fail(tempdir: Path):
-    dataset = LuxonisDataset("test_fail", delete_existing=True)
-
+def test_dataset_fail(dataset_name: str, tempdir: Path):
     def generator():
         for i in range(10):
             img = create_image(i, tempdir)
@@ -149,7 +140,7 @@ def test_dataset_fail(tempdir: Path):
                 },
             }
 
-    dataset.add(generator(), batch_size=2)
+    dataset = create_dataset(dataset_name, generator())
 
     with pytest.raises(ValueError):
         dataset.set_skeletons()
@@ -175,6 +166,7 @@ def test_loader_iterator(storage_url: str, tempdir: Path):
         _ = loader[0]
 
 
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
 def test_make_splits(
     bucket_storage: BucketStorage, dataset_name: str, tempdir: Path
 ):
@@ -196,13 +188,10 @@ def test_make_splits(
             definitions[["train", "val", "test"][i % 3]].append(str(path))
         _start_index += step
 
-    dataset = LuxonisDataset(
-        dataset_name,
-        delete_existing=True,
-        delete_remote=True,
-        bucket_storage=bucket_storage,
+    dataset = create_dataset(
+        dataset_name, generator(), bucket_storage, splits=False
     )
-    dataset.add(generator())
+
     assert len(dataset) == 15
     assert dataset.get_splits() is None
     dataset.make_splits(definitions)
@@ -280,6 +269,7 @@ def test_make_splits(
         ), f"Split {split} has {len(split_data)} samples"
 
 
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
 def test_metadata(
     bucket_storage: BucketStorage, dataset_name: str, tempdir: Path
 ):
@@ -298,14 +288,7 @@ def test_metadata(
                 },
             }
 
-    dataset = LuxonisDataset(
-        dataset_name,
-        delete_existing=True,
-        delete_remote=True,
-        bucket_storage=bucket_storage,
-    )
-    dataset.add(generator())
-    dataset.make_splits()
+    dataset = create_dataset(dataset_name, generator(), bucket_storage)
     loader = LuxonisLoader(dataset)
     for _, labels in loader:
         labels = {get_task_type(k): v for k, v in labels.items()}
@@ -321,35 +304,85 @@ def test_metadata(
         assert labels["metadata/id"].tolist() == list(range(127, 137))
 
 
-def test_no_labels(tempdir: Path):
-    dataset = LuxonisDataset("no_labels", delete_existing=True)
-
-    def generator():
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
+def test_no_labels(dataset_name: str, tempdir: Path, subtests: SubTests):
+    def generator(total: bool):
         for i in range(10):
             img = create_image(i, tempdir)
-            yield {
-                "file": img,
-            }
+            if i == 0:
+                if total:
+                    yield {
+                        "file": img,
+                    }
+                else:
+                    yield {
+                        "file": img,
+                        "annotation": {
+                            "class": "person",
+                            "boundingbox": {
+                                "x": 0.1,
+                                "y": 0.1,
+                                "w": 0.1,
+                                "h": 0.1,
+                            },
+                            "keypoints": {
+                                "keypoints": [[0.1, 0.1, 0], [0.2, 0.2, 1]]
+                            },
+                            "segmentation": {
+                                "mask": np.random.rand(512, 512) > 0.5
+                            },
+                            "instance_segmentation": {
+                                "mask": np.random.rand(512, 512) > 0.5
+                            },
+                            "metadata": {
+                                "color": "red",
+                            },
+                            "sub_detections": {
+                                "head": {
+                                    "boundingbox": {
+                                        "x": 0.2,
+                                        "y": 0.2,
+                                        "w": 0.1,
+                                        "h": 0.1,
+                                    },
+                                },
+                            },
+                        },
+                    }
 
-    dataset.add(generator())
-    dataset.make_splits()
+    for total in [True, False]:
+        with subtests.test(f"test_{'total' if total else 'almost'}_empty"):
+            dataset = create_dataset(dataset_name, generator(total=total))
 
-    loader = LuxonisLoader(dataset)
-    for _, labels in loader:
-        assert labels == {}
+            if total:
+                expected_tasks = set()
+            else:
+                expected_tasks = {
+                    "/classification",
+                    "/boundingbox",
+                    "/keypoints",
+                    "/segmentation",
+                    "/instance_segmentation",
+                    "/metadata/color",
+                    "/head/boundingbox",
+                }
 
-    loader = LuxonisLoader(
-        dataset,
-        width=512,
-        height=512,
-        augmentation_config=[{"name": "Flip", "params": {}}],
-    )
-    for _, labels in loader:
-        assert labels == {}
+            for _, labels in LuxonisLoader(dataset):
+                assert set(labels.keys()) == expected_tasks
+
+            augmented_loader = LuxonisLoader(
+                dataset,
+                width=512,
+                height=512,
+                augmentation_config=[{"name": "Flip", "params": {}}],
+            )
+            for _, labels in augmented_loader:
+                assert set(labels.keys()) == expected_tasks
 
 
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
 def test_deep_nested_labels(
-    augmentation_config: List[Dict[str, Any]], tempdir: Path
+    dataset_name: str, augmentation_config: List[Dict[str, Any]], tempdir: Path
 ):
     def generator():
         for i in range(10):
@@ -390,9 +423,7 @@ def test_deep_nested_labels(
                 },
             }
 
-    dataset = LuxonisDataset("deep_nested_labels", delete_existing=True)
-    dataset.add(generator())
-    dataset.make_splits()
+    dataset = create_dataset(dataset_name, generator())
 
     loader = LuxonisLoader(
         dataset,
@@ -414,9 +445,8 @@ def test_deep_nested_labels(
     )
 
 
-def test_partial_labels(tempdir: Path):
-    dataset = LuxonisDataset("partial_labels", delete_existing=True)
-
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
+def test_partial_labels(dataset_name: str, tempdir: Path):
     def generator():
         for i in range(8):
             img = create_image(i, tempdir)
@@ -458,7 +488,8 @@ def test_partial_labels(tempdir: Path):
                     },
                 }
 
-    dataset.add(generator()).make_splits()
+    dataset = create_dataset(dataset_name, generator())
+
     loader = LuxonisLoader(
         dataset,
         width=512,
@@ -477,16 +508,10 @@ def test_partial_labels(tempdir: Path):
     )
 
 
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
 def test_clone_dataset(
     bucket_storage: BucketStorage, dataset_name: str, tempdir: Path
 ):
-    dataset = LuxonisDataset(
-        dataset_name,
-        bucket_storage=bucket_storage,
-        delete_existing=True,
-        delete_remote=True,
-    )
-
     def generator1():
         for i in range(3):
             img = create_image(i, tempdir)
@@ -498,8 +523,12 @@ def test_clone_dataset(
                 },
             }
 
-    dataset.add(generator1())
-    dataset.make_splits({"train": 0.6, "val": 0.4})
+    dataset = create_dataset(
+        dataset_name,
+        generator1(),
+        bucket_storage,
+        splits={"train": 0.6, "val": 0.4},
+    )
 
     cloned_dataset = dataset.clone(new_dataset_name=dataset_name + "_cloned")
 
@@ -515,6 +544,7 @@ def test_clone_dataset(
     assert df_cloned.equals(df_original)
 
 
+@pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
 def test_merge_datasets(
     bucket_storage: BucketStorage,
     dataset_name: str,
@@ -523,12 +553,7 @@ def test_merge_datasets(
 ):
     dataset_name = f"{dataset_name}_{bucket_storage.value}"
     dataset1_name = f"{dataset_name}_1"
-    dataset1 = LuxonisDataset(
-        dataset1_name,
-        bucket_storage=bucket_storage,
-        delete_existing=True,
-        delete_remote=True,
-    )
+    dataset2_name = f"{dataset_name}_2"
 
     def generator1():
         for i in range(3):
@@ -541,17 +566,6 @@ def test_merge_datasets(
                 },
             }
 
-    dataset1.add(generator1())
-    dataset1.make_splits({"train": 0.6, "val": 0.4})
-
-    dataset2_name = f"{dataset_name}_2"
-    dataset2 = LuxonisDataset(
-        dataset2_name,
-        bucket_storage=bucket_storage,
-        delete_existing=True,
-        delete_remote=True,
-    )
-
     def generator2():
         for i in range(3, 6):
             img = create_image(i, tempdir)
@@ -563,8 +577,19 @@ def test_merge_datasets(
                 },
             }
 
-    dataset2.add(generator2())
-    dataset2.make_splits({"train": 0.6, "val": 0.4})
+    dataset1 = create_dataset(
+        dataset1_name,
+        generator1(),
+        bucket_storage,
+        splits={"train": 0.6, "val": 0.4},
+    )
+
+    dataset2 = create_dataset(
+        dataset2_name,
+        generator2(),
+        bucket_storage,
+        splits={"train": 0.6, "val": 0.4},
+    )
 
     with subtests.test("test_inplace"):
         cloned_dataset1 = dataset1.clone(

--- a/tests/test_data/test_dataset_integration.py
+++ b/tests/test_data/test_dataset_integration.py
@@ -1,13 +1,14 @@
 import json
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import List
 
 import cv2
 import numpy as np
 from utils import gather_tasks
 
 from luxonis_ml.data import BucketStorage, LuxonisDataset, LuxonisLoader
+from luxonis_ml.typing import Params
 from luxonis_ml.utils import LuxonisFileSystem, setup_logging
 
 setup_logging(use_rich=True, rich_print=True)
@@ -26,7 +27,7 @@ def test_parking_lot_generate(
     tempdir: Path,
     bucket_storage: BucketStorage,
     dataset_name: str,
-    augmentation_config: List[Dict[str, Any]],
+    augmentation_config: List[Params],
     height: int,
     width: int,
     storage_url: str,

--- a/tests/test_data/test_dataset_integration.py
+++ b/tests/test_data/test_dataset_integration.py
@@ -1,23 +1,16 @@
 import json
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List
 
 import cv2
 import numpy as np
+from utils import gather_tasks
 
 from luxonis_ml.data import BucketStorage, LuxonisDataset, LuxonisLoader
 from luxonis_ml.utils import LuxonisFileSystem, setup_logging
 
 setup_logging(use_rich=True, rich_print=True)
-
-
-def gather_tasks(dataset: LuxonisDataset) -> Set[str]:
-    return {
-        f"{task_name}/{task_type}"
-        for task_name, task_types in dataset.get_tasks().items()
-        for task_type in task_types
-    }
 
 
 def get_annotations(sequence_path):

--- a/tests/test_data/test_task_ingestion.py
+++ b/tests/test_data/test_task_ingestion.py
@@ -17,7 +17,9 @@ STEP = 10
 
 def compute_histogram(dataset: LuxonisDataset) -> Dict[str, int]:
     classes = defaultdict(int)
-    loader = LuxonisLoader(dataset, update_mode=UpdateMode.ALWAYS)
+    loader = LuxonisLoader(
+        dataset, exclude_empty_annotations=True, update_mode=UpdateMode.ALWAYS
+    )
     for _, record in loader:
         for task, _ in record.items():
             if get_task_type(task) != "classification":

--- a/tests/test_nn_archive/test_nn_archive.py
+++ b/tests/test_nn_archive/test_nn_archive.py
@@ -1,7 +1,7 @@
 import shutil
 import tarfile
 from pathlib import Path
-from typing import Any, Dict, Literal
+from typing import Literal
 
 import onnx
 import pytest
@@ -21,6 +21,7 @@ from pydantic import ValidationError
 
 from luxonis_ml.nn_archive import ArchiveGenerator, is_nn_archive
 from luxonis_ml.nn_archive.model import HeadType, Input, Output
+from luxonis_ml.typing import Params
 
 DATA_DIR = Path("tests/data/test_nn_archive")
 
@@ -75,7 +76,7 @@ def setup():
 @pytest.mark.dependency(name="test_archive_generator")
 def test_archive_generator(
     compression: Literal["xz", "gz", "bz2"],
-    head: Dict[str, Any],
+    head: Params,
     archive_name: Literal[
         "classification",
         "ssd_detection",


### PR DESCRIPTION
Added argument `exclude_empty_labels` to `LuxonisLoader`.
- If set to `True`, the output labels dictionary will not contain all the labels.
  - The dataset has a single task `"animals"` with two task types: `"boundingbox"` and `"segmentation"` 
  - One example doesn't have any animal in it $\rightarrow$ no boundingbox
  - The output label dictionary will have a single key `"animals/segmentation"`
- If set to `False` (default), the missing labels will be filled with empty arrays
  - Using the above example, the label dictionary will have two keys: `"animals/segmentation"` and `"animals/boundingbox"`
  - The shape of the empty label is compatible with a non-empty label
    - `[0, 5]` for the above example  