### PR TITLE
Fix Dataset Corruption from Missing Class Info in Last Yield

### DIFF
--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -923,7 +923,7 @@ class LuxonisDataset(BaseDataset):
                     def update_state(task_name: str, ann: Detection) -> None:
                         if ann.class_name is not None:
                             classes_per_task[task_name].add(ann.class_name)
-                        else:
+                        elif not classes_per_task[task_name]:
                             classes_per_task[task_name] = set()
 
                         tasks[task_name] |= ann.get_task_types()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Fixed an issue where, if we yielded the annotation as the last yield without the class info but with the instance_id, the dataset would become corrupted. See the image under testing & validation.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Previously, if the keypoints were yielded at the end with missing class information but with the `instance_id` (so they should be linked with the bounding boxes), the dataset would be corrupted:

<img src="https://github.com/user-attachments/assets/1702f41d-a6de-476d-9b10-56fae0d15151" width="300"/>

A test was added to check for this issue, where the classes would appear as: `Classes: {'': {}}`.

