### PR TITLE
Fix duplicate exception logging

### DIFF
--- a/luxonis_ml/utils/logging.py
+++ b/luxonis_ml/utils/logging.py
@@ -61,7 +61,11 @@ def setup_logging(
             **kwargs,
         ),
         level=level,
-        format="{message}",
+        # NOTE: Needs to be a constant function to avoid
+        # duplicate logging of exceptions, see
+        # https://github.com/Delgan/loguru/issues/1172
+        format=lambda _: "{message}",
+        backtrace=False,
     )
 
     if file is not None:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes duplicate logging of exceptions, see `loguru` issue [#1172](https://github.com/Delgan/loguru/issues/1172)

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable