### PR TITLE
Fix: Pathlib representer for `yaml.safe_dump`

### DIFF
--- a/luxonis_ml/utils/config.py
+++ b/luxonis_ml/utils/config.py
@@ -1,4 +1,5 @@
 import ast
+from pathlib import PurePath
 from typing import Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
 
 import yaml
@@ -78,6 +79,14 @@ class LuxonisConfig(BaseModelExtraForbid):
         @type path: str
         @param path: Path to output yaml file.
         """
+
+        def path_representer(
+            dumper: yaml.SafeDumper, data: PurePath
+        ) -> yaml.ScalarNode:
+            return dumper.represent_scalar("tag:yaml.org,2002:str", str(data))
+
+        yaml.SafeDumper.add_multi_representer(PurePath, path_representer)
+
         with open(path, "w+") as f:
             yaml.safe_dump(self.model_dump(), f, default_flow_style=False)
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it possible to dump configs containing fields with `pathlib.Path` objects.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Added a representer for `pathlib.PurePath` to `yaml.SafeDumper`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Added a test case