### PR TITLE
Devops: Fixed `codecov` base report 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,7 +175,9 @@ jobs:
           cache: pip
 
       - name: Install the package
-        run: pip install -e .[dev]
+        run: |
+          pip install 'pillow-heif<0.22.0'
+          pip install -e .[dev]
 
       - name: Authenticate to Google Cloud
         if: ${{ env.GHC_ENABLED }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
       ROBOFLOW_API_KEY: ${{ secrets.ROBOFLOW_API_KEY }}
-      IS_MAIN_RUNNER: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
       LUXONISML_BUCKET: luxonis-test-bucket
       GHC_ENABLED: ${{ secrets.GCP_CREDENTIALS != null }}
 
@@ -192,21 +191,21 @@ jobs:
         run: pytest --cov --junitxml=junit.xml -o junit_family=legacy -vv -n auto -x
 
       - name: Upload test results to Codecov
-        if: ${{ env.IS_MAIN_RUNNER == true }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Upload coverage results to Codecov
-        if: ${{ env.IS_MAIN_RUNNER == true }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Upload coverage as artifact
-        if: ${{ env.IS_MAIN_RUNNER == true }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,7 +162,6 @@ jobs:
       IS_MAIN_RUNNER: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8' }}
       LUXONISML_BUCKET: luxonis-test-bucket
       GHC_ENABLED: ${{ secrets.GCP_CREDENTIALS != null }}
-      CODECOV_ENABLED: ${{ secrets.CODECOV_TOKEN != null }}
 
     steps:
       - name: Checkout
@@ -193,21 +192,21 @@ jobs:
         run: pytest --cov --junitxml=junit.xml -o junit_family=legacy -vv -n auto -x
 
       - name: Upload test results to Codecov
-        if: ${{ env.IS_MAIN_RUNNER && env.CODECOV_ENABLED }}
+        if: ${{ env.IS_MAIN_RUNNER == true }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Upload coverage results to Codecov
-        if: ${{ env.IS_MAIN_RUNNER && env.CODECOV_ENABLED }}
+        if: ${{ env.IS_MAIN_RUNNER == true }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
       - name: Upload coverage as artifact
-        if: ${{ env.IS_MAIN_RUNNER && env.CODECOV_ENABLED }}
+        if: ${{ env.IS_MAIN_RUNNER == true }}
         uses: actions/upload-artifact@v4
         with:
           name: coverage
@@ -218,18 +217,13 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
 
-    env:
-      CODECOV_ENABLED: ${{ secrets.CODECOV_TOKEN != null }}
-
     steps:
       - name: Checkout
-        if: ${{ env.CODECOV_ENABLED }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
       - name: Download artifacts
-        if: ${{ env.CODECOV_ENABLED }}
         uses: dawidd6/action-download-artifact@v7
         with:
           name: coverage
@@ -237,7 +231,6 @@ jobs:
           workflow: ci.yaml
 
       - name: Upload coverage results to Codecov
-        if: ${{ env.CODECOV_ENABLED }}
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/luxonis_ml/data/requirements.txt
+++ b/luxonis_ml/data/requirements.txt
@@ -10,3 +10,4 @@ filelock~=3.0
 bidict~=0.21
 gdown~=4.7
 defusedxml~=0.7
+pillow-heif<0.22.0

--- a/luxonis_ml/data/requirements.txt
+++ b/luxonis_ml/data/requirements.txt
@@ -10,4 +10,3 @@ filelock~=3.0
 bidict~=0.21
 gdown~=4.7
 defusedxml~=0.7
-pillow-heif<0.22.0


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes updating of the base coverage report.

**Note: Disabled tests on MacOS due to a new release of `pillow-heif` which cannot be built there. Restricting the version is not helping either. The tests MacOS will be re-enabled again once the issue is resolved**

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable