### PR TITLE
Fix: Empty segmentations

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -461,6 +461,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                                 ],
                             )
                         )
+                    elif target_type == "classification":
+                        data[target_name] = np.zeros(
+                            self.n_classes[
+                                self.target_names_to_tasks[target_name]
+                            ]
+                        )
                     else:
                         data[target_name] = np.array([])
                     continue

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -352,6 +352,9 @@ def apply_mosaic4_to_instance_masks(
     out_masks = []
     out_shape = [out_height * 2, out_width * 2]
 
+    if not any(m.size for m in masks_batch):
+        return np.zeros((out_height, out_width, 0), dtype=np.uint8)
+
     for quadrant, masks in enumerate(masks_batch):
         if masks.size == 0:
             continue
@@ -394,6 +397,9 @@ def apply_mosaic4_to_instance_masks(
                 y_crop : y_crop + out_height, x_crop : x_crop + out_width
             ]
             out_masks.append(combined_mask)
+
+    if not out_masks:
+        return np.zeros((out_height, out_width, 0), dtype=np.uint8)
 
     return np.stack(out_masks, axis=-1)
 

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -232,17 +232,12 @@ class LuxonisLoader(BaseLoader):
                     elif task_type == "keypoints":
                         n_keypoints = self.dataset.get_n_keypoints()[task_name]
                         labels[task] = np.zeros((0, n_keypoints * 3))
-                    elif task_type == "segmentation":
+                    elif task_type in {
+                        "segmentation",
+                        "instance_segmentation",
+                    }:
                         labels[task] = np.zeros(
                             (0, img.shape[0], img.shape[1])
-                        )
-                    elif task_type == "instance_segmentation":
-                        labels[task] = np.zeros(
-                            (
-                                len(self.dataset.get_classes()[task_name]),
-                                img.shape[0],
-                                img.shape[1],
-                            )
                         )
                     elif task_type == "classification" or task_is_metadata(
                         task

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -232,12 +232,17 @@ class LuxonisLoader(BaseLoader):
                     elif task_type == "keypoints":
                         n_keypoints = self.dataset.get_n_keypoints()[task_name]
                         labels[task] = np.zeros((0, n_keypoints * 3))
-                    elif task_type in {
-                        "segmentation",
-                        "instance_segmentation",
-                    }:
+                    elif task_type == "instance_segmentation":
                         labels[task] = np.zeros(
                             (0, img.shape[0], img.shape[1])
+                        )
+                    elif task_type == "segmentation":
+                        labels[task] = np.zeros(
+                            (
+                                len(self.classes[task_name]),
+                                img.shape[0],
+                                img.shape[1],
+                            )
                         )
                     elif task_type == "classification" or task_is_metadata(
                         task

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -37,7 +37,7 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
                         "instance_segmentation": {
                             "height": 256,
                             "width": 256,
-                            "points": [(0.25, 0.25), (0.3, 0.3)],
+                            "points": [(0.25, 0.25), (0.3, 0.3), (0.4, 0.4)],
                         },
                         "boundingbox": {
                             "x": 0.2,

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -63,7 +63,7 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
         dataset, augmentation_config=config, height=256, width=256
     )
     for _img, labels in loader:
-        if labels["/class"].shape[0] == 0:
+        if labels["/classification"].shape[0] == 0:
             assert labels["/classification"].shape == (0, 2)
             assert labels["/boundingbox"].shape == (0, 5)
             assert labels["/keypoints"].shape == (0, 2 * 3)

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -62,11 +62,15 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
     loader = LuxonisLoader(
         dataset, augmentation_config=config, height=256, width=256
     )
-    for _img, labels in loader:
-        if labels["/classification"].shape[0] == 0:
-            assert labels["/classification"].shape == (0, 2)
+    for _, labels in loader:
+        if "/classification" not in labels:
+            continue
+
+        n_classes = dataset.get_n_classes()[""]
+        if labels["/classification"].sum() == 0:
+            assert labels["/classification"].shape == (n_classes,)
             assert labels["/boundingbox"].shape == (0, 5)
             assert labels["/keypoints"].shape == (0, 2 * 3)
-            assert labels["/segmentation"].shape == (0, 256, 256)
+            assert labels["/segmentation"].shape == (n_classes, 256, 256)
+            assert labels["/segmentation"].sum() == 0
             assert labels["/instance_segmentation"].shape == (0, 256, 256)
-            continue

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -64,7 +64,7 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
     )
     for _img, labels in loader:
         if labels["/class"].shape[0] == 0:
-            assert labels["/class"].shape == (0, 2)
+            assert labels["/classification"].shape == (0, 2)
             assert labels["/boundingbox"].shape == (0, 5)
             assert labels["/keypoints"].shape == (0, 2 * 3)
             assert labels["/segmentation"].shape == (0, 256, 256)

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -34,6 +34,11 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
                             "height": 256,
                             "width": 256,
                         },
+                        "instance_segmentation": {
+                            "height": 256,
+                            "width": 256,
+                            "points": [(0.25, 0.25), (0.3, 0.3)],
+                        },
                         "boundingbox": {
                             "x": 0.2,
                             "y": 0.2,
@@ -57,5 +62,11 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
     loader = LuxonisLoader(
         dataset, augmentation_config=config, height=256, width=256
     )
-    for _ in loader:
-        pass
+    for _img, labels in loader:
+        if labels["/class"].shape[0] == 0:
+            assert labels["/class"].shape == (0, 2)
+            assert labels["/boundingbox"].shape == (0, 5)
+            assert labels["/keypoints"].shape == (0, 2 * 3)
+            assert labels["/segmentation"].shape == (0, 256, 256)
+            assert labels["/instance_segmentation"].shape == (0, 256, 256)
+            continue


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Fixed multiple bugs related to augmenting empty annotations.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Fixed a bug in Mosaic4 that occurred when an image had no instance segmentation masks
-  Fixed an issue where zero instance segmentation masks were returned instead of empty masks when an image was missing instance segmentation annotations
- Fixed empty classification labels

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Improved relevant tests