### PR TITLE
Sort classes alphabetically

### DIFF
--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -12,6 +12,7 @@ with guard_missing_extra("data"):
         LuxonisComponent,
         LuxonisDataset,
         LuxonisSource,
+        Metadata,
         UpdateMode,
     )
     from .loaders import LOADERS_REGISTRY, BaseLoader, LuxonisLoader
@@ -45,6 +46,7 @@ __all__ = [
     "DatasetIterator",
     "DATASETS_REGISTRY",
     "Category",
+    "Metadata",
     "LOADERS_REGISTRY",
     "ImageType",
     "LuxonisComponent",

--- a/luxonis_ml/data/datasets/__init__.py
+++ b/luxonis_ml/data/datasets/__init__.py
@@ -10,6 +10,7 @@ from .annotation import (
 )
 from .base_dataset import DATASETS_REGISTRY, BaseDataset, DatasetIterator
 from .luxonis_dataset import LuxonisDataset, UpdateMode
+from .metadata import Metadata
 from .source import LuxonisComponent, LuxonisSource
 
 __all__ = [
@@ -28,4 +29,5 @@ __all__ = [
     "Detection",
     "ArrayAnnotation",
     "UpdateMode",
+    "Metadata",
 ]

--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -80,8 +80,8 @@ class BaseDataset(
         @param classes: Either a list of class names or a dictionary
             mapping class names to class IDs. If list is provided, the
             class IDs will be assigned I{alphabetically} starting from
-            0. If the class names contain the class C{"background"}, it
-            will be assigned the class ID 0.
+            C{0}. If the class names contain the class C{"background"},
+            it will be assigned the class ID C{0}.
         @type task: Optional[str]
         @param task: Optionally specify the task where these classes
             apply.

--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -1,5 +1,14 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union
+from typing import (
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 from semver.version import Version
 from typing_extensions import TypeAlias
@@ -60,13 +69,19 @@ class BaseDataset(
 
     @abstractmethod
     def set_classes(
-        self, classes: List[str], task: Optional[str] = None
+        self,
+        classes: Union[List[str], Dict[str, int]],
+        task: Optional[str] = None,
     ) -> None:
-        """Sets the names of classes for the dataset. This can be across
-        all CV tasks or certain tasks.
+        """Sets the classes for the dataset. This can be across all CV
+        tasks or certain tasks.
 
-        @type classes: List[str]
-        @param classes: List of class names to set.
+        @type classes: Union[List[str], Dict[str, int]]
+        @param classes: Either a list of class names or a dictionary
+            mapping class names to class IDs. If list is provided, the
+            class IDs will be assigned I{alphabetically} starting from
+            0. If the class names contain the class C{"background"}, it
+            will be assigned the class ID 0.
         @type task: Optional[str]
         @param task: Optionally specify the task where these classes
             apply.

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -655,9 +655,9 @@ class LuxonisDataset(BaseDataset):
             )
             metadata_json = json.loads(path.read_text())
             version = Version.parse(metadata_json.get("ldf_version", "1.0.0"))
-            if version == LDF_VERSION:
-                return Metadata(**metadata_json)
-            return self._migrate_metadata(metadata_json)
+            if version != LDF_VERSION:  # pragma: no cover
+                return self._migrate_metadata(metadata_json)
+            return Metadata(**metadata_json)
         else:
             return Metadata(
                 source=LuxonisSource(),

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1030,20 +1030,9 @@ class LuxonisDataset(BaseDataset):
                 logger.info(
                     f"Detected new classes for task {task}: {new_classes}"
                 )
-                all_class_names = classes | old_classes
-                has_background = "background" in all_class_names
-                all_class_names -= {"background"}
-                all_class_names = sorted(all_class_names)
-                if has_background:
-                    all_class_names.insert(0, "background")
 
-                self.set_classes(
-                    {
-                        class_name: i
-                        for i, class_name in enumerate(all_class_names)
-                    },
-                    task=task,
-                )
+                self.set_classes(list(classes | old_classes), task=task)
+
         for task, num_kpts in num_kpts_per_task.items():
             self.set_skeletons(
                 labels=[str(i) for i in range(num_kpts)],

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -489,7 +489,7 @@ class LuxonisDataset(BaseDataset):
 
         if not attempt_migration or self.version == LDF_VERSION or df is None:
             return df
-        return migrate_dataframe(df)
+        return migrate_dataframe(df)  # pragma: no cover
 
     @overload
     def _get_file_index(

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -18,9 +18,7 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    TypedDict,
     Union,
-    cast,
     overload,
 )
 
@@ -29,7 +27,6 @@ import polars as pl
 import pyarrow.parquet as pq
 from filelock import FileLock
 from loguru import logger
-from ordered_set import OrderedSet
 from semver.version import Version
 from typing_extensions import Self, override
 
@@ -52,41 +49,14 @@ from luxonis_ml.utils import (
 
 from .annotation import Category, DatasetRecord
 from .base_dataset import BaseDataset, DatasetIterator
+from .metadata import Metadata
+from .migration import (
+    LDF_1_0_0_TASK_TYPES,
+    LDF_1_0_0_TASKS,
+    LDF_1_0_0_MetadataDict,
+)
 from .source import LuxonisSource
 from .utils import find_filepath_uuid, get_dir, get_file
-
-LDF_1_0_0_TASKS = {
-    "classification",
-    "segmentation",
-    "boundingbox",
-    "keypoints",
-    "array",
-}
-
-LDF_1_0_0_TASK_TYPES = {
-    "BBoxAnnotation": "boundingbox",
-    "ClassificationAnnotation": "classification",
-    "PolylineSegmentationAnnotation": "segmentation",
-    "RLESegmentationAnnotation": "segmentation",
-    "MaskSegmentationAnnotation": "segmentation",
-    "KeypointAnnotation": "keypoints",
-    "ArrayAnnotation": "array",
-}
-
-
-class Skeletons(TypedDict):
-    labels: List[str]
-    edges: List[Tuple[int, int]]
-
-
-class Metadata(TypedDict):
-    source: LuxonisSource.LuxonisSourceDocument
-    ldf_version: str
-    classes: Dict[str, List[str]]
-    tasks: Dict[str, List[str]]
-    skeletons: Dict[str, Skeletons]
-    categorical_encodings: Dict[str, Dict[str, int]]
-    metadata_types: Dict[str, Literal["float", "int", "str", "Category"]]
 
 
 class LuxonisDataset(BaseDataset):
@@ -141,12 +111,9 @@ class LuxonisDataset(BaseDataset):
         self.team_id = team_id or self._get_credential("LUXONISML_TEAM_ID")
 
         if delete_existing:
-            if LuxonisDataset.exists(
-                dataset_name, team_id, bucket_storage, self.bucket
-            ):
-                LuxonisDataset(
-                    dataset_name, team_id, bucket_type, bucket_storage
-                ).delete_dataset(delete_remote=delete_remote)
+            self._init_paths()
+            if self.exists(dataset_name, team_id, bucket_storage, self.bucket):
+                self.delete_dataset(delete_remote=delete_remote)
 
         self._init_paths()
 
@@ -156,18 +123,16 @@ class LuxonisDataset(BaseDataset):
             self.fs = LuxonisFileSystem(self.path)
 
         _lock_metadata = self.base_path / ".metadata.lock"
-        with FileLock(
-            str(_lock_metadata)
-        ):  # DDP GCS training - multiple processes
-            self._metadata = cast(
-                Metadata, defaultdict(dict, self._get_metadata())
-            )
+
+        # For DDP GCS training - multiple processes
+        with FileLock(str(_lock_metadata)):
+            self._metadata = self._get_metadata()
 
         if self.version != LDF_VERSION:
             logger.warning(
                 f"LDF versions do not match. The current `luxonis-ml` "
                 f"installation supports LDF v{LDF_VERSION}, but the "
-                f"`{self.identifier}` dataset is in v{self._metadata['ldf_version']}. "
+                f"`{self.identifier}` dataset is in v{self._metadata.ldf_version}. "
                 "Internal migration will be performed. Note that some parts "
                 "and new features might not work correctly unless you "
                 "manually re-create the dataset using the latest version "
@@ -177,12 +142,12 @@ class LuxonisDataset(BaseDataset):
 
     @property
     def metadata(self) -> Metadata:
-        """Returns the metadata of the dataset.
+        """Returns a copy of the dataset metadata.
 
-        The metadata is a dictionary containing the following keys:
+        The metadata is a pydantic model with the following fields:
             - source: L{LuxonisSource}
             - ldf_version: str
-            - classes: Dict[task_name, List[class_name]]
+            - classes: Dict[task_name, Dict[class_name, class_id]]
             - tasks: Dict[task_name, List[task_type]]
             - skeletons: Dict[task_name, Skeletons]
               - Skeletons is a dictionary with keys 'labels' and 'edges'
@@ -206,14 +171,14 @@ class LuxonisDataset(BaseDataset):
     @cached_property
     def version(self) -> Version:
         return Version.parse(
-            self._metadata["ldf_version"], optional_minor_and_patch=True
+            self._metadata.ldf_version, optional_minor_and_patch=True
         )
 
     @property
     def source(self) -> LuxonisSource:
-        if "source" not in self._metadata:
+        if self._metadata.source is None:
             raise ValueError("Source not found in metadata")
-        return LuxonisSource.from_document(self._metadata["source"])
+        return self._metadata.source
 
     @property
     @override
@@ -301,27 +266,7 @@ class LuxonisDataset(BaseDataset):
 
     def _merge_metadata_with(self, other: "LuxonisDataset") -> None:
         """Merges relevant metadata from `other` into `self`."""
-        for key, value in other._metadata.items():
-            if key not in self._metadata:
-                self._metadata[key] = value
-            else:
-                existing_val = self._metadata[key]
-
-                if isinstance(existing_val, dict) and isinstance(value, dict):
-                    if key == "classes":
-                        for task_name, class_list in value.items():
-                            if task_name not in existing_val:
-                                existing_val[task_name] = class_list
-                            else:
-                                existing_val[task_name] = list(
-                                    set(existing_val[task_name]).union(
-                                        class_list
-                                    )
-                                )
-                    else:
-                        existing_val.update(value)
-                else:
-                    self._metadata[key] = value
+        self._metadata = self._metadata.merge_with(other._metadata)
         self._write_metadata()
 
     def clone(
@@ -357,15 +302,15 @@ class LuxonisDataset(BaseDataset):
         )
 
         new_dataset._init_paths()
-        new_dataset._metadata = defaultdict(dict, self._get_metadata())
+        new_dataset._metadata = self._get_metadata()
 
-        new_dataset._metadata["original_dataset"] = self.dataset_name
+        new_dataset._metadata.parent_dataset = self.dataset_name
 
         if self.is_remote and push_to_cloud:
             new_dataset.sync_to_cloud()
 
         path = self.metadata_path / "metadata.json"
-        path.write_text(json.dumps(self._metadata, indent=4))
+        path.write_text(self._metadata.model_dump_json(indent=4))
 
         return new_dataset
 
@@ -674,7 +619,7 @@ class LuxonisDataset(BaseDataset):
 
     def _write_metadata(self) -> None:
         path = self.metadata_path / "metadata.json"
-        path.write_text(json.dumps(self._metadata, indent=4))
+        path.write_text(self._metadata.model_dump_json(indent=4))
         with suppress(shutil.SameFileError):
             self.fs.put_file(path, "metadata/metadata.json")
 
@@ -708,49 +653,58 @@ class LuxonisDataset(BaseDataset):
                 self.metadata_path,
                 default=self.metadata_path / "metadata.json",
             )
-            metadata = json.loads(path.read_text())
-            version = Version.parse(metadata.get("ldf_version", "1.0.0"))
-            if version != LDF_VERSION:  # pragma: no cover
-                metadata = self._migrate_metadata(metadata)
-            return metadata
+            metadata_json = json.loads(path.read_text())
+            version = Version.parse(metadata_json.get("ldf_version", "1.0.0"))
+            if version == LDF_VERSION:
+                return Metadata(**metadata_json)
+            return self._migrate_metadata(metadata_json)
         else:
-            return {
-                "source": LuxonisSource().to_document(),
-                "ldf_version": str(LDF_VERSION),
-                "classes": {},
-                "tasks": {},
-                "skeletons": {},
-                "categorical_encodings": {},
-                "metadata_types": {},
-            }
+            return Metadata(
+                source=LuxonisSource(),
+                ldf_version=str(LDF_VERSION),
+                classes={},
+                tasks={},
+                skeletons={},
+                categorical_encodings={},
+                metadata_types={},
+            )
 
     def _migrate_metadata(
-        self, metadata: Metadata
+        self, metadata: LDF_1_0_0_MetadataDict
     ) -> Metadata:  # pragma: no cover
+        new_metadata = {}
         old_classes = metadata["classes"]
         if set(old_classes.keys()) <= LDF_1_0_0_TASKS:
-            metadata["classes"] = {
-                "detection": next(iter(old_classes.values()))
+            old_class_names = next(iter(old_classes.values()))
+            new_metadata["classes"] = {
+                "detection": {
+                    class_name: i
+                    for i, class_name in enumerate(old_class_names)
+                }
             }
-            metadata["tasks"] = {"detection": list(old_classes.keys())}
+            new_metadata["tasks"] = {"detection": list(old_classes.keys())}
         else:
             df = self._load_df_offline(lazy=True, attempt_migration=False)
             if df is None:
                 raise ValueError("Cannot migrate when the dataset is empty")
             tasks_df = df.select(["task", "type"]).unique().collect()
-            new_classes = defaultdict(list)
+            new_classes = defaultdict(dict)
             tasks = defaultdict(list)
             for task_name, task_type in tasks_df.iter_rows():
                 new_task_name = task_name
                 if task_name in LDF_1_0_0_TASKS:
                     new_task_name = "detection"
                 tasks[new_task_name].append(LDF_1_0_0_TASK_TYPES[task_type])
-                new_classes[new_task_name].extend(
-                    old_classes.get(task_name, [])
+                old_class_names = old_classes.get(task_name, [])
+                new_classes[new_task_name].update(
+                    {
+                        class_name: i
+                        for i, class_name in enumerate(old_class_names)
+                    }
                 )
-            metadata["classes"] = dict(new_classes)
-            metadata["tasks"] = dict(tasks)
-        return metadata
+            new_metadata["classes"] = dict(new_classes)
+            new_metadata["tasks"] = dict(tasks)
+        return Metadata(**new_metadata)
 
     @property
     def is_remote(self) -> bool:
@@ -765,12 +719,14 @@ class LuxonisDataset(BaseDataset):
         @param source: The new C{LuxonisSource} to replace the old one.
         """
 
-        self._metadata["source"] = source.to_document()
+        self._metadata.source = source
         self._write_metadata()
 
     @override
     def set_classes(
-        self, classes: List[str], task: Optional[str] = None
+        self,
+        classes: Union[List[str], Dict[str, int]],
+        task: Optional[str] = None,
     ) -> None:
         if task is None:
             tasks = self.get_task_names()
@@ -778,12 +734,28 @@ class LuxonisDataset(BaseDataset):
             tasks = [task]
 
         for task in tasks:
-            self._metadata["classes"][task] = classes
+            self._metadata.set_classes(classes, task)
+
         self._write_metadata()
 
     @override
-    def get_classes(self) -> Dict[str, List[str]]:
-        return self._metadata["classes"]
+    def get_classes(self) -> Dict[str, Dict[str, int]]:
+        """Returns a bi-directional mapping of classes to class ids for
+        each task.
+
+        @type: Dict[str, Dict[str, int]]
+        """
+        return self._metadata.classes
+
+    def get_class_names(self) -> Dict[str, List[str]]:
+        """Returns a dictionary mapping task names to class names.
+
+        @rtype: Dict[str, List[str]]
+        """
+        return {
+            task: list(classes.keys())
+            for task, classes in self._metadata.classes.items()
+        }
 
     @override
     def set_skeletons(
@@ -800,7 +772,7 @@ class LuxonisDataset(BaseDataset):
         else:
             tasks = [task]
         for task in tasks:
-            self._metadata["skeletons"][task] = {
+            self._metadata.skeletons[task] = {
                 "labels": labels or [],
                 "edges": edges or [],
             }
@@ -812,22 +784,22 @@ class LuxonisDataset(BaseDataset):
     ) -> Dict[str, Tuple[List[str], List[Tuple[int, int]]]]:
         return {
             task: (skel["labels"], skel["edges"])
-            for task, skel in self._metadata["skeletons"].items()
+            for task, skel in self._metadata.skeletons.items()
         }
 
     @override
     def get_tasks(self) -> Dict[str, List[str]]:
-        return self._metadata["tasks"]
+        return self._metadata.tasks
 
     def get_categorical_encodings(
         self,
     ) -> Dict[str, Dict[str, int]]:
-        return self._metadata["categorical_encodings"]
+        return self._metadata.categorical_encodings
 
     def get_metadata_types(
         self,
     ) -> Dict[str, Literal["float", "int", "str", "Category"]]:
-        return self._metadata["metadata_types"]
+        return self._metadata.metadata_types
 
     def sync_from_cloud(
         self, update_mode: UpdateMode = UpdateMode.IF_EMPTY
@@ -990,9 +962,7 @@ class LuxonisDataset(BaseDataset):
 
         data_batch: list[DatasetRecord] = []
 
-        classes_per_task: Dict[str, OrderedSet[str]] = defaultdict(
-            lambda: OrderedSet([])
-        )
+        classes_per_task: Dict[str, Set[str]] = defaultdict(set)
         categorical_encodings = defaultdict(dict)
         metadata_types = {}
         num_kpts_per_task: Dict[str, int] = {}
@@ -1020,7 +990,7 @@ class LuxonisDataset(BaseDataset):
                     if ann.class_name is not None:
                         classes_per_task[record.task].add(ann.class_name)
                     else:
-                        classes_per_task[record.task] = OrderedSet([])
+                        classes_per_task[record.task] = set()
                     if ann.keypoints is not None:
                         num_kpts_per_task[record.task] = len(
                             ann.keypoints.keypoints
@@ -1070,7 +1040,20 @@ class LuxonisDataset(BaseDataset):
                 logger.info(
                     f"Detected new classes for task {task}: {new_classes}"
                 )
-                self.set_classes(list(classes | old_classes), task)
+                all_class_names = classes | old_classes
+                has_background = "background" in all_class_names
+                all_class_names -= {"background"}
+                all_class_names = sorted(all_class_names)
+                if has_background:
+                    all_class_names.insert(0, "background")
+
+                self.set_classes(
+                    {
+                        class_name: i
+                        for i, class_name in enumerate(all_class_names)
+                    },
+                    task=task,
+                )
         for task, num_kpts in num_kpts_per_task.items():
             self.set_skeletons(
                 labels=[str(i) for i in range(num_kpts)],
@@ -1078,8 +1061,8 @@ class LuxonisDataset(BaseDataset):
                 task=task,
             )
 
-        self._metadata["categorical_encodings"] = dict(categorical_encodings)
-        self._metadata["metadata_types"] = metadata_types
+        self._metadata.categorical_encodings = dict(categorical_encodings)
+        self._metadata.metadata_types = metadata_types
 
         with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
             self._write_index(index, new_index, path=tmp_file.name)
@@ -1102,7 +1085,7 @@ class LuxonisDataset(BaseDataset):
             .iter_rows()
         ):
             tasks[task_name].append(task_type)
-        self._metadata["tasks"] = tasks
+        self._metadata.tasks = tasks
         self._write_metadata()
 
     def _warn_on_duplicates(self) -> None:

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -747,16 +747,6 @@ class LuxonisDataset(BaseDataset):
         """
         return self._metadata.classes
 
-    def get_class_names(self) -> Dict[str, List[str]]:
-        """Returns a dictionary mapping task names to class names.
-
-        @rtype: Dict[str, List[str]]
-        """
-        return {
-            task: list(classes.keys())
-            for task, classes in self._metadata.classes.items()
-        }
-
     @override
     def set_skeletons(
         self,

--- a/luxonis_ml/data/datasets/metadata.py
+++ b/luxonis_ml/data/datasets/metadata.py
@@ -35,7 +35,7 @@ class Metadata(BaseModelExtraForbid):
 
     def merge_with(self, other: "Metadata") -> "Metadata":
         """Merge two metadata objects together."""
-        if self.ldf_version != other.ldf_version:
+        if self.ldf_version != other.ldf_version:  # pragma: no cover
             raise ValueError(
                 "Cannot merge metadata with different LDF versions"
             )

--- a/luxonis_ml/data/datasets/metadata.py
+++ b/luxonis_ml/data/datasets/metadata.py
@@ -1,0 +1,113 @@
+from typing import Dict, Iterable, List, Literal, Optional, Tuple, Union
+
+from typing_extensions import TypedDict
+
+from luxonis_ml.utils.pydantic_utils import BaseModelExtraForbid
+
+from .source import LuxonisSource
+
+
+class Skeletons(TypedDict):
+    labels: List[str]
+    edges: List[Tuple[int, int]]
+
+
+class Metadata(BaseModelExtraForbid):
+    source: Optional[LuxonisSource]
+    ldf_version: str
+    classes: Dict[str, Dict[str, int]]
+    tasks: Dict[str, List[str]]
+    skeletons: Dict[str, Skeletons]
+    categorical_encodings: Dict[str, Dict[str, int]]
+    metadata_types: Dict[str, Literal["float", "int", "str", "Category"]]
+    parent_dataset: Optional[str] = None
+
+    def set_classes(
+        self, classes: Union[List[str], Dict[str, int]], task: str
+    ) -> None:
+        if isinstance(classes, list):
+            self.classes[task] = {
+                class_name: i
+                for i, class_name in enumerate(self._sort_classes(classes))
+            }
+        else:
+            self.classes[task] = classes
+
+    def merge_with(self, other: "Metadata") -> "Metadata":
+        """Merge two metadata objects together."""
+        if self.ldf_version != other.ldf_version:
+            raise ValueError(
+                "Cannot merge metadata with different LDF versions"
+            )
+
+        merged_classes = {}
+        for key in set(self.classes) | set(other.classes):
+            if key in self.classes and key in other.classes:
+                all_classes = self._sort_classes(
+                    set(self.classes[key]) | set(other.classes[key])
+                )
+                merged_classes[key] = {
+                    class_name: i for i, class_name in enumerate(all_classes)
+                }
+            elif key in self.classes:
+                merged_classes[key] = self.classes[key]
+            else:
+                merged_classes[key] = other.classes[key]
+
+        merged_tasks = {}
+        for key in set(self.tasks) | set(other.tasks):
+            if key in self.tasks and key in other.tasks:
+                merged_tasks[key] = list(
+                    set(self.tasks[key] + other.tasks[key])
+                )
+            elif key in self.tasks:
+                merged_tasks[key] = self.tasks[key]
+            else:
+                merged_tasks[key] = other.tasks[key]
+
+        merged_skeletons = {**self.skeletons, **other.skeletons}
+
+        merged_categorical_encodings = {}
+        for key in set(self.categorical_encodings) | set(
+            other.categorical_encodings
+        ):
+            if (
+                key in self.categorical_encodings
+                and key in other.categorical_encodings
+            ):
+                merged_inner = self.categorical_encodings[key].copy()
+                merged_inner.update(other.categorical_encodings[key])
+                merged_categorical_encodings[key] = merged_inner
+            elif key in self.categorical_encodings:
+                merged_categorical_encodings[key] = self.categorical_encodings[
+                    key
+                ]
+            else:
+                merged_categorical_encodings[key] = (
+                    other.categorical_encodings[key]
+                )
+
+        merged_metadata_types = {**self.metadata_types, **other.metadata_types}
+        if self.source is None and other.source is not None:
+            merged_source = other.source
+        elif self.source is not None and other.source is None:
+            merged_source = self.source
+        elif self.source is not None and other.source is not None:
+            merged_source = self.source.merge_with(other.source)
+        else:
+            merged_source = None
+
+        return Metadata(
+            ldf_version=self.ldf_version,
+            source=merged_source,
+            classes=merged_classes,
+            tasks=merged_tasks,
+            skeletons=merged_skeletons,
+            categorical_encodings=merged_categorical_encodings,
+            metadata_types=merged_metadata_types,  # type: ignore
+        )
+
+    def _sort_classes(self, classes: Iterable[str]) -> List[str]:
+        return sorted(
+            classes, key=lambda x: 0 if x == "background" else (1, x)
+        )

--- a/luxonis_ml/data/datasets/metadata.py
+++ b/luxonis_ml/data/datasets/metadata.py
@@ -109,5 +109,5 @@ class Metadata(BaseModelExtraForbid):
 
     def _sort_classes(self, classes: Iterable[str]) -> List[str]:
         return sorted(
-            classes, key=lambda x: 0 if x == "background" else (1, x)
+            classes, key=lambda x: (0, "") if x == "background" else (1, x)
         )

--- a/luxonis_ml/data/datasets/metadata.py
+++ b/luxonis_ml/data/datasets/metadata.py
@@ -109,5 +109,6 @@ class Metadata(BaseModelExtraForbid):
 
     def _sort_classes(self, classes: Iterable[str]) -> List[str]:
         return sorted(
-            classes, key=lambda x: (0, "") if x == "background" else (1, x)
+            classes,
+            key=lambda x: (0, "") if x == "background" else (1, x.lower()),
         )

--- a/luxonis_ml/data/datasets/migration.py
+++ b/luxonis_ml/data/datasets/migration.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, Final, List, Literal, Set
+
+from typing_extensions import TypedDict
+
+from .metadata import Skeletons
+
+LDF_1_0_0_TASKS: Final[Set[str]] = {
+    "classification",
+    "segmentation",
+    "boundingbox",
+    "keypoints",
+    "array",
+}
+
+LDF_1_0_0_TASK_TYPES: Final[Dict[str, str]] = {
+    "BBoxAnnotation": "boundingbox",
+    "ClassificationAnnotation": "classification",
+    "PolylineSegmentationAnnotation": "segmentation",
+    "RLESegmentationAnnotation": "segmentation",
+    "MaskSegmentationAnnotation": "segmentation",
+    "KeypointAnnotation": "keypoints",
+    "ArrayAnnotation": "array",
+}
+
+
+class LDF_1_0_0_MetadataDict(TypedDict):
+    source: Dict[str, Any]
+    ldf_version: str
+    classes: Dict[str, List[str]]
+    tasks: Dict[str, List[str]]
+    skeletons: Dict[str, Skeletons]
+    categorical_encodings: Dict[str, Dict[str, int]]
+    metadata_types: Dict[str, Literal["float", "int", "str", "Category"]]

--- a/luxonis_ml/data/datasets/migration.py
+++ b/luxonis_ml/data/datasets/migration.py
@@ -1,8 +1,20 @@
-from typing import Any, Dict, Final, List, Literal, Set
+from collections import defaultdict
+from typing import (
+    Any,
+    Dict,
+    Final,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Union,
+    overload,
+)
 
+import polars as pl
 from typing_extensions import TypedDict
 
-from .metadata import Skeletons
+from .metadata import Metadata, Skeletons
 
 LDF_1_0_0_TASKS: Final[Set[str]] = {
     "classification",
@@ -31,3 +43,93 @@ class LDF_1_0_0_MetadataDict(TypedDict):
     skeletons: Dict[str, Skeletons]
     categorical_encodings: Dict[str, Dict[str, int]]
     metadata_types: Dict[str, Literal["float", "int", "str", "Category"]]
+
+
+@overload
+def migrate_dataframe(df: pl.LazyFrame) -> pl.LazyFrame: ...
+
+
+@overload
+def migrate_dataframe(df: pl.DataFrame) -> pl.DataFrame: ...
+
+
+def migrate_dataframe(
+    df: Union[pl.LazyFrame, pl.DataFrame],
+) -> Union[pl.LazyFrame, pl.DataFrame]:  # pragma: no cover
+    return (
+        df.rename({"class": "class_name"})
+        .with_columns(
+            pl.when(pl.col("task").is_in(LDF_1_0_0_TASKS))
+            .then(pl.lit("detection"))
+            .otherwise(pl.col("task"))
+            .alias("task_name")
+        )
+        .with_columns(
+            pl.when(pl.col("type") == "BBoxAnnotation")
+            .then(pl.lit("boundingbox"))
+            .when(pl.col("type") == "ClassificationAnnotation")
+            .then(pl.lit("classification"))
+            .when(
+                pl.col("type").is_in(
+                    [
+                        "PolylineSegmentationAnnotation",
+                        "RLESegmentationAnnotation",
+                        "MaskSegmentationAnnotation",
+                    ]
+                )
+            )
+            .then(pl.lit("segmentation"))
+            .when(pl.col("type") == "KeypointAnnotation")
+            .then(pl.lit("keypoints"))
+            .when(pl.col("type") == "ArrayAnnotation")
+            .then(pl.lit("array"))
+            .otherwise(pl.col("type"))
+            .alias("task_type")
+        )
+        .with_columns(pl.lit("image").alias("source_name"))
+        .select(
+            [
+                "file",
+                "source_name",
+                "task_name",
+                "class_name",
+                "instance_id",
+                "task_type",
+                "annotation",
+                "uuid",
+            ]
+        )
+    )
+
+
+def migrate_metadata(
+    metadata: LDF_1_0_0_MetadataDict, df: Optional[pl.LazyFrame]
+) -> Metadata:  # pragma: no cover
+    new_metadata = {}
+    old_classes = metadata["classes"]
+    if set(old_classes.keys()) <= LDF_1_0_0_TASKS:
+        old_class_names = next(iter(old_classes.values()))
+        new_metadata["classes"] = {
+            "detection": {
+                class_name: i for i, class_name in enumerate(old_class_names)
+            }
+        }
+        new_metadata["tasks"] = {"detection": list(old_classes.keys())}
+    else:
+        if df is None:
+            raise ValueError("Cannot migrate when the dataset is empty")
+        tasks_df = df.select(["task", "type"]).unique().collect()
+        new_classes = defaultdict(dict)
+        tasks = defaultdict(list)
+        for task_name, task_type in tasks_df.iter_rows():
+            new_task_name = task_name
+            if task_name in LDF_1_0_0_TASKS:
+                new_task_name = "detection"
+            tasks[new_task_name].append(LDF_1_0_0_TASK_TYPES[task_type])
+            old_class_names = old_classes.get(task_name, [])
+            new_classes[new_task_name].update(
+                {class_name: i for i, class_name in enumerate(old_class_names)}
+            )
+        new_metadata["classes"] = dict(new_classes)
+        new_metadata["tasks"] = dict(tasks)
+    return Metadata(**new_metadata)

--- a/luxonis_ml/data/datasets/source.py
+++ b/luxonis_ml/data/datasets/source.py
@@ -7,6 +7,18 @@ from luxonis_ml.utils import BaseModelExtraForbid
 
 
 class LuxonisComponent(BaseModelExtraForbid):
+    """Abstraction for a piece of media within a source. Most commonly,
+
+    this abstracts an image sensor.
+    @type name: str
+    @ivar name: A recognizable name for the component.
+    @type media_type: L{MediaType}
+    @ivar media_type: Enum for the type of media for the component.
+    @type image_type: L{ImageType}
+    @ivar image_type: Enum for the image type. Only used if
+        C{media_type==MediaType.IMAGE}.
+    """
+
     name: str
     media_type: MediaType = MediaType.IMAGE
     image_type: ImageType = ImageType.COLOR

--- a/luxonis_ml/data/datasets/source.py
+++ b/luxonis_ml/data/datasets/source.py
@@ -1,120 +1,55 @@
-from dataclasses import dataclass
-from typing import List, Optional, TypedDict
+from typing import Dict
 
-from ..utils.enums import ImageType, MediaType
+from pydantic import Field
+
+from luxonis_ml.data.utils import ImageType, MediaType
+from luxonis_ml.utils import BaseModelExtraForbid
 
 
-@dataclass
-class LuxonisComponent:
-    """Abstraction for a piece of media within a source. Most commonly,
-    this abstracts an image sensor.
-
-    @type name: str
-    @param name: A recognizable name for the component.
-    @type media_type: L{MediaType}
-    @param media_type: Enum for the type of media for the component.
-    @type image_type: L{ImageType}
-    @param image_type: Enum for the image type. Only used if
-        C{media_type==MediaType.IMAGE}.
-    """
-
+class LuxonisComponent(BaseModelExtraForbid):
     name: str
     media_type: MediaType = MediaType.IMAGE
     image_type: ImageType = ImageType.COLOR
 
-    class LuxonisComponentDocument(TypedDict):
-        name: str
-        media_type: str
-        image_type: str
 
-    def to_document(self) -> LuxonisComponentDocument:
-        return {
-            "name": self.name,
-            "media_type": self.media_type.value,
-            "image_type": self.image_type.value,
-        }
-
-    @classmethod
-    def from_document(
-        cls, document: LuxonisComponentDocument
-    ) -> "LuxonisComponent":
-        if document["image_type"] is not None:
-            return cls(
-                name=document["name"],
-                media_type=MediaType(document["media_type"]),
-                image_type=ImageType(document["image_type"]),
-            )
-        else:
-            return cls(
-                name=document["name"],
-                media_type=MediaType(document["media_type"]),
-            )
-
-
-class LuxonisSource:
+class LuxonisSource(BaseModelExtraForbid):
     """Abstracts the structure of a dataset and which components/media
-    are included."""
+    are included.
 
-    class LuxonisSourceDocument(TypedDict):
-        name: str
-        main_component: str
-        components: List[LuxonisComponent.LuxonisComponentDocument]
+    For example, with an U{OAK-D<https://docs.luxonis.com/projects/hardware
+    /en/latest/pages/BW1098OAK/>}, you can have a source with 4 image
+    components: C{rgb} (color), C{left} (mono), C{right} (mono), and C{depth}.
 
-    def __init__(
-        self,
-        name: str = "default",
-        components: Optional[List[LuxonisComponent]] = None,
-        main_component: Optional[str] = None,
-    ) -> None:
-        """Abstracts the structure of a dataset by grouping together
-        components.
+    @type name: str
+    @ivar name: A recognizable name for the source. Defaults to "default".
 
-        For example, with an U{OAK-D<https://docs.luxonis.com/projects/hardware
-        /en/latest/pages/BW1098OAK/>}, you can have a source with 4 image
-        components: C{rgb} (color), C{left} (mono), C{right} (mono), and C{depth}.
+    @type components: Optional[List[LuxonisComponent]]
+    @ivar components: If not using the default configuration, a list of
+    L{LuxonisComponent} to group together in the source.
 
-        @type name: str
-        @param name: A recognizable name for the source. Defaults to "default".
+    @type main_component: Optional[str]
+    @ivar main_component: The name of the component that should be
+        primarily visualized.
+    """
 
-        @type components: Optional[List[LuxonisComponent]]
-        @param components: If not using the default configuration, a list of
-        L{LuxonisComponent} to group together in the source.
+    name: str = "default"
+    components: Dict[str, LuxonisComponent] = Field(
+        default_factory=lambda: {"default": LuxonisComponent(name="default")}
+    )
+    main_component: str = "default"
 
-        @type main_component: Optional[str]
-        @param main_component: The name of the component that should be
-            primarily visualized.
+    def merge_with(self, other: "LuxonisSource") -> "LuxonisSource":
+        """Merge two sources together.
+
+        @type other: LuxonisSource
+        @param other: The other source to merge with.
+        @rtype: LuxonisSource
+        @return: A new source with the components of both sources.
         """
-
-        self.name = name
-        if components is None:
-            components = [
-                LuxonisComponent(name)
-            ]  # basic source includes a single color image
-
-        self.components = {
-            component.name: component for component in components
-        }
-        self.main_component = main_component or next(iter(self.components))
-
-    def to_document(self) -> LuxonisSourceDocument:
-        return {
-            "name": self.name,
-            "main_component": self.main_component,
-            "components": [
-                component.to_document()
-                for component in self.components.values()
-            ],
-        }
-
-    @classmethod
-    def from_document(cls, document: LuxonisSourceDocument) -> "LuxonisSource":
-        return cls(
-            name=document.get("name", "default"),
-            main_component=document.get("main_component"),
-            components=[
-                LuxonisComponent.from_document(component_doc)
-                for component_doc in document["components"]
-            ]
-            if "components" in document
-            else None,
+        components = self.components.copy()
+        components.update(other.components)
+        return LuxonisSource(
+            name=self.name,
+            components=components,
+            main_component=self.main_component,
         )

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -149,24 +149,11 @@ class LuxonisLoader(BaseLoader):
         for view in self.view:
             self.instances.extend(splits[view])
 
-        self.idx_to_df_row: list[list[int]] = []
+        self.idx_to_df_row: List[List[int]] = []
         for uuid in self.instances:
             boolean_mask = self.df["uuid"] == uuid
             row_indexes = boolean_mask.arg_true().to_list()
             self.idx_to_df_row.append(row_indexes)
-
-        self.class_mappings: Dict[str, Dict[str, int]] = {}
-        for task in self.df["task_name"].unique():
-            class_mapping = {
-                class_: i
-                for i, class_ in enumerate(
-                    sorted(
-                        self.classes.get(task, []),
-                        key=lambda x: {"background": -1}.get(x, 0),
-                    )
-                )
-            }
-            self.class_mappings[task] = class_mapping
 
         self.tasks_without_background = set()
 
@@ -174,8 +161,8 @@ class LuxonisLoader(BaseLoader):
         for task, seg_masks in task_type_iterator(test_labels, "segmentation"):
             task_name = get_task_name(task)
             if seg_masks.shape[0] > 1 and (
-                "background" not in self.class_mappings
-                or self.class_mappings[task_name]["background"] != 0
+                "background" not in self.classes[task_name]
+                or self.classes[task_name]["background"] != 0
             ):
                 unassigned_pixels = np.sum(seg_masks, axis=0) == 0
 
@@ -188,14 +175,15 @@ class LuxonisLoader(BaseLoader):
                     )
                     self.tasks_without_background.add(task)
                     if "background" not in self.classes[task_name]:
-                        self.classes[task_name].append("background")
-                        self.class_mappings[task_name] = {
-                            class_: idx + 1
-                            for class_, idx in self.class_mappings[
-                                task_name
-                            ].items()
+                        self.classes[task_name] = {
+                            "background": 0,
+                            **{
+                                class_name: i + 1
+                                for class_name, i in self.classes[
+                                    task_name
+                                ].items()
+                            },
                         }
-                        self.class_mappings[task_name]["background"] = 0
 
     @override
     def __len__(self) -> int:
@@ -276,7 +264,8 @@ class LuxonisLoader(BaseLoader):
 
         if not self.idx_to_df_row:
             raise ValueError(
-                f"No data found in dataset '{self.dataset.identifier}' for {self.view} views"
+                f"No data found in dataset '{self.dataset.identifier}' "
+                f"for {self.view} views"
             )
 
         ann_indices = self.idx_to_df_row[idx]
@@ -327,7 +316,7 @@ class LuxonisLoader(BaseLoader):
                 labels_by_task[full_task_name].append(annotation)
                 if class_name is not None:
                     class_ids_by_task[full_task_name].append(
-                        self.class_mappings[task_name][class_name]
+                        self.classes[task_name][class_name]
                     )
                 else:
                     class_ids_by_task[full_task_name].append(0)
@@ -359,7 +348,7 @@ class LuxonisLoader(BaseLoader):
             )
             if task in self.tasks_without_background:
                 unassigned_pixels = ~np.any(array, axis=0)
-                background_idx = self.class_mappings[task_name]["background"]
+                background_idx = self.classes[task_name]["background"]
                 array[background_idx, unassigned_pixels] = 1
 
             labels[task] = array

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -211,7 +211,9 @@ class COCOParser(BaseParser):
             if "keypoints" in cat.keys() and "skeleton" in cat.keys():
                 skeletons[categories[cat["id"]]] = {
                     "labels": cat["keypoints"],
-                    "edges": (np.array(cat["skeleton"]) - 1).tolist(),
+                    "edges": list(
+                        map(tuple, (np.array(cat["skeleton"]) - 1).tolist())
+                    ),
                 }
 
         def generator() -> DatasetIterator:

--- a/luxonis_ml/data/requirements.txt
+++ b/luxonis_ml/data/requirements.txt
@@ -10,3 +10,4 @@ ordered-set>=4.0.0
 semver>=3.0.0
 # roboflow>=0.1.1
 filelock>=3.0.0
+bidict>=0.21.0

--- a/luxonis_ml/data/utils/constants.py
+++ b/luxonis_ml/data/utils/constants.py
@@ -1,6 +1,10 @@
+from typing import Final
+
 from semver.version import Version
 
-LDF_VERSION: Version = Version.parse("2.0", optional_minor_and_patch=True)
+LDF_VERSION: Final[Version] = Version.parse(
+    "2.0", optional_minor_and_patch=True
+)
 """The version of the Luxonis Data Format used by this library.
 
 Mismatch in major version numbers indicates incompatibility. Minor

--- a/luxonis_ml/data/utils/data_utils.py
+++ b/luxonis_ml/data/utils/data_utils.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterator, Optional, Tuple
 
 import numpy as np
 import polars as pl
@@ -82,7 +82,7 @@ def rgb_to_bool_masks(
 def infer_task(
     old_task: str,
     class_name: Optional[str],
-    current_classes: Dict[str, List[str]],
+    current_classes: Dict[str, Dict[str, int]],
 ) -> str:
     if not hasattr(infer_task, "_logged_infered_classes"):
         infer_task._logged_infered_classes = defaultdict(bool)

--- a/tests/test_data/test_classes_ordering.py
+++ b/tests/test_data/test_classes_ordering.py
@@ -1,0 +1,191 @@
+import random
+from pathlib import Path
+from typing import List
+
+import numpy as np
+from pytest_subtests.plugin import SubTests
+from utils import create_dataset, create_image
+
+from luxonis_ml.data import LuxonisLoader
+from luxonis_ml.data.datasets.luxonis_dataset import LuxonisDataset
+
+
+def build_segmentation(
+    polylines: List[List[float]], img_w: int, img_h: int
+) -> dict:
+    points = []
+    for polyline in polylines:
+        poly_arr = np.array(polyline).reshape(-1, 2)
+        points += [
+            (poly_arr[i, 0] / img_w, poly_arr[i, 1] / img_h)
+            for i in range(len(poly_arr))
+        ]
+    return {"height": img_h, "width": img_w, "points": points}
+
+
+def test_ordering_loader_background(tempdir: Path, subtests: SubTests):
+    width, height = 512, 512
+    segmentation = build_segmentation(
+        [[0, 0, width / 2, 0, width / 2, height / 2, 0, height / 2]],
+        width,
+        height,
+    )
+
+    def generator(classes_list: List[str]):
+        for i, class_name in enumerate(classes_list):
+            yield {
+                "file": create_image(i, tempdir),
+                "annotation": {
+                    "class": class_name,
+                    "segmentation": segmentation,
+                },
+            }
+
+    with subtests.test("implicit"):
+        classes_list = ["dog", "cat", "airplane"]
+        dataset = create_dataset(
+            "test_segmentation_no_background", generator(classes_list)
+        )
+
+        loader = LuxonisLoader(dataset, height=height, width=width)
+        for _, labels in loader:
+            classification = labels["/classification"]
+            assert len(classification) == len(classes_list) + 1
+            assert not np.array_equal(
+                classification, [1.0] + [0.0] * len(classes_list)
+            )
+
+        assert loader.classes[""] == {
+            "background": 0,
+            "airplane": 1,
+            "cat": 2,
+            "dog": 3,
+        }
+
+    with subtests.test("explicit"):
+        classes_list = ["dog", "cat", "airplane", "background"]
+        dataset = create_dataset(
+            "test_segmentation_with_background", generator(classes_list)
+        )
+
+        loader = LuxonisLoader(
+            dataset, view="train", height=height, width=width
+        )
+        for _, labels in loader:
+            classification = labels["/classification"]
+            assert len(classification) == len(classes_list)
+
+        assert loader.classes[""] == {
+            "background": 0,
+            "airplane": 1,
+            "cat": 2,
+            "dog": 3,
+        }
+
+
+def test_ordering_loader_no_backgroun(tempdir: Path):
+    width, height = 512, 512
+    left_seg = build_segmentation(
+        [[0, 0, width / 2, 0, width / 2, height, 0, height]], width, height
+    )
+    right_seg = build_segmentation(
+        [[width / 2, 0, width, 0, width, height, width / 2, height]],
+        width,
+        height,
+    )
+
+    def generator():
+        yield {
+            "file": create_image(0, tempdir),
+            "annotation": {"class": "dog", "segmentation": right_seg},
+        }
+        yield {
+            "file": create_image(0, tempdir),
+            "annotation": {"class": "cat", "segmentation": left_seg},
+        }
+
+    dataset = create_dataset("test_dual_class_segmentation", generator())
+
+    loader = LuxonisLoader(dataset, view="train", height=height, width=width)
+    for _, labels in loader:
+        classification = labels["/classification"]
+        assert len(classification) == 2
+
+    assert loader.classes == {"": {"cat": 0, "dog": 1}}
+
+
+def test_ordering_dataset(
+    dataset_name: str, tempdir: Path, subtests: SubTests
+):
+    class_names = list("abcdefghij")
+
+    def generator(classes: List[str]):
+        for i, class_name in enumerate(classes):
+            img = create_image(i, tempdir)
+            yield {
+                "file": img,
+                "task": "ordering",
+                "annotation": {
+                    "class": class_name,
+                },
+            }
+
+    with subtests.test("no_background"):
+        random.shuffle(class_names)
+        dataset = create_dataset(dataset_name, generator(class_names))
+        assert dataset.get_classes()["ordering"] == {
+            "a": 0,
+            "b": 1,
+            "c": 2,
+            "d": 3,
+            "e": 4,
+            "f": 5,
+            "g": 6,
+            "h": 7,
+            "i": 8,
+            "j": 9,
+        }
+
+    with subtests.test("with_background"):
+        class_names.append("background")
+        random.shuffle(class_names)
+        dataset = create_dataset(dataset_name, generator(class_names))
+        assert dataset.get_classes()["ordering"] == {
+            "background": 0,
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "f": 6,
+            "g": 7,
+            "h": 8,
+            "i": 9,
+            "j": 10,
+        }
+
+    with subtests.test("set_classes"):
+        dataset = LuxonisDataset(dataset_name)
+        dataset.set_classes(["d", "b", "a", "c"])
+        assert dataset.get_classes()["ordering"] == {
+            "a": 0,
+            "b": 1,
+            "c": 2,
+            "d": 3,
+        }
+        dataset.set_classes(["d", "b", "a", "c", "background"])
+        assert dataset.get_classes()["ordering"] == {
+            "background": 0,
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+        }
+        dataset.set_classes({"a": 2, "b": 1, "c": 0, "d": 3, "background": 4})
+        assert dataset.get_classes()["ordering"] == {
+            "a": 2,
+            "b": 1,
+            "c": 0,
+            "d": 3,
+            "background": 4,
+        }

--- a/tests/test_data/test_classes_ordering.py
+++ b/tests/test_data/test_classes_ordering.py
@@ -117,7 +117,7 @@ def test_ordering_loader_no_backgroun(tempdir: Path):
 def test_ordering_dataset(
     dataset_name: str, tempdir: Path, subtests: SubTests
 ):
-    class_names = list("abcdefghij")
+    class_names = list("abcdefghijKLM")
 
     def generator(classes: List[str]):
         for i, class_name in enumerate(classes):
@@ -144,6 +144,9 @@ def test_ordering_dataset(
             "h": 7,
             "i": 8,
             "j": 9,
+            "K": 10,
+            "L": 11,
+            "M": 12,
         }
 
     with subtests.test("with_background"):
@@ -162,6 +165,9 @@ def test_ordering_dataset(
             "h": 8,
             "i": 9,
             "j": 10,
+            "K": 11,
+            "L": 12,
+            "M": 13,
         }
 
     with subtests.test("set_classes"):

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -44,7 +44,7 @@ def test_dataset(
             dataset_name, bucket_storage=bucket_storage
         )
         assert set(dataset.get_task_names()) == {"coco"}
-        assert dataset.get_classes().get("coco") == ["person"]
+        assert dataset.get_classes().get("coco") == {"person": 0}
         assert dataset.get_skeletons() == {
             "coco": (
                 [
@@ -67,25 +67,25 @@ def test_dataset(
                     "right_ankle",
                 ],
                 [
-                    [15, 13],
-                    [13, 11],
-                    [16, 14],
-                    [14, 12],
-                    [11, 12],
-                    [5, 11],
-                    [6, 12],
-                    [5, 6],
-                    [5, 7],
-                    [6, 8],
-                    [7, 9],
-                    [8, 10],
-                    [1, 2],
-                    [0, 1],
-                    [0, 2],
-                    [1, 3],
-                    [2, 4],
-                    [3, 5],
-                    [4, 6],
+                    (15, 13),
+                    (13, 11),
+                    (16, 14),
+                    (14, 12),
+                    (11, 12),
+                    (5, 11),
+                    (6, 12),
+                    (5, 6),
+                    (5, 7),
+                    (6, 8),
+                    (7, 9),
+                    (8, 10),
+                    (1, 2),
+                    (0, 1),
+                    (0, 2),
+                    (1, 3),
+                    (2, 4),
+                    (3, 5),
+                    (4, 6),
                 ],
             ),
         }
@@ -97,11 +97,9 @@ def test_dataset(
         pytest.exit("Dataset creation failed")
 
     with subtests.test("test_source"):
-        assert dataset.source.to_document() == LuxonisSource().to_document()
-        dataset.update_source(LuxonisSource("test"))
-        assert (
-            dataset.source.to_document() == LuxonisSource("test").to_document()
-        )
+        assert dataset.source == LuxonisSource()
+        dataset.update_source(LuxonisSource(name="test"))
+        assert dataset.source == LuxonisSource(name="test")
 
     with subtests.test("test_load"):
         loader = LuxonisLoader(dataset)

--- a/tests/test_data/test_dataset_metadata.py
+++ b/tests/test_data/test_dataset_metadata.py
@@ -1,0 +1,185 @@
+import pytest
+
+from luxonis_ml.data import Metadata
+from luxonis_ml.data.datasets.source import LuxonisSource
+
+
+@pytest.fixture
+def basic_metadata() -> Metadata:
+    return Metadata(
+        source=None,
+        ldf_version="2.0.0",
+        classes={"task1": {"class1": 0, "class2": 1}},
+        tasks={"task1": ["subtask1", "subtask2"]},
+        skeletons={"task1": {"labels": ["head", "tail"], "edges": [(0, 1)]}},
+        categorical_encodings={"cat1": {"a": 0, "b": 1}},
+        metadata_types={"field1": "str", "field2": "int"},
+    )
+
+
+def test_merge_with_different_versions():
+    """Test that merging metadata with different LDF versions raises
+    ValueError."""
+    metadata1 = Metadata(
+        ldf_version="2.0.0",
+        source=None,
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+    metadata2 = Metadata(
+        ldf_version="2.0",
+        source=None,
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+
+    with pytest.raises(
+        ValueError, match="Cannot merge metadata with different LDF versions"
+    ):
+        metadata1.merge_with(metadata2)
+
+
+def test_merge_classes(basic_metadata: Metadata):
+    """Test merging of classes dictionaries."""
+    other_metadata = Metadata(
+        source=None,
+        ldf_version="2.0.0",
+        classes={"task1": {"class2": 1, "class3": 2}, "task2": {"classA": 0}},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+
+    merged = basic_metadata.merge_with(other_metadata)
+
+    assert "task1" in merged.classes
+    assert "task2" in merged.classes
+    assert len(merged.classes["task1"]) == 3
+    assert all(
+        c in merged.classes["task1"] for c in ["class1", "class2", "class3"]
+    )
+    assert merged.classes["task2"] == {"classA": 0}
+
+
+def test_merge_tasks(basic_metadata: Metadata):
+    """Test merging of tasks dictionaries."""
+    other_metadata = Metadata(
+        source=None,
+        ldf_version="2.0.0",
+        classes={},
+        tasks={"task1": ["subtask2", "subtask3"], "task2": ["other_subtask"]},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+
+    merged = basic_metadata.merge_with(other_metadata)
+
+    assert set(merged.tasks["task1"]) == {"subtask1", "subtask2", "subtask3"}
+    assert merged.tasks["task2"] == ["other_subtask"]
+
+
+def test_merge_categorical_encodings(basic_metadata: Metadata):
+    """Test merging of categorical encodings."""
+    other_metadata = Metadata(
+        source=None,
+        ldf_version="2.0.0",
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={"cat1": {"b": 1, "c": 2}, "cat2": {"x": 0}},
+        metadata_types={},
+    )
+
+    merged = basic_metadata.merge_with(other_metadata)
+
+    assert "cat1" in merged.categorical_encodings
+    assert "cat2" in merged.categorical_encodings
+    assert merged.categorical_encodings["cat1"]["c"] == 2
+    assert merged.categorical_encodings["cat2"] == {"x": 0}
+
+
+def test_merge_sources():
+    """Test merging of sources."""
+    source1 = LuxonisSource()
+    source2 = LuxonisSource()
+
+    metadata1 = Metadata(
+        source=source1,
+        ldf_version="2.0.0",
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+
+    metadata2 = Metadata(
+        source=source2,
+        ldf_version="2.0.0",
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+
+    merged = metadata1.merge_with(metadata2)
+    assert merged.source is not None
+
+
+def test_merge_with_none_sources():
+    """Test merging when one or both sources are None."""
+    source = LuxonisSource()
+
+    metadata1 = Metadata(
+        source=None,
+        ldf_version="2.0.0",
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+
+    metadata2 = Metadata(
+        source=source,
+        ldf_version="2.0.0",
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={},
+    )
+
+    merged = metadata1.merge_with(metadata2)
+    assert merged.source == source
+
+    merged = metadata2.merge_with(metadata1)
+    assert merged.source == source
+
+
+def test_merge_metadata_types(basic_metadata: Metadata):
+    """Test merging of metadata types."""
+    other_metadata = Metadata(
+        source=None,
+        ldf_version="2.0.0",
+        classes={},
+        tasks={},
+        skeletons={},
+        categorical_encodings={},
+        metadata_types={"field2": "int", "field3": "float"},
+    )
+
+    merged = basic_metadata.merge_with(other_metadata)
+
+    assert merged.metadata_types["field1"] == "str"
+    assert merged.metadata_types["field2"] == "int"
+    assert merged.metadata_types["field3"] == "float"

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -3,11 +3,7 @@ from pathlib import Path
 import numpy as np
 from utils import create_image
 
-from luxonis_ml.data import (
-    BucketStorage,
-    LuxonisDataset,
-    LuxonisLoader,
-)
+from luxonis_ml.data import BucketStorage, LuxonisDataset, LuxonisLoader
 
 
 def test_edge_cases(tempdir: Path):

--- a/tests/test_data/test_utils/test_visualizations.py
+++ b/tests/test_data/test_utils/test_visualizations.py
@@ -239,12 +239,12 @@ def test_visualize():
         "image": image.copy(),
         "labels": expected_semantic + expected_labels,
     }
-    class_names = {
-        "task": ["class_name"],
-        "semantic": ["background", "red", "green", "blue"],
-        "task2": ["class_name2"],
+    classes = {
+        "task": {"class_name": 0},
+        "semantic": {"background": 0, "red": 1, "green": 2, "blue": 3},
+        "task2": {"class_name2": 0},
     }
-    image = visualize(image, labels, class_names, blend_all=True)
+    image = visualize(image, labels, classes, blend_all=True)
     image = (
         cv2.cvtColor(image, cv2.COLOR_RGB2GRAY).astype(bool).astype(np.uint8)
     )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Helps to keep consistent order of class names.

## Specification
<!-- Briefly describe what’s changing and any relevant details. -->
- Changed signature of `BaseDataset.get_classes` and `set_classes` to accept and return a mapping from class names to IDs instead of a list of class names
  - `set_classes` accepts both a list of class names and the mapping
    - If list is provided, the class IDs are assigned alphabetically (except for the `"background"` class)
    - If mapping is provided, it is used as is
      - In case we would want to explicitly set a specific class IDs
- `LuxonisDataset._metadata` changed from a dictionary to a `pydantic` model
  - The same for `LuxonisSource` and `LuxonisComponent`
- Cleaned up the `luxonis_dataset.py` a bit
  - Moved the `Metadata` class and migration code to separate files

## Dependencies & Potential Impact
Change of the `BaseDataset.get_classes` and `BaseDataset.set_classes` is a breaking change

## Testing & Validation
Added new test file `test_classes_ordering.py` that tests the ordering in both `LuxonisDataset` and `LuxonisLoader`