### PR TITLE
Feature: Task names override in parsers

### DIFF
--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -901,13 +901,11 @@ class LuxonisDataset(BaseDataset):
 
         with ParquetFileManager(annotations_path) as pfm:
             for i, record in enumerate(generator, start=1):
-                explicit_task = False
                 if not isinstance(record, DatasetRecord):
-                    explicit_task = "task_name" in record or "task" in record
                     record = DatasetRecord(**record)
                 ann = record.annotation
                 if ann is not None:
-                    if not explicit_task:
+                    if not record.task_name:
                         record.task_name = infer_task(
                             record.task_name,
                             ann.class_name,
@@ -976,7 +974,7 @@ class LuxonisDataset(BaseDataset):
             new_classes = list(classes - old_classes)
             if new_classes or task not in curr_classes:
                 logger.info(
-                    f"Detected new classes for task {task}: {new_classes}"
+                    f"Detected new classes for task group '{task}': {new_classes}"
                 )
 
                 self.set_classes(list(classes | old_classes), task=task)

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -1,20 +1,43 @@
 import os
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from luxonis_ml.data import BaseDataset, DatasetIterator
+from luxonis_ml.data.datasets.annotation import DatasetRecord
 from luxonis_ml.enums.enums import DatasetType
 
 ParserOutput = Tuple[DatasetIterator, Dict[str, Dict], List[Path]]
 
 
-@dataclass
 class BaseParser(ABC):
-    dataset: BaseDataset
-    dataset_type: DatasetType
-    task_name: Optional[str]
+    def __init__(
+        self,
+        dataset: BaseDataset,
+        dataset_type: DatasetType,
+        task_name: Optional[Union[str, Dict[str, str]]],
+    ):
+        """
+        @type dataset: BaseDataset
+        @param dataset: Dataset to add the parsed data to.
+        @type dataset_type: DatasetType
+        @param dataset_type: Type of the dataset.
+        @type task_name: Optional[Union[str, Dict[str, str]]]
+        @param task_name: Optional task name(s) for the dataset.
+            Can be either a single string, in which case all the records
+            added to the dataset will use this value as `task_name`, or
+            a dictionary with class names as keys and task names as values.
+            In the latter case, the task name for a record with a given
+            class name will be taken from the dictionary.
+        """
+        self.dataset = dataset
+        self.dataset_type = dataset_type
+        task_name = task_name or ""
+        if isinstance(task_name, str):
+            self.task_name = defaultdict(lambda: task_name)
+        else:
+            self.task_name = defaultdict(str, task_name)
 
     @staticmethod
     @abstractmethod
@@ -88,13 +111,12 @@ class BaseParser(ABC):
         old_cwd = Path.cwd()
         try:
             generator, skeletons, added_images = self.from_split(**kwargs)
-            self.dataset.add(self._add_task(generator))
+            self.dataset.add(self._wrap_generator(generator))
             if skeletons:
                 for skeleton in skeletons.values():
                     self.dataset.set_skeletons(
                         skeleton.get("labels"),
                         skeleton.get("edges"),
-                        self.task_name,
                     )
             return added_images
         finally:
@@ -230,7 +252,7 @@ class BaseParser(ABC):
             if img.suffix in cv2_supported_image_formats
         ]
 
-    def _add_task(self, generator: DatasetIterator) -> DatasetIterator:
+    def _wrap_generator(self, generator: DatasetIterator) -> DatasetIterator:
         """Adds task to the generator.
 
         @type generator: DatasetIterator
@@ -239,11 +261,20 @@ class BaseParser(ABC):
         @return: Generator function with added task
         """
 
-        task_name = self.task_name or ""
         for item in generator:
             if isinstance(item, dict):
-                if "task_name" not in item or self.task_name is not None:
-                    item["task_name"] = task_name
-            elif not item.task_name or self.task_name is not None:
-                item.task_name = task_name
-            yield item
+                item = DatasetRecord(**item)
+
+            if self.task_name is not None:
+                if item.annotation is None:
+                    for task_name in set(self.task_name.values()):
+                        yield item.model_copy(
+                            update={"task_name": task_name}, deep=True
+                        )
+                else:
+                    class_name = item.annotation.class_name
+                    if class_name is not None:
+                        item.task_name = self.task_name[class_name]
+                    yield item
+            else:
+                yield item

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -273,10 +273,12 @@ class BaseParser(ABC):
                 else:
                     class_name = item.annotation.class_name
                     if class_name is not None:
-                        if class_name not in self.task_name:
+                        try:
+                            task_name = self.task_name[class_name]
+                        except KeyError:
                             raise ValueError(
                                 f"Class '{class_name}' not found in task names."
-                            )
+                            ) from None
 
                         item.task_name = self.task_name[class_name]
                     yield item

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -33,7 +33,6 @@ class BaseParser(ABC):
         """
         self.dataset = dataset
         self.dataset_type = dataset_type
-        task_name = task_name or ""
         if isinstance(task_name, str):
             self.task_name = defaultdict(lambda: task_name)
         else:

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -37,7 +37,7 @@ class BaseParser(ABC):
         if isinstance(task_name, str):
             self.task_name = defaultdict(lambda: task_name)
         else:
-            self.task_name = defaultdict(str, task_name)
+            self.task_name = task_name
 
     @staticmethod
     @abstractmethod
@@ -274,6 +274,11 @@ class BaseParser(ABC):
                 else:
                     class_name = item.annotation.class_name
                     if class_name is not None:
+                        if class_name not in self.task_name:
+                            raise ValueError(
+                                f"Class '{class_name}' not found in task names."
+                            )
+
                         item.task_name = self.task_name[class_name]
                     yield item
             else:

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -67,7 +67,7 @@ class LuxonisParser(Generic[T]):
         save_dir: Optional[Union[Path, str]] = None,
         dataset_plugin: T = None,
         dataset_type: Optional[DatasetType] = None,
-        task_name: Optional[str] = None,
+        task_name: Optional[Union[str, Dict[str, str]]] = None,
         **kwargs,
     ):
         """High-level abstraction over various parsers.
@@ -100,9 +100,13 @@ class LuxonisParser(Generic[T]):
         @param dataset_type: If provided, the parser will use this
             dataset type instead of trying to recognize it
             automatically.
-        @type task_name: Optional[str]
-        @param task_name: Name of the task. If C{None}, the task name
-            is derived from the dataset format.
+        @type task_name: Optional[Union[str, Dict[str, str]]]
+        @param task_name: Optional task name(s) for the dataset.
+            Can be either a single string, in which case all the records
+            added to the dataset will use this value as `task_name`, or
+            a dictionary with class names as keys and task names as values.
+            In the latter case, the task name for a record with a given
+            class name will be taken from the dictionary.
         @type kwargs: Dict[str, Any]
         @param kwargs: Additional C{kwargs} to be passed to the
             constructor of specific L{BaseDataset} implementation.


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it possible to specify a task name based on the class name when using parsers. 
This makes it possible to use parsers with more complicated datasets. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Changed the signature of `task_name` argument to `str | dict[str, str]`. Single string behavior is the same as before (the same `task_name` is used for all the records). 
In addition, the user can specify this to be a dictionary mapping class names to task names, in which case the `task_name` will be selected based on the class of the annotation.

**Example**
```python
parser = LuxonisParser(
    ...
    task_name={
        "cat": "animals",
        "dog": "animals",
        "person": "people"
    },
)
dataset = parser.parse()
``` 

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable