### PR TITLE
fix empty label shapes

### DIFF
--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -230,7 +230,7 @@ class LuxonisLoader(BaseLoader):
                         labels[task] = np.zeros((0, 5))
                     elif task_type == "keypoints":
                         n_keypoints = self.dataset.get_n_keypoints()[task_name]
-                        labels[task] = np.zeros((0, n_keypoints, 3))
+                        labels[task] = np.zeros((0, n_keypoints * 3))
                     elif task_type == "segmentation":
                         labels[task] = np.zeros(
                             (0, img.shape[0], img.shape[1])


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Fixing incorrect keypoint shape returned by the Luxonis-ML loader for empty keypoints. It should be (N, n_keypoints * 3) instead of (N, n_keypoints, 3).

## Specification
<!-- Briefly describe what’s changing and any relevant details. -->

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? -->

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. -->

## Testing & Validation
<!-- How was this tested? Include relevant test results. -->
