### PR TITLE
Removed `numpy` dependency in `luxonis_ml.typing`

### DIFF
--- a/luxonis_ml/__init__.py
+++ b/luxonis_ml/__init__.py
@@ -1,7 +1,10 @@
 __version__ = "0.6.0"
 
-from .utils.environ import environ
-from .utils.logging import setup_logging
+from contextlib import suppress
 
-if not environ.LUXONISML_DISABLE_SETUP_LOGGING:
-    setup_logging()
+with suppress(ImportError):
+    from .utils.environ import environ
+    from .utils.logging import setup_logging
+
+    if not environ.LUXONISML_DISABLE_SETUP_LOGGING:
+        setup_logging()

--- a/luxonis_ml/__init__.py
+++ b/luxonis_ml/__init__.py
@@ -1,10 +1,7 @@
 __version__ = "0.6.0"
 
-from contextlib import suppress
+from .utils.environ import environ
+from .utils.logging import setup_logging
 
-with suppress(ImportError):
-    from .utils.environ import environ
-    from .utils.logging import setup_logging
-
-    if not environ.LUXONISML_DISABLE_SETUP_LOGGING:
-        setup_logging()
+if not environ.LUXONISML_DISABLE_SETUP_LOGGING:
+    setup_logging()

--- a/luxonis_ml/typing.py
+++ b/luxonis_ml/typing.py
@@ -1,9 +1,14 @@
+from contextlib import suppress
 from pathlib import Path, PurePosixPath
 from typing import Dict, Literal, Tuple, Union
 
-import numpy as np
 from pydantic import BaseModel, JsonValue
 from typing_extensions import TypeAlias
+
+# When used without installed dependencies
+with suppress(ImportError):
+    import numpy as np
+
 
 PathType: TypeAlias = Union[str, Path]
 """A string or a `pathlib.Path` object."""
@@ -22,11 +27,11 @@ TaskType: TypeAlias = Literal[
 ]
 
 
-Labels: TypeAlias = Dict[str, np.ndarray]
+Labels: TypeAlias = Dict[str, "np.ndarray"]
 """Dictionary mappping task names to the annotations as C{np.ndarray}"""
 
 
-LoaderOutput: TypeAlias = Tuple[np.ndarray, Labels]
+LoaderOutput: TypeAlias = Tuple["np.ndarray", Labels]
 """C{LoaderOutput} is a tuple of an image as a C{np.ndarray} and a
 dictionary of task group names and their annotations as
 L{Annotations}."""


### PR DESCRIPTION
## Purpose
Helps to reduce dependencies in situations where we don't want to install the full set

## Specification
- Removed explicit dependency on `numpy` in `luxonis_ml.typing`
- This makes it possible to use with `luxonis-train` installed without dependencies

## Dependencies & Potential Impact
- No new dependencies introduced
- No breaking changes expected
