### PR TITLE
Fix: duplicate warning with multiple tasks

### DIFF
--- a/luxonis_ml/data/utils/data_utils.py
+++ b/luxonis_ml/data/utils/data_utils.py
@@ -153,6 +153,7 @@ def warn_on_duplicates(df: pl.LazyFrame) -> None:
         df.group_by(
             "original_filepath",
             "task_type",
+            "task_name",
             "annotation",
         )
         .agg(pl.len().alias("count"))
@@ -163,6 +164,7 @@ def warn_on_duplicates(df: pl.LazyFrame) -> None:
     for (
         file_name,
         task_type,
+        task_name,
         annotation,
         count,
     ) in duplicate_annotation.iter_rows():
@@ -170,6 +172,7 @@ def warn_on_duplicates(df: pl.LazyFrame) -> None:
             annotation = "<binary mask>"
         if not task_is_metadata(task_type):
             logger.warning(
-                f"File '{file_name}' has the same '{task_type}' annotation "
+                f"File '{file_name}' of task '{task_name}' has the f"
+                f"same '{task_type}' annotation "
                 f"'{annotation}' repeated {count} times."
             )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
The warning for duplicate annotations does not take into account multi-task datasets.
(Same annotations belonging to different tasks should not trigger the warning).

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Added grouping by `task_name` in `warn_on_duplicates`.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable