### PR TITLE
Fix: empty labels

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -55,7 +55,7 @@ def print_info(name: str) -> None:
     class_table = Table(
         title="Classes", box=rich.box.ROUNDED, row_styles=["yellow", "cyan"]
     )
-    if len(classes) > 1 or next(iter(classes)):
+    if len(classes) > 1 or (classes and next(iter(classes))):
         class_table.add_column(
             "Task Name", header_style="magenta i", max_width=30
         )

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -244,6 +244,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         height: int,
         width: int,
         targets: Dict[str, str],
+        n_classes: Dict[str, int],
         config: Iterable[Params],
         keep_aspect_ratio: bool = True,
         is_validation_pipeline: bool = False,
@@ -251,6 +252,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
     ):
         self.targets: Dict[str, TargetType] = {}
         self.target_names_to_tasks = {}
+        self.n_classes = n_classes
         self.image_size = (height, width)
 
         for task, task_type in targets.items():
@@ -449,7 +451,18 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 task = self.target_names_to_tasks[target_name]
 
                 if task not in labels:
-                    data[target_name] = np.array([])
+                    if target_type == "mask":
+                        data[target_name] = np.empty(
+                            (
+                                0,
+                                0,
+                                self.n_classes[
+                                    self.target_names_to_tasks[target_name]
+                                ],
+                            )
+                        )
+                    else:
+                        data[target_name] = np.array([])
                     continue
 
                 array = labels[task]

--- a/luxonis_ml/data/augmentations/base_engine.py
+++ b/luxonis_ml/data/augmentations/base_engine.py
@@ -21,6 +21,7 @@ class AugmentationEngine(
         height: int,
         width: int,
         targets: Mapping[str, str],
+        n_classes: Mapping[str, int],
         config: Iterable[Params],
         keep_aspect_ratio: bool,
         is_validation_pipeline: bool,
@@ -39,6 +40,15 @@ class AugmentationEngine(
                 {
                     "detection/boundingbox": "bbox",
                     "detection/segmentation": "mask",
+                }
+
+        @type n_classes: Dict[str, int]
+        @param n_classes: Dictionary mapping task names to the number
+            of associated classes. Example::
+                {
+                    "cars/boundingbox": 2,
+                    "cars/segmentation": 2,
+                    "motorbikes/boundingbox": 1,
                 }
 
         @type config: List[Params]

--- a/luxonis_ml/data/augmentations/batch_transform.py
+++ b/luxonis_ml/data/augmentations/batch_transform.py
@@ -61,11 +61,16 @@ class BatchTransform(ABC, A.DualTransform):
     def apply_to_classification(
         self, classification_batch: List[np.ndarray], **_
     ) -> np.ndarray:
+        for i in range(len(classification_batch)):
+            if classification_batch[i].size == 0:
+                classification_batch[i] = np.zeros(1)
         return np.clip(sum(classification_batch), 0, 1)
 
     def apply_to_metadata(
         self, metadata_batch: List[np.ndarray], **_
     ) -> np.ndarray:
+        if all(arr.size == 0 for arr in metadata_batch):
+            return np.array([])
         return np.concatenate([arr for arr in metadata_batch if arr.size > 0])
 
     @override

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -119,10 +119,14 @@ class Mosaic4(BatchTransform):
         @return: Transformed masks.
         """
         for i in range(len(mask_batch)):
-            if mask_batch[i].size == 0:
-                mask_batch[i] = np.zeros(
-                    (rows, cols), dtype=mask_batch[i].dtype
-                )
+            mask = mask_batch[i]
+            if mask.size == 0:
+                if len(mask.shape) == 2:
+                    mask_batch[i] = np.zeros((rows, cols), dtype=mask.dtype)
+                else:
+                    mask_batch[i] = np.zeros(
+                        (rows, cols, mask.shape[-1]), dtype=mask.dtype
+                    )
         return apply_mosaic4_to_images(
             mask_batch,
             self.out_height,

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -2,7 +2,17 @@ import json
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple, Union
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 import cv2
 import numpy as np
@@ -86,6 +96,25 @@ class Detection(BaseModelExtraForbid):
                 ]
             )
         return self
+
+    def get_task_types(self) -> Set[str]:
+        task_types = {
+            task_type
+            for task_type in [
+                "boundingbox",
+                "keypoints",
+                "segmentation",
+                "instance_segmentation",
+                "array",
+            ]
+            if getattr(self, task_type) is not None
+        }
+        if self.class_name is not None:
+            task_types.add("classification")
+        for metadata_key in self.metadata:
+            task_types.add(f"metadata/{metadata_key}")
+
+        return task_types
 
 
 class Annotation(ABC, BaseModelExtraForbid):

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -222,6 +222,9 @@ class KeypointAnnotation(Annotation):
     @model_validator(mode="before")
     @classmethod
     def validate_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if "keypoints" not in values:
+            return values
+
         warn = False
         for i, keypoint in enumerate(values["keypoints"]):
             if (keypoint[0] < -2 or keypoint[0] > 2) or (

--- a/luxonis_ml/data/datasets/base_dataset.py
+++ b/luxonis_ml/data/datasets/base_dataset.py
@@ -49,6 +49,15 @@ class BaseDataset(
         ...
 
     @abstractmethod
+    def set_tasks(self, tasks: Dict[str, List[str]]) -> None:
+        """Sets the tasks for the dataset.
+
+        @type tasks: Dict[str, List[str]]
+        @param tasks: A dictionary mapping task names to task types.
+        """
+        ...
+
+    @abstractmethod
     def get_tasks(self) -> Dict[str, str]:
         """Returns a dictionary mapping task names to task types.
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -11,6 +11,7 @@ from pathlib import Path, PurePosixPath
 from typing import (
     Any,
     Dict,
+    Iterable,
     List,
     Literal,
     Mapping,
@@ -47,7 +48,7 @@ from luxonis_ml.utils import (
     make_progress_bar,
 )
 
-from .annotation import Category, DatasetRecord
+from .annotation import Category, DatasetRecord, Detection
 from .base_dataset import BaseDataset, DatasetIterator
 from .metadata import Metadata
 from .migration import migrate_dataframe, migrate_metadata
@@ -698,6 +699,14 @@ class LuxonisDataset(BaseDataset):
     def get_tasks(self) -> Dict[str, List[str]]:
         return self._metadata.tasks
 
+    @override
+    def set_tasks(self, tasks: Mapping[str, Iterable[str]]) -> None:
+        self._metadata.tasks = {
+            task_name: sorted(task_types)
+            for task_name, task_types in tasks.items()
+        }
+        self._write_metadata()
+
     def get_categorical_encodings(
         self,
     ) -> Dict[str, Dict[str, int]]:
@@ -870,6 +879,7 @@ class LuxonisDataset(BaseDataset):
         data_batch: list[DatasetRecord] = []
 
         classes_per_task: Dict[str, Set[str]] = defaultdict(set)
+        tasks: Dict[str, Set[str]] = defaultdict(set)
         categorical_encodings = defaultdict(dict)
         metadata_types = {}
         num_kpts_per_task: Dict[str, int] = {}
@@ -894,36 +904,48 @@ class LuxonisDataset(BaseDataset):
                         record.task = infer_task(
                             record.task, ann.class_name, self.get_classes()
                         )
-                    if ann.class_name is not None:
-                        classes_per_task[record.task].add(ann.class_name)
-                    else:
-                        classes_per_task[record.task] = set()
-                    if ann.keypoints is not None:
-                        num_kpts_per_task[record.task] = len(
-                            ann.keypoints.keypoints
-                        )
-                    for name, value in ann.metadata.items():
-                        task = f"{record.task}/metadata/{name}"
-                        typ = type(value).__name__
-                        if (
-                            task in metadata_types
-                            and metadata_types[task] != typ
-                        ):
-                            if {typ, metadata_types[task]} == {"int", "float"}:
-                                metadata_types[task] = "float"
-                            else:
-                                raise ValueError(
-                                    f"Metadata type mismatch for {task}: {metadata_types[task]} and {typ}"
-                                )
-                        else:
-                            metadata_types[task] = typ
 
-                        if not isinstance(value, Category):
-                            continue
-                        if value not in categorical_encodings[task]:
-                            categorical_encodings[task][value] = len(
-                                categorical_encodings[task]
+                    def update_state(task_name: str, ann: Detection) -> None:
+                        if ann.class_name is not None:
+                            classes_per_task[task_name].add(ann.class_name)
+                        else:
+                            classes_per_task[task_name] = set()
+
+                        tasks[task_name] |= ann.get_task_types()
+
+                        if ann.keypoints is not None:
+                            num_kpts_per_task[task_name] = len(
+                                ann.keypoints.keypoints
                             )
+                        for name, value in ann.metadata.items():
+                            task = f"{task_name}/metadata/{name}"
+                            typ = type(value).__name__
+                            if (
+                                task in metadata_types
+                                and metadata_types[task] != typ
+                            ):
+                                if {typ, metadata_types[task]} == {
+                                    "int",
+                                    "float",
+                                }:
+                                    metadata_types[task] = "float"
+                                else:
+                                    raise ValueError(
+                                        f"Metadata type mismatch for {task}: {metadata_types[task]} and {typ}"
+                                    )
+                            else:
+                                metadata_types[task] = typ
+
+                            if not isinstance(value, Category):
+                                continue
+                            if value not in categorical_encodings[task]:
+                                categorical_encodings[task][value] = len(
+                                    categorical_encodings[task]
+                                )
+                        for name, sub_detection in ann.sub_detections.items():
+                            update_state(f"{task_name}/{name}", sub_detection)
+
+                    update_state(record.task, ann)
 
                 data_batch.append(record)
                 if i % batch_size == 0:
@@ -964,25 +986,10 @@ class LuxonisDataset(BaseDataset):
             self._write_index(index, new_index, path=tmp_file.name)
 
         self.fs.put_file(tmp_file.name, "metadata/file_index.parquet")
+        self.set_tasks(tasks)
         self._write_metadata()
         self._warn_on_duplicates()
-        self._save_tasks_to_metadata()
         return self
-
-    def _save_tasks_to_metadata(self) -> None:
-        df = self._load_df_offline()
-        if df is None:
-            return
-        tasks = defaultdict(list)
-        for task_name, task_type in (
-            df.select("task_name", "task_type")
-            .unique()
-            .drop_nulls()
-            .iter_rows()
-        ):
-            tasks[task_name].append(task_type)
-        self._metadata.tasks = tasks
-        self._write_metadata()
 
     def _warn_on_duplicates(self) -> None:
         df = self._load_df_offline(lazy=True)

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -630,13 +630,6 @@ class LuxonisDataset(BaseDataset):
 
     @override
     def update_source(self, source: LuxonisSource) -> None:
-        """Updates underlying source of the dataset with a new
-        L{LuxonisSource}.
-
-        @type source: LuxonisSource
-        @param source: The new C{LuxonisSource} to replace the old one.
-        """
-
         self._metadata.source = source
         self._write_metadata()
 
@@ -658,12 +651,18 @@ class LuxonisDataset(BaseDataset):
 
     @override
     def get_classes(self) -> Dict[str, Dict[str, int]]:
-        """Returns a bi-directional mapping of classes to class ids for
-        each task.
-
-        @type: Dict[str, Dict[str, int]]
-        """
         return self._metadata.classes
+
+    def get_n_classes(self) -> Dict[str, int]:
+        """Returns a mapping of task names to number of classes.
+
+        @rtype: Dict[str, int]
+        @return: A mapping from task names to number of classes.
+        """
+        return {
+            task_name: len(classes)
+            for task_name, classes in self.get_classes().items()
+        }
 
     @override
     def set_skeletons(

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -130,13 +130,6 @@ class LuxonisLoader(BaseLoader):
             self.df = self.df.join(file_index, on="uuid").drop("file_right")
 
         self.classes = self.dataset.get_classes()
-        self.augmentations = self._init_augmentations(
-            augmentation_engine,
-            augmentation_config or [],
-            height,
-            width,
-            keep_aspect_ratio,
-        )
         self.instances: List[str] = []
         splits_path = self.dataset.metadata_path / "splits.json"
         if not splits_path.exists():
@@ -184,6 +177,14 @@ class LuxonisLoader(BaseLoader):
                                 ].items()
                             },
                         }
+
+        self.augmentations = self._init_augmentations(
+            augmentation_engine,
+            augmentation_config or [],
+            height,
+            width,
+            keep_aspect_ratio,
+        )
 
     @override
     def __len__(self) -> int:

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -410,11 +410,18 @@ class LuxonisLoader(BaseLoader):
             for task_type in task_types
         }
 
+        n_classes = {
+            f"{task_name}/{task_type}": self.dataset.get_n_classes()[task_name]
+            for task_name, task_types in self.dataset.get_tasks().items()
+            for task_type in task_types
+        }
+
         return AUGMENTATION_ENGINES.get(augmentation_engine)(
             height=height,
             width=width,
             config=augmentation_config,
             targets=targets,
+            n_classes=n_classes,
             keep_aspect_ratio=keep_aspect_ratio,
             is_validation_pipeline="train" not in self.view,
         )

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -34,7 +34,7 @@ def labels() -> Labels:
 
 
 @pytest.fixture
-def targets() -> Dict[str, TaskType]:
+def targets() -> Dict[str, str]:
     return {
         "task/boundingbox": "boundingbox",
         "task/keypoints": "keypoints",
@@ -42,8 +42,20 @@ def targets() -> Dict[str, TaskType]:
     }
 
 
+@pytest.fixture
+def n_classes() -> Dict[str, int]:
+    return {
+        "task/boundingbox": 1,
+        "task/keypoints": 1,
+        "task/segmentation": 1,
+    }
+
+
 def test_mosaic4(
-    image: np.ndarray, labels: Labels, targets: Dict[str, TaskType]
+    image: np.ndarray,
+    labels: Labels,
+    targets: Dict[str, str],
+    n_classes: Dict[str, int],
 ):
     config = [
         {
@@ -51,20 +63,26 @@ def test_mosaic4(
             "params": {"p": 1.0, "out_width": 640, "out_height": 640},
         }
     ]
-    augmentations = AlbumentationsEngine(256, 256, targets, config)
+    augmentations = AlbumentationsEngine(256, 256, targets, n_classes, config)
     augmentations.apply([(image.copy(), deepcopy(labels)) for _ in range(4)])
 
 
 def test_mixup(
-    image: np.ndarray, labels: Labels, targets: Dict[str, TaskType]
+    image: np.ndarray,
+    labels: Labels,
+    targets: Dict[str, TaskType],
+    n_classes: Dict[str, int],
 ):
     config = [{"name": "MixUp", "params": {"p": 1.0}}]
-    augmentations = AlbumentationsEngine(256, 256, targets, config)
+    augmentations = AlbumentationsEngine(256, 256, targets, n_classes, config)
     augmentations.apply([(image.copy(), deepcopy(labels)) for _ in range(2)])
 
 
 def test_batched_p_0(
-    image: np.ndarray, labels: Labels, targets: Dict[str, TaskType]
+    image: np.ndarray,
+    labels: Labels,
+    targets: Dict[str, TaskType],
+    n_classes: Dict[str, int],
 ):
     config = [
         {
@@ -73,5 +91,5 @@ def test_batched_p_0(
         },
         {"name": "MixUp", "params": {"p": 0}},
     ]
-    augmentations = AlbumentationsEngine(256, 256, targets, config)
+    augmentations = AlbumentationsEngine(256, 256, targets, n_classes, config)
     augmentations.apply([(image.copy(), deepcopy(labels)) for _ in range(8)])

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -1,10 +1,14 @@
 from pathlib import Path
+from typing import Literal
+
+import pytest
 
 from luxonis_ml.data.loaders.luxonis_loader import LuxonisLoader
 from tests.test_data.utils import create_dataset, create_image
 
 
-def test_empty(dataset_name: str, tempdir: Path):
+@pytest.mark.parametrize("n_samples", [0, 1, 2])
+def test_empty(dataset_name: str, tempdir: Path, n_samples: Literal[0, 1, 2]):
     config = [
         {
             "name": "Defocus",
@@ -16,10 +20,10 @@ def test_empty(dataset_name: str, tempdir: Path):
         },
     ]
 
-    def generator():
+    def generator(keep_samples: Literal[0, 1, 2]):
         for i in range(20):
             img = create_image(i, tempdir)
-            if i < 2:
+            if i < keep_samples:
                 yield {
                     "file": img,
                     "annotation": {
@@ -46,7 +50,9 @@ def test_empty(dataset_name: str, tempdir: Path):
             else:
                 yield {"file": img}
 
-    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    dataset = create_dataset(
+        dataset_name, generator(n_samples), splits={"train": 1.0}
+    )
     loader = LuxonisLoader(
         dataset, augmentation_config=config, height=256, width=256
     )

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from luxonis_ml.data.loaders.luxonis_loader import LuxonisLoader
+from tests.test_data.utils import create_dataset, create_image
+
+
+def test_empty(dataset_name: str, tempdir: Path):
+    config = [
+        {
+            "name": "Defocus",
+            "params": {"p": 1.0},
+        },
+        {
+            "name": "Mosaic4",
+            "params": {"p": 1.0, "out_width": 640, "out_height": 640},
+        },
+    ]
+
+    def generator():
+        for i in range(20):
+            img = create_image(i, tempdir)
+            if i < 2:
+                yield {
+                    "file": img,
+                    "annotation": {
+                        "class": ["dog", "cat"][i],
+                        "segmentation": {
+                            "points": [(0.2, 0.2), (0.2, 0.4), (0.4, 0.4)],
+                            "height": 256,
+                            "width": 256,
+                        },
+                        "boundingbox": {
+                            "x": 0.2,
+                            "y": 0.2,
+                            "w": 0.3,
+                            "h": 0.3,
+                        },
+                        "keypoints": {
+                            "keypoints": [(0.25, 0.25, 2), (0.3, 0.3, 1)]
+                        },
+                        "metadata": {
+                            "breed": "labrador",
+                        },
+                    },
+                }
+            else:
+                yield {"file": img}
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    loader = LuxonisLoader(
+        dataset, augmentation_config=config, height=256, width=256
+    )
+    for _ in loader:
+        pass

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Literal
 
 import pytest
 
@@ -7,8 +6,8 @@ from luxonis_ml.data.loaders.luxonis_loader import LuxonisLoader
 from tests.test_data.utils import create_dataset, create_image
 
 
-@pytest.mark.parametrize("n_samples", [0, 1, 2])
-def test_empty(dataset_name: str, tempdir: Path, n_samples: Literal[0, 1, 2]):
+@pytest.mark.parametrize("n_samples", range(20))
+def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
     config = [
         {
             "name": "Defocus",
@@ -20,14 +19,14 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: Literal[0, 1, 2]):
         },
     ]
 
-    def generator(keep_samples: Literal[0, 1, 2]):
+    def generator(keep_samples: int):
         for i in range(20):
             img = create_image(i, tempdir)
             if i < keep_samples:
                 yield {
                     "file": img,
                     "annotation": {
-                        "class": ["dog", "cat"][i],
+                        "class": ["dog", "cat"][i % 2],
                         "segmentation": {
                             "points": [(0.2, 0.2), (0.2, 0.4), (0.4, 0.4)],
                             "height": 256,

--- a/tests/test_data/test_augmentations/test_special.py
+++ b/tests/test_data/test_augmentations/test_special.py
@@ -15,7 +15,7 @@ def test_metadata_no_boxes():
         },
     ]
     augmentations = AlbumentationsEngine(
-        256, 256, {"/metadata/id": "metadata/id"}, config
+        256, 256, {"/metadata/id": "metadata/id"}, {"/metadata/id": 0}, config
     )
     _, labels = augmentations.apply(
         [

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -427,6 +427,7 @@ def test_deep_nested_labels(
                     },
                     "sub_detections": {
                         "license_plate": {
+                            "class": "CO",
                             "boundingbox": {
                                 "x": 0.2,
                                 "y": 0.2,
@@ -435,6 +436,16 @@ def test_deep_nested_labels(
                             },
                             "metadata": {
                                 "text": "ABC123",
+                            },
+                            "sub_detections": {
+                                "text": {
+                                    "boundingbox": {
+                                        "x": 0.3,
+                                        "y": 0.3,
+                                        "w": 0.1,
+                                        "h": 0.1,
+                                    }
+                                },
                             },
                         },
                         "driver": {
@@ -453,7 +464,22 @@ def test_deep_nested_labels(
             }
 
     dataset = create_dataset(dataset_name, generator())
-
+    assert dataset.get_tasks() == {
+        "": ["boundingbox", "classification"],
+        "/driver": ["boundingbox", "keypoints"],
+        "/license_plate": [
+            "boundingbox",
+            "classification",
+            "metadata/text",
+        ],
+        "/license_plate/text": ["boundingbox"],
+    }
+    assert dataset.get_classes() == {
+        "": {"car": 0},
+        "/driver": {},
+        "/license_plate": {"CO": 0},
+        "/license_plate/text": {},
+    }
     loader = LuxonisLoader(
         dataset,
         height=512,
@@ -467,7 +493,9 @@ def test_deep_nested_labels(
         "/driver/boundingbox",
         "/driver/keypoints",
         "/license_plate/boundingbox",
+        "/license_plate/classification",
         "/license_plate/metadata/text",
+        "/license_plate/text/boundingbox",
     }
 
 

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import numpy as np
 import pytest
 from pytest_subtests.plugin import SubTests
-from utils import compare_loader_output, create_dataset, create_image
+from utils import create_dataset, create_image, get_loader_output
 
 from luxonis_ml.data import (
     BucketStorage,
@@ -461,17 +461,14 @@ def test_deep_nested_labels(
         augmentation_config=augmentation_config,
         augmentation_engine="albumentations",
     )
-    compare_loader_output(
-        loader,
-        {
-            "/classification",
-            "/boundingbox",
-            "/driver/boundingbox",
-            "/driver/keypoints",
-            "/license_plate/boundingbox",
-            "/license_plate/metadata/text",
-        },
-    )
+    assert get_loader_output(loader) == {
+        "/classification",
+        "/boundingbox",
+        "/driver/boundingbox",
+        "/driver/keypoints",
+        "/license_plate/boundingbox",
+        "/license_plate/metadata/text",
+    }
 
 
 @pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")
@@ -526,15 +523,12 @@ def test_partial_labels(dataset_name: str, tempdir: Path):
         augmentation_config=[{"name": "Rotate"}],
     )
 
-    compare_loader_output(
-        loader,
-        {
-            "/classification",
-            "/boundingbox",
-            "/keypoints",
-            "/segmentation",
-        },
-    )
+    assert get_loader_output(loader) == {
+        "/classification",
+        "/boundingbox",
+        "/keypoints",
+        "/segmentation",
+    }
 
 
 @pytest.mark.dependency(name="test_dataset[BucketStorage.LOCAL]")

--- a/tests/test_data/utils.py
+++ b/tests/test_data/utils.py
@@ -29,11 +29,11 @@ def create_image(i: int, dir: Path) -> Path:
     return path
 
 
-def compare_loader_output(loader: LuxonisLoader, tasks: Set[str]) -> None:
+def get_loader_output(loader: LuxonisLoader) -> Set[str]:
     all_labels = set()
     for _, labels in loader:
         all_labels.update(labels.keys())
-    assert all_labels == tasks
+    return all_labels
 
 
 def create_dataset(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Fixes various issues with empty labels when used with batched augmentations.
- Fixes additional issues related to nested labels and implicit background class

## Specification
<!-- Briefly describe what’s changing and any relevant details. -->
- New argument `n_classes` for `AugmentationEngine`, necessary for segmentation masks in case they are all empty
- Additional checks for empty labels
  - classification and metadata
- Fixed `luxonis_ml data info` when used with a dataset with no labels  
- Added abstract `set_tasks` to `BaseDataset` (to complement an already present `get_tasks`)
- Fixed correct setting of tasks / classes / number of keypoints for nested labels

## Testing & Validation
- Added new test cases for empty and almost empty datasets
- Improved tests for deep nested labels
<!-- How was this tested? Include relevant test results. -->
