### PR TITLE
Deprecate `DatasetRecord.task`

### DIFF
--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -535,7 +535,9 @@ class ArrayAnnotation(Annotation):
 class DatasetRecord(BaseModelExtraForbid):
     files: Dict[str, FilePath]
     annotation: Optional[Detection] = None
-    task_name: str = Field(validation_alias=AliasChoices("task", "task_name"))
+    task_name: str = Field(
+        "", validation_alias=AliasChoices("task", "task_name")
+    )
 
     @property
     def file(self) -> FilePath:

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -535,9 +535,7 @@ class ArrayAnnotation(Annotation):
 class DatasetRecord(BaseModelExtraForbid):
     files: Dict[str, FilePath]
     annotation: Optional[Detection] = None
-    task_name: str = Field(
-        ..., validation_alias=AliasChoices("task", "task_name")
-    )
+    task_name: str = Field(validation_alias=AliasChoices("task", "task_name"))
 
     @property
     def file(self) -> FilePath:

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -21,7 +21,6 @@ import pycocotools.mask
 from loguru import logger
 from PIL import Image, ImageDraw
 from pydantic import (
-    AliasChoices,
     Field,
     GetCoreSchemaHandler,
     field_serializer,
@@ -535,9 +534,7 @@ class ArrayAnnotation(Annotation):
 class DatasetRecord(BaseModelExtraForbid):
     files: Dict[str, FilePath]
     annotation: Optional[Detection] = None
-    task_name: str = Field(
-        "", validation_alias=AliasChoices("task", "task_name")
-    )
+    task_name: str = ""
 
     @property
     def file(self) -> FilePath:
@@ -558,6 +555,7 @@ class DatasetRecord(BaseModelExtraForbid):
                 "The 'task' field is deprecated. Use 'task_name' instead.",
                 stacklevel=2,
             )
+            values["task_name"] = values.pop("task")
         return values
 
     @model_validator(mode="before")

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -21,6 +21,7 @@ import pycocotools.mask
 from loguru import logger
 from PIL import Image, ImageDraw
 from pydantic import (
+    AliasChoices,
     Field,
     GetCoreSchemaHandler,
     field_serializer,
@@ -534,7 +535,9 @@ class ArrayAnnotation(Annotation):
 class DatasetRecord(BaseModelExtraForbid):
     files: Dict[str, FilePath]
     annotation: Optional[Detection] = None
-    task: str = ""
+    task_name: str = Field(
+        ..., validation_alias=AliasChoices("task", "task_name")
+    )
 
     @property
     def file(self) -> FilePath:
@@ -543,9 +546,19 @@ class DatasetRecord(BaseModelExtraForbid):
         return next(iter(self.files.values()))
 
     @model_validator(mode="after")
-    def validate_task_name(self) -> Self:
-        check_valid_identifier(self.task, label="Task name")
+    def validate_task_name_valid_identifier(self) -> Self:
+        check_valid_identifier(self.task_name, label="Task name")
         return self
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_task_name(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if "task" in values:
+            warnings.warn(
+                "The 'task' field is deprecated. Use 'task_name' instead.",
+                stacklevel=2,
+            )
+        return values
 
     @model_validator(mode="before")
     @classmethod
@@ -562,7 +575,7 @@ class DatasetRecord(BaseModelExtraForbid):
         @rtype: L{ParquetDict}
         @return: A dictionary of annotation data.
         """
-        yield from self._to_parquet_rows(self.annotation, self.task)
+        yield from self._to_parquet_rows(self.annotation, self.task_name)
 
     def _to_parquet_rows(
         self, annotation: Optional[Detection], task_name: str

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -908,8 +908,10 @@ class LuxonisDataset(BaseDataset):
                 ann = record.annotation
                 if ann is not None:
                     if not explicit_task:
-                        record.task = infer_task(
-                            record.task, ann.class_name, self.get_classes()
+                        record.task_name = infer_task(
+                            record.task_name,
+                            ann.class_name,
+                            self.get_classes(),
                         )
 
                     def update_state(task_name: str, ann: Detection) -> None:
@@ -952,7 +954,7 @@ class LuxonisDataset(BaseDataset):
                         for name, sub_detection in ann.sub_detections.items():
                             update_state(f"{task_name}/{name}", sub_detection)
 
-                    update_state(record.task, ann)
+                    update_state(record.task_name, ann)
 
                 data_batch.append(record)
                 if i % batch_size == 0:

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -244,6 +244,6 @@ class BaseParser(ABC):
             if isinstance(item, dict):
                 if "task" not in item or self.task_name is not None:
                     item["task"] = task_name
-            elif not item.task or self.task_name is not None:
-                item.task = task_name
+            elif not item.task_name or self.task_name is not None:
+                item.task_name = task_name
             yield item

--- a/tests/test_data/test_annotations.py
+++ b/tests/test_data/test_annotations.py
@@ -583,7 +583,7 @@ def test_record(tempdir: Path):
     record = DatasetRecord(
         file=filename,  # type: ignore
         annotation=detection,
-        task="test",
+        task_name="test",
     )
     common = {
         "file": filename,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
The name of the field `task` is confusing and inconsistent with the `task_name` field used in `luxonis-train`.  

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Renamed `DatasetRecord.task` to `task_name`. Deprecation warning is issued if the old `task` is used instead. 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable