### PR TITLE
Fix: `pycocotools` warnings

### DIFF
--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from pathlib import Path
@@ -300,9 +301,10 @@ class SegmentationAnnotation(Annotation):
     counts: bytes
 
     def to_numpy(self) -> np.ndarray:
-        return pycocotools.mask.decode(
-            {"counts": self.counts, "size": [self.height, self.width]}
-        ).astype(np.uint8)
+        with warnings.catch_warnings(record=True):
+            return pycocotools.mask.decode(
+                {"counts": self.counts, "size": [self.height, self.width]}
+            ).astype(np.uint8)
 
     @staticmethod
     @override
@@ -350,9 +352,10 @@ class SegmentationAnnotation(Annotation):
                         "RLE counts must be a list of positive integers"
                     )
 
-            rle: Any = pycocotools.mask.frPyObjects(
-                {"counts": counts, "size": [height, width]}, height, width
-            )
+            with warnings.catch_warnings(record=True):
+                rle: Any = pycocotools.mask.frPyObjects(
+                    {"counts": counts, "size": [height, width]}, height, width
+                )
             values["counts"] = rle["counts"]
             values["height"] = rle["size"][0]
             values["width"] = rle["size"][1]
@@ -397,7 +400,8 @@ class SegmentationAnnotation(Annotation):
             raise ValueError("Mask must be a 2D binary array")
 
         mask = np.asfortranarray(mask.astype(np.uint8))
-        rle = pycocotools.mask.encode(mask)
+        with warnings.catch_warnings(record=True):
+            rle = pycocotools.mask.encode(mask)
 
         return {
             "height": rle["size"][0],


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`numpy` in version `>=2.0.0` causes `pycocotools` to emit multitude of warnings which makes the logs hard to read.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Added suppression of the warnings.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
The warnings are related to deprecated parameters in the `__array__` protocol in `numpy>=2.0.0`. `pycocotools` is not an actively maintained library and it's possible it will break completely in the future. We might need to eventually implement the required parts ourselves. 

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable