### PR TITLE
remote option in CLI

### DIFF
--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -185,6 +185,8 @@ class LuxonisDataset(BaseDataset):
 
     def __len__(self) -> int:
         """Returns the number of instances in the dataset."""
+        if self.is_remote:
+            return len(list(self.fs.walk_dir("media")))
 
         df = self._load_df_offline()
         return len(df.select("uuid").unique()) if df is not None else 0
@@ -1219,6 +1221,6 @@ class LuxonisDataset(BaseDataset):
             for path in fs.walk_dir("", recursive=False, typ="directory")
         )
         with ThreadPoolExecutor() as executor:
-            return [
+            return sorted(
                 name for name in executor.map(process_directory, paths) if name
-            ]
+            )

--- a/luxonis_ml/data/datasets/metadata.py
+++ b/luxonis_ml/data/datasets/metadata.py
@@ -2,6 +2,7 @@ from typing import Dict, Iterable, List, Literal, Optional, Tuple, Union
 
 from typing_extensions import TypedDict
 
+from luxonis_ml.data.utils.constants import LDF_VERSION
 from luxonis_ml.utils.pydantic_utils import BaseModelExtraForbid
 
 from .source import LuxonisSource
@@ -14,12 +15,12 @@ class Skeletons(TypedDict):
 
 class Metadata(BaseModelExtraForbid):
     source: Optional[LuxonisSource]
-    ldf_version: str
-    classes: Dict[str, Dict[str, int]]
-    tasks: Dict[str, List[str]]
-    skeletons: Dict[str, Skeletons]
-    categorical_encodings: Dict[str, Dict[str, int]]
-    metadata_types: Dict[str, Literal["float", "int", "str", "Category"]]
+    ldf_version: str = str(LDF_VERSION)
+    classes: Dict[str, Dict[str, int]] = {}
+    tasks: Dict[str, List[str]] = {}
+    skeletons: Dict[str, Skeletons] = {}
+    categorical_encodings: Dict[str, Dict[str, int]] = {}
+    metadata_types: Dict[str, Literal["float", "int", "str", "Category"]] = {}
     parent_dataset: Optional[str] = None
 
     def set_classes(

--- a/luxonis_ml/data/datasets/migration.py
+++ b/luxonis_ml/data/datasets/migration.py
@@ -132,4 +132,6 @@ def migrate_metadata(
             )
         new_metadata["classes"] = dict(new_classes)
         new_metadata["tasks"] = dict(tasks)
-    return Metadata(**new_metadata)
+
+    metadata.update(new_metadata)
+    return Metadata(**metadata)  # type: ignore

--- a/luxonis_ml/data/datasets/source.py
+++ b/luxonis_ml/data/datasets/source.py
@@ -1,6 +1,6 @@
-from typing import Dict
+from typing import Any, Dict
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from luxonis_ml.data.utils import ImageType, MediaType
 from luxonis_ml.utils import BaseModelExtraForbid
@@ -65,3 +65,14 @@ class LuxonisSource(BaseModelExtraForbid):
             components=components,
             main_component=self.main_component,
         )
+
+    @field_validator("components", mode="before")
+    @classmethod
+    def validate_components(cls, components: Any) -> Any:
+        if isinstance(components, list):
+            migrated_components = {}
+            for component in components:
+                component = LuxonisComponent(**component)
+                migrated_components[component.name] = component
+            return migrated_components
+        return components


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adds option to work with remote datasets using the `luxonis-ml` CLI
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added `--bucket-storage/-b` option to `luxonis-ml data` commands
- Added support for remote datasets in `LuxonisDataset.__len__`
- Sorted names in `luxonis-ml data ls` command 
- Fixed some issues with migration of metadata from LDF 1.0

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable