### PR TITLE
Fix: Augmenting empty classification labels

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -461,6 +461,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                                 ],
                             )
                         )
+                    elif target_type == "classification":
+                        data[target_name] = np.zeros(
+                            self.n_classes[
+                                self.target_names_to_tasks[target_name]
+                            ]
+                        )
                     else:
                         data[target_name] = np.array([])
                     continue

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -57,5 +57,14 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
     loader = LuxonisLoader(
         dataset, augmentation_config=config, height=256, width=256
     )
-    for _ in loader:
-        pass
+    for _, labels in loader:
+        if "/classification" not in labels:
+            continue
+
+        n_classes = dataset.get_n_classes()[""]
+        if labels["/classification"].sum() == 0:
+            assert labels["/classification"].shape == (n_classes,)
+            assert labels["/boundingbox"].shape == (0, 5)
+            assert labels["/keypoints"].shape == (0, 2 * 3)
+            assert labels["/segmentation"].shape == (n_classes, 256, 256)
+            assert labels["/segmentation"].sum() == 0


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes incorrectly handled empty classification labels in augmentations.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Added more explicit test for empty annotations.