### PR TITLE
fix kpts and bbox edge cases

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -247,7 +247,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         config: Iterable[Params],
         keep_aspect_ratio: bool = True,
         is_validation_pipeline: bool = False,
-        min_bbox_visibility: float = 0.0,
+        min_bbox_visibility: float = 4e-4,
     ):
         self.targets: Dict[str, TargetType] = {}
         self.target_names_to_tasks = {}

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -247,7 +247,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         config: Iterable[Params],
         keep_aspect_ratio: bool = True,
         is_validation_pipeline: bool = False,
-        min_bbox_visibility: float = 4e-4,
+        min_bbox_visibility: float = 0.0,
     ):
         self.targets: Dict[str, TargetType] = {}
         self.target_names_to_tasks = {}

--- a/luxonis_ml/data/augmentations/base_engine.py
+++ b/luxonis_ml/data/augmentations/base_engine.py
@@ -24,7 +24,7 @@ class AugmentationEngine(
         config: Iterable[Params],
         keep_aspect_ratio: bool,
         is_validation_pipeline: bool,
-        min_bbox_visibility: float = 4e-4,
+        min_bbox_visibility: float = 0.0,
     ):
         """Initialize augmentation pipeline from configuration.
 
@@ -52,9 +52,7 @@ class AugmentationEngine(
         @param is_validation_pipeline: Whether this is a validation
             pipeline (in which case some augmentations are skipped)
         @type min_bbox_visibility: float
-        @param min_bbox_visibility: Minimum area of a bounding box for it to be considered visible.
-        By default, it is set to 4e-4 to address issues with corner bounding boxes having minimal area.
-        Additionally, the keypoints for such bounding boxes contain no useful information.
+        @param min_bbox_visibility: Minimum fraction of the original bounding box that must remain visible after augmentation.
         """
         ...
 

--- a/luxonis_ml/data/augmentations/base_engine.py
+++ b/luxonis_ml/data/augmentations/base_engine.py
@@ -24,7 +24,7 @@ class AugmentationEngine(
         config: Iterable[Params],
         keep_aspect_ratio: bool,
         is_validation_pipeline: bool,
-        min_bbox_visibility: float = 0,
+        min_bbox_visibility: float = 4e-4,
     ):
         """Initialize augmentation pipeline from configuration.
 
@@ -52,8 +52,9 @@ class AugmentationEngine(
         @param is_validation_pipeline: Whether this is a validation
             pipeline (in which case some augmentations are skipped)
         @type min_bbox_visibility: float
-        @param min_bbox_visibility: Minimum area of a bounding box to be
-            considered visible.
+        @param min_bbox_visibility: Minimum area of a bounding box for it to be considered visible.
+        By default, it is set to 4e-4 to address issues with corner bounding boxes having minimal area.
+        Additionally, the keypoints for such bounding boxes contain no useful information.
         """
         ...
 

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -39,24 +39,15 @@ def postprocess_mask(mask: np.ndarray) -> np.ndarray:
 
 
 def postprocess_bboxes(bboxes: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    area_threshold = 0.0004  # 0.02 * 0.02 Small area threshold to remove invalid bboxes and respective keypoints.
     if bboxes.size == 0:
-        return np.zeros((0, 5)), np.zeros((0,), dtype=np.uint8)
+        return np.zeros((0, 6)), np.zeros((0, 1), dtype=np.uint8)
+
     ordering = bboxes[:, -1]
-    raw_bboxes = bboxes[:, :-1]
-    raw_bboxes[:, 2] -= raw_bboxes[:, 0]
-    raw_bboxes[:, 3] -= raw_bboxes[:, 1]
-    widths = raw_bboxes[:, 2]
-    heights = raw_bboxes[:, 3]
-    areas = widths * heights
+    out_bboxes = bboxes[:, :-1]
+    out_bboxes[:, 2] -= out_bboxes[:, 0]
+    out_bboxes[:, 3] -= out_bboxes[:, 1]
 
-    valid_mask = areas >= area_threshold
-    raw_bboxes = raw_bboxes[valid_mask]
-    refined_ordering = ordering[valid_mask]
-
-    out_bboxes = raw_bboxes[:, [4, 0, 1, 2, 3]]
-
-    return out_bboxes, refined_ordering.astype(np.uint8)
+    return out_bboxes[:, [4, 0, 1, 2, 3]], ordering.astype(np.uint8)
 
 
 def postprocess_keypoints(

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -39,7 +39,7 @@ def postprocess_mask(mask: np.ndarray) -> np.ndarray:
 
 
 def postprocess_bboxes(bboxes: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-    area_threshold = 0.0001  # 0.01 * 0.01 Small area threshold to remove invalid bboxes and respective keypoints.
+    area_threshold = 0.0004  # 0.02 * 0.02 Small area threshold to remove invalid bboxes and respective keypoints.
     if bboxes.size == 0:
         return np.zeros((0, 5)), np.zeros((0,), dtype=np.uint8)
     ordering = bboxes[:, -1]

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -39,15 +39,24 @@ def postprocess_mask(mask: np.ndarray) -> np.ndarray:
 
 
 def postprocess_bboxes(bboxes: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    area_threshold = 0.0004  # 0.02 * 0.02 Small area threshold to remove invalid bboxes and respective keypoints.
     if bboxes.size == 0:
-        return np.zeros((0, 6)), np.zeros((0, 1), dtype=np.uint8)
-
+        return np.zeros((0, 5)), np.zeros((0,), dtype=np.uint8)
     ordering = bboxes[:, -1]
-    out_bboxes = bboxes[:, :-1]
-    out_bboxes[:, 2] -= out_bboxes[:, 0]
-    out_bboxes[:, 3] -= out_bboxes[:, 1]
+    raw_bboxes = bboxes[:, :-1]
+    raw_bboxes[:, 2] -= raw_bboxes[:, 0]
+    raw_bboxes[:, 3] -= raw_bboxes[:, 1]
+    widths = raw_bboxes[:, 2]
+    heights = raw_bboxes[:, 3]
+    areas = widths * heights
 
-    return out_bboxes[:, [4, 0, 1, 2, 3]], ordering.astype(np.uint8)
+    valid_mask = areas >= area_threshold
+    raw_bboxes = raw_bboxes[valid_mask]
+    refined_ordering = ordering[valid_mask]
+
+    out_bboxes = raw_bboxes[:, [4, 0, 1, 2, 3]]
+
+    return out_bboxes, refined_ordering.astype(np.uint8)
 
 
 def postprocess_keypoints(

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -306,5 +306,5 @@ def test_edge_cases(tempdir: Path):
 
                 bbox_area = width * height
                 assert (
-                    bbox_area > 0.0004
+                    bbox_area >= 0.0004
                 ), f"BBox area too small: {bbox}, area={bbox_area}"

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -1,8 +1,310 @@
-import pytest
+from pathlib import Path
 
-from luxonis_ml.data import LuxonisDataset, LuxonisLoader
+import numpy as np
+from utils import create_image
+
+from luxonis_ml.data import (
+    BucketStorage,
+    LuxonisDataset,
+    LuxonisLoader,
+)
 
 
-def test_invalid():
-    with pytest.raises(FileNotFoundError):
-        LuxonisLoader(LuxonisDataset("non-existent"))
+def test_edge_cases(tempdir: Path):
+    keypoints_before = np.array(
+        [
+            [
+                0.41100962,
+                0.63641827,
+                2.0,
+                0.49552885,
+                0.61091346,
+                2.0,
+                0.50201923,
+                0.63555288,
+                2.0,
+                0.41879808,
+                0.66302885,
+                2.0,
+            ],
+            [
+                0.86091346,
+                0.76336538,
+                2.0,
+                0.99495192,
+                0.71382212,
+                2.0,
+                0.97978365,
+                0.75096154,
+                0.0,
+                0.87086538,
+                0.7909375,
+                2.0,
+            ],
+            [
+                0.77483173,
+                0.23288462,
+                2.0,
+                0.90862981,
+                0.16939904,
+                2.0,
+                0.91990385,
+                0.19620192,
+                2.0,
+                0.78622596,
+                0.26213942,
+                2.0,
+            ],
+            [
+                0.07838942,
+                0.40788462,
+                2.0,
+                0.12990385,
+                0.59675481,
+                2.0,
+                0.10711538,
+                0.60266827,
+                2.0,
+                0.05271635,
+                0.41540865,
+                2.0,
+            ],
+            [
+                0.03276442,
+                0.38091346,
+                2.0,
+                0.08644231,
+                0.5690625,
+                2.0,
+                0.06149038,
+                0.57569712,
+                2.0,
+                0.00709135,
+                0.3884375,
+                2.0,
+            ],
+            [
+                0.0,
+                0.39269231,
+                0.0,
+                0.01310096,
+                0.5846875,
+                2.0,
+                0.0,
+                0.58747596,
+                0.0,
+                0.0,
+                0.40019231,
+                0.0,
+            ],
+            [
+                0.06036058,
+                0.23735577,
+                2.0,
+                0.0,
+                0.25528846,
+                0.0,
+                0.0,
+                0.23185096,
+                0.0,
+                0.05483173,
+                0.21627404,
+                2.0,
+            ],
+            [
+                0.09098558,
+                0.72336538,
+                2.0,
+                0.14283654,
+                0.90288462,
+                2.0,
+                0.12247596,
+                0.91052885,
+                2.0,
+                0.06740385,
+                0.72949519,
+                2.0,
+            ],
+            [
+                0.04668269,
+                0.18875,
+                2.0,
+                0.0,
+                0.20668269,
+                0.0,
+                0.0,
+                0.18322115,
+                0.0,
+                0.04115385,
+                0.16766827,
+                2.0,
+            ],
+            [
+                0.02704327,
+                0.14060096,
+                2.0,
+                0.0,
+                0.15853365,
+                0.0,
+                0.0,
+                0.13507212,
+                0.0,
+                0.02149038,
+                0.11951923,
+                0.0,
+            ],
+            [
+                0.41819712,
+                0.90716346,
+                2.0,
+                0.45608173,
+                0.89471154,
+                2.0,
+                0.47170673,
+                0.94043269,
+                2.0,
+                0.43572115,
+                0.95435096,
+                2.0,
+            ],
+        ]
+    )
+
+    bboxes_before = np.array(
+        [
+            [0.0, 0.41100962, 0.61091346, 0.09100962, 0.05211538],
+            [0.0, 0.86091346, 0.71382212, 0.13403846, 0.07711538],
+            [0.0, 0.77483173, 0.16939904, 0.14507212, 0.09274038],
+            [0.0, 0.05271635, 0.40788462, 0.0771875, 0.19478365],
+            [0.0, 0.00709135, 0.38091346, 0.07935096, 0.19478365],
+            [0.0, 0.0, 0.39269231, 0.01310096, 0.19478365],
+            [0.0, 0.0, 0.21627404, 0.06036058, 0.03901442],
+            [0.0, 0.06740385, 0.72336538, 0.07543269, 0.18716346],
+            [0.0, 0.0, 0.16766827, 0.04668269, 0.03901442],
+            [0.0, 0.0, 0.11951923, 0.02704327, 0.03901442],
+            [0.0, 0.41819712, 0.89471154, 0.05350962, 0.05963942],
+        ]
+    )
+
+    def generator():
+        num_samples = len(keypoints_before)
+        for i in range(num_samples):
+            img = create_image(i, tempdir)
+            keypoints_list = keypoints_before[i].tolist()
+            bbox_list = bboxes_before[i].tolist()
+
+            keypoints_split = [
+                [x, y, int(visibility)]
+                for x, y, visibility in (
+                    keypoints_list[j : j + 3]
+                    for j in range(0, len(keypoints_list), 3)
+                )
+            ]
+
+            yield {
+                "file": img,
+                "annotation": {
+                    "class": "dog",
+                    "boundingbox": {
+                        "x": bbox_list[1],
+                        "y": bbox_list[2],
+                        "w": bbox_list[3],
+                        "h": bbox_list[4],
+                    },
+                    "keypoints": {"keypoints": keypoints_split},
+                },
+            }
+
+    dataset = LuxonisDataset(
+        "test_edge_cases",
+        delete_existing=True,
+        delete_remote=True,
+        bucket_storage=BucketStorage.LOCAL,
+    ).add(generator())
+
+    dataset.make_splits(ratios=(1, 0, 0))
+
+    augmentation_config = [
+        {
+            "name": "Mosaic4",
+            "params": {"p": 1, "out_width": 512, "out_height": 512},
+        },
+        {
+            "name": "Rotate",
+            "params": {
+                "limit": 10,
+                "p": 1,
+                "border_mode": 0,
+                "value": [0, 0, 0],
+            },
+        },
+        {
+            "name": "Perspective",
+            "params": {
+                "scale": [0.02, 0.05],
+                "keep_size": True,
+                "pad_mode": 0,
+                "pad_val": 0,
+                "mask_pad_val": 0,
+                "fit_output": False,
+                "interpolation": 1,
+                "always_apply": False,
+                "p": 1,
+            },
+        },
+        {
+            "name": "Affine",
+            "params": {
+                "scale": 1.0,
+                "translate_percent": 0.0,
+                "rotate": 0,
+                "shear": 5,
+                "interpolation": 1,
+                "mask_interpolation": 0,
+                "cval": 0,
+                "cval_mask": 0,
+                "mode": 0,
+                "fit_output": False,
+                "keep_ratio": False,
+                "rotate_method": "largest_box",
+                "always_apply": False,
+                "p": 1,
+            },
+        },
+    ]
+
+    loader = LuxonisLoader(
+        dataset,
+        view="train",
+        augmentation_config=augmentation_config,
+        height=512,
+        width=512,
+    )
+    for _ in range(20):
+        for batch in loader:
+            keypoints = batch[1]["/keypoints"]
+            bboxes = batch[1]["/boundingbox"]
+            keypoints = keypoints.reshape(-1, 3)
+            for kp in keypoints:
+                x, y, v = kp
+                assert not (
+                    x == 0 and y == 0 and v in {1, 2}
+                ), f"Invalid keypoint detected: {kp}"
+                assert 0 <= x <= 1, f"Keypoint x out of bounds: {kp}"
+                assert 0 <= y <= 1, f"Keypoint y out of bounds: {kp}"
+
+            for bbox in bboxes:
+                _, x_min, y_min, width, height = bbox
+
+                x_max = x_min + width
+                y_max = y_min + height
+
+                assert 0 <= x_min <= 1, f"BBox x_min out of bounds: {bbox}"
+                assert 0 <= y_min <= 1, f"BBox y_min out of bounds: {bbox}"
+                assert 0 <= x_max <= 1, f"BBox x_max out of bounds: {bbox}"
+                assert 0 <= y_max <= 1, f"BBox y_max out of bounds: {bbox}"
+
+                bbox_area = width * height
+                assert (
+                    bbox_area > 0.0004
+                ), f"BBox area too small: {bbox}, area={bbox_area}"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
We've introduced a bounding-box area threshold (`area_threshold = 0.0001`) to remove very small/invalid bounding boxes and their corresponding keypoints. We also added edge-case handling for keypoints.

## Specification
<!-- Briefly describe what’s changing and any relevant details. -->

- **Filtering**: `postprocess_bboxes` now excludes boxes with `width * height < 0.0001`.
- **Keypoint Indexing**: `postprocess_keypoints` discards keypoints for excluded boxes and clamps out-of-bounds coordinates setting the visibility to 0.
## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? -->

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. -->

## Testing & Validation
<!-- How was this tested? Include relevant test results. -->
Before:
- Keypoints appear at (0,0) with v > 0.
- Minimal-area bounding boxes remain
- Out-of-range keypoints have visibility=2
<img src="https://github.com/user-attachments/assets/0db11f76-e89f-48d4-9e88-bec06cfd17e8" alt="Before" width="300">


After 
<img src="https://github.com/user-attachments/assets/2a31341f-2593-4059-8bb0-67e448441cff" alt="After" width="300">


