### PR TITLE
Replaced `pkg_resources` with `importlib.metadata`

### DIFF
--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import entry_points
 
 from luxonis_ml.guard_extras import guard_missing_extra
 
@@ -22,14 +22,14 @@ with guard_missing_extra("data"):
 
 def load_dataset_plugins() -> None:  # pragma: no cover
     """Registers any external dataset BaseDataset class plugins."""
-    for entry_point in pkg_resources.iter_entry_points("dataset_plugins"):
+    for entry_point in entry_points().get("dataset_plugins", []):
         plugin_class = entry_point.load()
         DATASETS_REGISTRY.register(module=plugin_class)
 
 
 def load_loader_plugins() -> None:  # pragma: no cover
     """Registers any external dataset BaseLoader class plugins."""
-    for entry_point in pkg_resources.iter_entry_points("loader_plugins"):
+    for entry_point in entry_points().get("loader_plugins", []):
         plugin_class = entry_point.load()
         DATASETS_REGISTRY.register(module=plugin_class)
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`pkg_resources` is deprecated in favor of `importlib.metadata`.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Replaced `pkg_resources.iter_entry_points` with `importlib.metadata.entry_points`
## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable