### PR TITLE
Feat Dataset Health

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest]
         python-version: [ '3.8', '3.10' ]
 
     if: ${{ github.event_name == 'pull_request' }}

--- a/luxonis_ml/data/README.md
+++ b/luxonis_ml/data/README.md
@@ -252,6 +252,7 @@ The available commands are:
 - `luxonis_ml data ls` - lists all datasets
 - `luxonis_ml data info <dataset_name>` - prints information about the dataset
 - `luxonis_ml data inspect <dataset_name>` - renders the data in the dataset on screen using `cv2`
+- `luxonis_ml data health <dataset_name>` -  checks the health of the dataset and logs and renders dataset statistics
 - `luxonis_ml data delete <dataset_name>` - deletes the dataset
 
 For more information, run `luxonis_ml data --help` or pass the `--help` flag to any of the above commands.

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -551,14 +551,17 @@ def health(
                 axs[i][0], task_type, class_dist_by_type.get(task_type, [])
             )
             _plot_heatmap(
-                axs[i][1], fig, task_type, heatmaps_by_type.get(task_type)
+                axs[i][1],
+                fig,
+                task_type,
+                heatmaps_by_type.get(task_type),  # type: ignore
             )
 
         plt.tight_layout()
         plt.subplots_adjust(top=0.9, hspace=0.5)
 
         if save_path:
-            fig.savefig(f"{save_path}/dataset_health_{task_name}.png", dpi=150)
+            fig.savefig(f"{save_path}/dataset_health_{task_name}.png", dpi=150)  # type: ignore
             plt.close(fig)
         else:
             plt.show(block=False)

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -422,9 +422,16 @@ def parse(
 def health(
     name: DatasetNameArgument,
     bucket_storage: BucketStorage = bucket_option,
-    save_path: Optional[str] = None,
-    sample_size: int = typer.Option(
-        50000,
+    save_dir: Optional[str] = typer.Option(
+        None,
+        "--save-dir",
+        "-s",
+        help="Directory where the plots should be saved. "
+        "If not provided, the plots will be displayed.",
+        show_default=False,
+    ),
+    sample_size: Optional[int] = typer.Option(
+        None,
         "--sample-size",
         "-s",
         help="Number of annotation rows to sample from the dataset. Note that each task type annotation is in a separate row.",
@@ -517,8 +524,8 @@ def health(
         plt.tight_layout()
         plt.subplots_adjust(top=0.9, hspace=0.5)
 
-        if save_path:
-            fig.savefig(f"{save_path}/dataset_health_{task_name}.png", dpi=150)  # type: ignore
+        if save_dir:
+            fig.savefig(f"{save_dir}/dataset_health_{task_name}.png", dpi=150)  # type: ignore
             plt.close(fig)
         else:
             plt.show(block=False)

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -552,7 +552,7 @@ def health(
             )
             _plot_heatmap(
                 axs[i][1],
-                fig,
+                fig,  # type: ignore
                 task_type,
                 heatmaps_by_type.get(task_type),  # type: ignore
             )

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1372,26 +1372,25 @@ class LuxonisDataset(BaseDataset):
         return zip_path
 
     def get_statistics(self) -> Dict[str, Any]:
-        """
-        Returns dataset statistics as a dictionary with these keys:
+        """Returns comprehensive dataset statistics as a structured
+        dictionary.
 
-        "duplicates": Contains:
-            - "duplicate_uuids": List of {"uuid": str, "files": List[str]}
-            - "duplicate_annotations": List of dicts with file_name, task_name,
-            task_type, annotation, and count
+        The returned dictionary contains:
 
-        "class_distribution": List of {"task_type", "class_name", "count"} dicts
-            showing class frequencies per task (excluding classification tasks)
+            - "duplicates": Analysis of duplicated content
+                - "duplicate_uuids": List of {"uuid": str, "files": List[str]} for images with same UUID
+                - "duplicate_annotations": List of repeated annotations with file_name, task_name, task_type,
+                    annotation content, and count
 
-        "missing_annotations": List of file paths lacking annotations
+            - "class_distributions": Nested dictionary of class frequencies organized by task_name and task_type
+            (excludes classification tasks)
 
-        "heatmaps": Dict with task-type keys ('boundingbox', 'keypoints', etc.) and
-        15x15 grid matrices (list of lists) showing annotation density. None if
-        no data exists for a task type.
+            - "missing_annotations": List of file paths that exist in the dataset but lack annotations
+
+            - "heatmaps": Spatial distribution of annotations as 15x15 grid matrices organized by task_name and task_type
 
         @rtype: Dict[str, Any]
-        @return: Dictionary containing the keys "duplicates", "class_distribution",
-                "missing_annotations", and "heatmaps" as described above.
+        @return: Dataset statistics dictionary as described above
         """
         df = self._load_df_offline(lazy=True)
         index = self._get_file_index(lazy=True, sync_from_cloud=self.is_remote)

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1511,7 +1511,7 @@ class LuxonisDataset(BaseDataset):
                         "counts": annotation["counts"],
                         "size": [annotation["height"], annotation["width"]],
                     }
-                    mask = mask_utils.decode(rle)
+                    mask = mask_utils.decode(rle)  # type: ignore
                     h, w = mask.shape
                     rows, cols = np.where(mask)
                     if rows.size > 0:
@@ -1537,7 +1537,9 @@ class LuxonisDataset(BaseDataset):
 
                 data = np.array(coords)
                 heatmap, _, _ = np.histogram2d(
-                    data[:, 0], data[:, 1], bins=[x_edges, y_edges]
+                    data[:, 0],
+                    data[:, 1],
+                    bins=[x_edges, y_edges],  # type: ignore
                 )
                 stats["heatmaps"][task_name][task_type] = heatmap.T.tolist()
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1364,10 +1364,10 @@ class LuxonisDataset(BaseDataset):
         return zip_path
 
     def get_statistics(
-        self, sample_size: Optional[int] = None
+        self, sample_size: Optional[int] = None, view: Optional[str] = None
     ) -> Dict[str, Any]:
         """Returns comprehensive dataset statistics as a structured
-        dictionary.
+        dictionary for the given view or the entire dataset.
 
         The returned dictionary contains:
 
@@ -1383,6 +1383,10 @@ class LuxonisDataset(BaseDataset):
 
             - "heatmaps": Spatial distribution of annotations as 15x15 grid matrices organized by task_name and task_type
 
+        @type sample_size: Optional[int]
+        @param sample_size: Number of samples to use for heatmap generation
+        @type view: Optional[str]
+        @param view: Name of the view to analyze. If None, the entire dataset is analyzed.
         @rtype: Dict[str, Any]
         @return: Dataset statistics dictionary as described above
         """
@@ -1400,6 +1404,10 @@ class LuxonisDataset(BaseDataset):
             return stats
 
         df = df.join(index, on="uuid").drop("file_right")
+
+        splits = self.get_splits()
+        if view and view in splits:
+            df = df.filter(pl.col("uuid").is_in(splits[view]))
 
         stats["duplicates"] = get_duplicates_info(df)
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1386,7 +1386,7 @@ class LuxonisDataset(BaseDataset):
         "missing_annotations": List of file paths lacking annotations
 
         "heatmaps": Dict with task-type keys ('boundingbox', 'keypoints', etc.) and
-        20x20 grid matrices (list of lists) showing annotation density. None if
+        15x15 grid matrices (list of lists) showing annotation density. None if
         no data exists for a task type.
 
         @rtype: Dict[str, Any]

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -39,12 +39,12 @@ from luxonis_ml.data.utils import (
     BucketType,
     ParquetFileManager,
     UpdateMode,
-    find_duplicates,
     get_class_distributions,
     get_duplicates_info,
     get_heatmaps,
     get_missing_annotations,
     infer_task,
+    warn_on_duplicates,
 )
 from luxonis_ml.data.utils.constants import LDF_VERSION
 from luxonis_ml.data.utils.task_utils import get_task_type
@@ -1016,18 +1016,7 @@ class LuxonisDataset(BaseDataset):
         if df is None or index is None:
             return
         df = df.join(index, on="uuid").drop("file_right")
-        duplicates_info = find_duplicates(df)
-        if duplicates_info["duplicate_uuids"]:
-            for item in duplicates_info["duplicate_uuids"]:
-                logger.warning(
-                    f"UUID {item['uuid']} is the same for multiple files: {item['files']}"
-                )
-
-        for item in duplicates_info["duplicate_annotations"]:
-            logger.warning(
-                f"File '{item['file_name']}' of task '{item['task_name']}' has the "
-                f"same '{item['task_type']}' annotation '{item['annotation']}' repeated {item['count']} times."
-            )
+        warn_on_duplicates(df)
 
     def get_splits(self) -> Optional[Dict[str, List[str]]]:
         splits_path = get_file(

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1406,8 +1406,8 @@ class LuxonisDataset(BaseDataset):
         df = df.join(index, on="uuid").drop("file_right")
 
         splits = self.get_splits()
-        if view and view in splits:
-            df = df.filter(pl.col("uuid").is_in(splits[view]))
+        if splits is not None and view and view in splits:
+            df = df.filter(pl.col("uuid").is_in(splits[view]))  # type: ignore
 
         stats["duplicates"] = get_duplicates_info(df)
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1395,7 +1395,6 @@ class LuxonisDataset(BaseDataset):
 
         stats = {
             "duplicates": {},
-            "class_distribution": {},
             "missing_annotations": 0,
             "heatmaps": {},
         }

--- a/luxonis_ml/data/parsers/voc_parser.py
+++ b/luxonis_ml/data/parsers/voc_parser.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import numpy as np
 from defusedxml.ElementTree import parse
@@ -82,6 +82,9 @@ class VOCParser(BaseParser):
         for anno_xml in annotation_dir.glob("*.xml"):
             annotation_data = parse(anno_xml)
             root = annotation_data.getroot()
+            if root is None:
+                raise ValueError(f"'{anno_xml}' is empty")
+            root = cast(ET.Element, root)
 
             path = image_dir.absolute().resolve() / self._xml_find(
                 root, "filename"

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -6,6 +6,7 @@ from .data_utils import (
     get_missing_annotations,
     infer_task,
     rgb_to_bool_masks,
+    warn_on_duplicates,
 )
 from .enums import BucketStorage, BucketType, ImageType, MediaType, UpdateMode
 from .parquet import ParquetFileManager, ParquetRecord
@@ -52,4 +53,5 @@ __all__ = [
     "task_is_metadata",
     "task_type_iterator",
     "visualize",
+    "warn_on_duplicates",
 ]

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -1,6 +1,15 @@
-from .data_utils import find_duplicates, infer_task, rgb_to_bool_masks
+from .data_utils import (
+    find_duplicates,
+    get_class_distributions,
+    get_duplicates_info,
+    get_heatmaps,
+    get_missing_annotations,
+    infer_task,
+    rgb_to_bool_masks,
+)
 from .enums import BucketStorage, BucketType, ImageType, MediaType, UpdateMode
 from .parquet import ParquetFileManager, ParquetRecord
+from .plot_utils import plot_class_distribution, plot_heatmap
 from .task_utils import (
     get_task_name,
     get_task_type,
@@ -29,9 +38,15 @@ __all__ = [
     "create_text_image",
     "distinct_color_generator",
     "find_duplicates",
+    "get_class_distributions",
+    "get_duplicates_info",
+    "get_heatmaps",
+    "get_missing_annotations",
     "get_task_name",
     "get_task_type",
     "infer_task",
+    "plot_class_distribution",
+    "plot_heatmap",
     "rgb_to_bool_masks",
     "split_task",
     "task_is_metadata",

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -1,4 +1,4 @@
-from .data_utils import infer_task, rgb_to_bool_masks, warn_on_duplicates
+from .data_utils import find_duplicates, infer_task, rgb_to_bool_masks
 from .enums import BucketStorage, BucketType, ImageType, MediaType, UpdateMode
 from .parquet import ParquetFileManager, ParquetRecord
 from .task_utils import (
@@ -28,6 +28,7 @@ __all__ = [
     "concat_images",
     "create_text_image",
     "distinct_color_generator",
+    "find_duplicates",
     "get_task_name",
     "get_task_type",
     "infer_task",
@@ -36,5 +37,4 @@ __all__ = [
     "task_is_metadata",
     "task_type_iterator",
     "visualize",
-    "warn_on_duplicates",
 ]

--- a/luxonis_ml/data/utils/data_utils.py
+++ b/luxonis_ml/data/utils/data_utils.py
@@ -148,7 +148,7 @@ def find_duplicates(df: pl.LazyFrame) -> Dict[str, List[Dict[str, Any]]]:
         "duplicate_annotations": [],
     }
 
-    # Warn on duplicate UUIDs
+    # Find duplicate UUIDs
     uuid_file_pairs = df.select("uuid", "file").unique().collect()
 
     duplicates = (
@@ -171,18 +171,21 @@ def find_duplicates(df: pl.LazyFrame) -> Dict[str, List[Dict[str, Any]]]:
                 }
             )
 
-    # Warn on duplicate annotations
+    # Find duplicate annotations
     def is_all_zero_keypoints(annotation_str: str) -> bool:
         """Check if a keypoints annotation has all zeros (x, y,
         visibility)."""
-        annotation = json.loads(annotation_str)
-        if "keypoints" in annotation:
-            for kp in annotation["keypoints"]:
-                if len(kp) >= 3:
-                    x, y, v = kp[0], kp[1], kp[2]
-                    if x != 0 or y != 0 or v != 0:
-                        return False
-            return True
+        try:
+            annotation = json.loads(annotation_str)
+            if "keypoints" in annotation:
+                for kp in annotation["keypoints"]:
+                    if len(kp) >= 3:
+                        x, y, v = kp[0], kp[1], kp[2]
+                        if x != 0 or y != 0 or v != 0:
+                            return False
+                return True
+        except (TypeError, ValueError):
+            return False
         return False
 
     filtered_df = df.filter(

--- a/luxonis_ml/data/utils/data_utils.py
+++ b/luxonis_ml/data/utils/data_utils.py
@@ -319,7 +319,9 @@ def get_duplicates_info(df: pl.LazyFrame) -> Dict[str, Any]:
 
 
 def get_heatmaps(
-    df: pl.LazyFrame, sample_size: Optional[int] = None
+    df: pl.LazyFrame,
+    sample_size: Optional[int] = None,
+    downsample_factor: int = 5,
 ) -> Dict[str, Dict[str, List[List[int]]]]:
     """Generates heatmaps for bounding boxes, keypoints, and
     segmentations.
@@ -329,6 +331,9 @@ def get_heatmaps(
     @type sample_size: Optional[int]
     @param sample_size: Number of samples to take from the dataset.
         Default is None.
+    @type downsample_factor: int
+    @param downsample_factor: Factor to downsample the segmentation
+        masks.
     @rtype: Dict[str, Dict[str, List[List[int]]]]
     @return: A dictionary with task names as keys, and dictionaries with
         task types as keys and lists of lists of integers representing
@@ -395,6 +400,8 @@ def get_heatmaps(
                     "size": [annotation["height"], annotation["width"]],
                 }
                 mask = mask_utils.decode(rle)
+                if downsample_factor > 1:
+                    mask = mask[::downsample_factor, ::downsample_factor]
                 rows_idx, cols_idx = np.where(mask)
                 if rows_idx.size == 0:
                     continue

--- a/luxonis_ml/data/utils/data_utils.py
+++ b/luxonis_ml/data/utils/data_utils.py
@@ -419,7 +419,7 @@ def get_heatmaps(
                     "counts": annotation["counts"],
                     "size": [annotation["height"], annotation["width"]],
                 }
-                mask = mask_utils.decode(rle)
+                mask = mask_utils.decode(rle)  # type: ignore
                 if downsample_factor > 1:
                     mask = mask[::downsample_factor, ::downsample_factor]
                 rows_idx, cols_idx = np.where(mask)

--- a/luxonis_ml/data/utils/data_utils.py
+++ b/luxonis_ml/data/utils/data_utils.py
@@ -234,6 +234,26 @@ def find_duplicates(df: pl.LazyFrame) -> Dict[str, List[Dict[str, Any]]]:
     return result
 
 
+def warn_on_duplicates(df: pl.LazyFrame) -> None:
+    """Logs warnings for duplicate UUIDs and annotations in the dataset.
+
+    @type df: pl.LazyFrame
+    @param df: Polars lazy frame containing dataset information.
+    """
+    duplicates_info = find_duplicates(df)
+    if duplicates_info["duplicate_uuids"]:
+        for item in duplicates_info["duplicate_uuids"]:
+            logger.warning(
+                f"UUID {item['uuid']} is the same for multiple files: {item['files']}"
+            )
+
+    for item in duplicates_info["duplicate_annotations"]:
+        logger.warning(
+            f"File '{item['file_name']}' of task '{item['task_name']}' has the "
+            f"same '{item['task_type']}' annotation '{item['annotation']}' repeated {item['count']} times."
+        )
+
+
 def get_class_distributions(
     df: pl.LazyFrame,
 ) -> Dict[str, Dict[str, List[Dict[str, Any]]]]:

--- a/luxonis_ml/data/utils/data_utils.py
+++ b/luxonis_ml/data/utils/data_utils.py
@@ -188,7 +188,11 @@ def find_duplicates(df: pl.LazyFrame) -> Dict[str, List[Dict[str, Any]]]:
     filtered_df = df.filter(
         ~(
             (pl.col("task_type") == "keypoints")
-            & (pl.col("annotation").map_elements(is_all_zero_keypoints))
+            & (
+                pl.col("annotation").map_elements(
+                    is_all_zero_keypoints, return_dtype=pl.Boolean
+                )
+            )
         )
     )
     duplicate_annotation = (

--- a/luxonis_ml/data/utils/plot_utils.py
+++ b/luxonis_ml/data/utils/plot_utils.py
@@ -14,7 +14,9 @@ def _prepare_class_data(
     return classes, counts
 
 
-def _annotate_bars(ax: plt.Axes, bars: BarContainer) -> None:
+def _annotate_bars(
+    ax: plt.Axes, bars: BarContainer
+) -> None:  # pragma: no cover
     """Adds numeric labels above bars."""
     for bar in bars:
         height = bar.get_height()
@@ -31,7 +33,7 @@ def _annotate_bars(ax: plt.Axes, bars: BarContainer) -> None:
 
 def plot_class_distribution(
     ax: plt.Axes, task_type: str, task_data: List[Dict[str, Any]]
-) -> None:
+) -> None:  # pragma: no cover
     """Plots a bar chart of class distribution.
 
     @type ax: plt.Axes
@@ -80,7 +82,7 @@ def plot_heatmap(
     fig: plt.Figure,
     task_type: str,
     heatmap_data: Optional[List[List[float]]],
-) -> None:
+) -> None:  # pragma: no cover
     """ " Plots a heatmap of heatmap_data.
 
     @type ax: plt.Axes

--- a/luxonis_ml/data/utils/plot_utils.py
+++ b/luxonis_ml/data/utils/plot_utils.py
@@ -59,7 +59,7 @@ def plot_class_distribution(
     ax.tick_params(
         axis="x", rotation=90 if num_classes > 5 else 45, labelsize=8
     )
-    for tick in ax.get_xticklabels():
+    for tick in ax.get_xticklabels():  # type: ignore
         tick.set_ha("center")
     ax.margins(x=0.01)
 

--- a/luxonis_ml/data/utils/plot_utils.py
+++ b/luxonis_ml/data/utils/plot_utils.py
@@ -1,0 +1,99 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.container import BarContainer
+
+
+def _prepare_class_data(
+    task_data: List[Dict[str, Any]],
+) -> Tuple[List[str], List[int]]:
+    """Extracts class names and counts from task_data."""
+    classes = [x["class_name"] for x in task_data]
+    counts = [x["count"] for x in task_data]
+    return classes, counts
+
+
+def _annotate_bars(ax: plt.Axes, bars: BarContainer) -> None:
+    """Adds numeric labels above bars."""
+    for bar in bars:
+        height = bar.get_height()
+        ax.annotate(
+            f"{height}",
+            xy=(bar.get_x() + bar.get_width() / 2, height),
+            xytext=(0, 5),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=7,
+        )
+
+
+def plot_class_distribution(
+    ax: plt.Axes, task_type: str, task_data: List[Dict[str, Any]]
+) -> None:
+    """Plots a bar chart of class distribution.
+
+    @type ax: plt.Axes
+    @param ax: The axis to plot on.
+    @type task_type: str
+    @param task_type: The type of task.
+    @type task_data: List[Dict[str, Any]]
+    @param task_data: The task data to plot.
+    """
+    if not task_data:
+        ax.axis("off")
+        ax.set_title(f"{task_type} Class Distribution (None)", fontsize=12)
+        return
+
+    classes, counts = _prepare_class_data(task_data)
+    num_classes = len(classes)
+    bar_width = 1 / (num_classes**0.1) if num_classes else 1
+    bars = ax.bar(classes, counts, width=bar_width, color="royalblue")
+
+    # Set plot properties
+    if counts:
+        ax.set_ylim(top=max(counts) * 1.15)
+    ax.set_title(f"{task_type} Class Distribution", fontsize=12, pad=15)
+    ax.set_ylabel("Count", fontsize=12)
+    ax.tick_params(axis="x", rotation=90)
+    ax.margins(x=0.01)
+
+    _annotate_bars(ax, bars)
+
+
+def _prepare_heatmap_data(
+    heatmap_data: Optional[List[List[float]]],
+) -> np.ndarray:
+    """Converts heatmap_data to a normalized NumPy array."""
+    matrix = np.array(heatmap_data, dtype=np.float32)
+    max_val = matrix.max()
+    return matrix / max_val if max_val > 0 else matrix
+
+
+def plot_heatmap(
+    ax: plt.Axes,
+    fig: plt.Figure,
+    task_type: str,
+    heatmap_data: Optional[List[List[float]]],
+) -> None:
+    """ " Plots a heatmap of heatmap_data.
+
+    @type ax: plt.Axes
+    @param ax: The axis to plot on.
+    @type fig: plt.Figure
+    @param fig: The figure to plot on.
+    @type task_type: str
+    @param task_type: The type of task.
+    @type heatmap_data: Optional[List[List[float]]]
+    @param heatmap_data: The heatmap data to plot.
+    """
+    if heatmap_data is None:
+        ax.axis("off")
+        ax.set_title(f"{task_type} Heatmap (None)", fontsize=12)
+        return
+
+    matrix = _prepare_heatmap_data(heatmap_data)
+    im = ax.imshow(matrix, cmap="viridis", extent=[0, 1, 0, 1], vmin=0, vmax=1)
+    fig.colorbar(im, ax=ax, label="Relative Annotation Density")
+    ax.set_title(f"{task_type} Heatmap", fontsize=12)

--- a/luxonis_ml/data/utils/plot_utils.py
+++ b/luxonis_ml/data/utils/plot_utils.py
@@ -56,7 +56,11 @@ def plot_class_distribution(
         ax.set_ylim(top=max(counts) * 1.15)
     ax.set_title(f"{task_type} Class Distribution", fontsize=12, pad=15)
     ax.set_ylabel("Count", fontsize=12)
-    ax.tick_params(axis="x", rotation=90)
+    ax.tick_params(
+        axis="x", rotation=90 if num_classes > 5 else 45, labelsize=8
+    )
+    for tick in ax.get_xticklabels():
+        tick.set_ha("center")
     ax.margins(x=0.01)
 
     _annotate_bars(ax, bars)

--- a/tests/test_data/test_health.py
+++ b/tests/test_data/test_health.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+
+from luxonis_ml.data import LuxonisParser
+from luxonis_ml.data.utils.plot_utils import (
+    _prepare_class_data,
+    _prepare_heatmap_data,
+)
+
+
+@pytest.mark.parametrize("url", ["COCO_people_subset.zip"])
+def test_dataset_health(
+    dataset_name: str,
+    url: str,
+    storage_url: str,
+    tempdir: Path,
+):
+    url = f"{storage_url}/{url}"
+    dataset = LuxonisParser(
+        url,
+        dataset_name=dataset_name,
+        delete_existing=True,
+        save_dir=tempdir,
+    ).parse()
+
+    statistics = dataset.get_statistics()
+
+    class_dists = statistics["class_distributions"][""]
+    tasks = [
+        "segmentation",
+        "keypoints",
+        "instance_segmentation",
+        "boundingbox",
+    ]
+    for task in tasks:
+        task_classes = class_dists[task]
+        assert len(task_classes) == 1
+        assert task_classes[0]["class_name"] == "person"
+        assert task_classes[0]["count"] == 145
+        _prepare_class_data(task_classes)
+
+    heatmaps = statistics["heatmaps"][""]
+    annotation_types = [
+        "boundingbox",
+        "keypoints",
+        "segmentation",
+        "instance_segmentation",
+    ]
+    for ann_type in annotation_types:
+        grid = heatmaps[ann_type]
+        _prepare_heatmap_data(grid)
+        assert len(grid) == 15
+        for row in grid:
+            assert len(row) == 15
+
+    assert heatmaps["segmentation"] == heatmaps["instance_segmentation"]
+
+    assert (
+        sum(sum(row) for row in statistics["heatmaps"][""]["keypoints"])
+        == 1169
+    )
+    assert (
+        sum(sum(row) for row in statistics["heatmaps"][""]["boundingbox"])
+        == 145
+    )
+    assert (
+        sum(sum(row) for row in statistics["heatmaps"][""]["segmentation"])
+        == 66953
+    )
+    assert (
+        sum(
+            sum(row)
+            for row in statistics["heatmaps"][""]["instance_segmentation"]
+        )
+        == 66953
+    )

--- a/tests/test_data/test_health.py
+++ b/tests/test_data/test_health.py
@@ -65,13 +65,19 @@ def test_dataset_health(
         == 145
     )
     assert (
-        sum(sum(row) for row in statistics["heatmaps"][""]["segmentation"])
-        == 66953
+        abs(
+            sum(sum(row) for row in statistics["heatmaps"][""]["segmentation"])
+            - 66953
+        )
+        <= 2
     )
     assert (
-        sum(
-            sum(row)
-            for row in statistics["heatmaps"][""]["instance_segmentation"]
+        abs(
+            sum(
+                sum(row)
+                for row in statistics["heatmaps"][""]["instance_segmentation"]
+            )
+            - 66953
         )
-        == 66953
+        <= 2
     )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

Adds a new CLI command named `health` that generates dataset statistics, including duplicates, files with missing annotations, class distributions, and annotation heatmaps. It also logs files with missing annotations, duplicate UUIDs, or duplicate annotations, and optionally saves or displays plots of class distributions and heatmaps.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->

Example of plotting the distributions and heatmap can be seen in the image below:  

<img src="https://github.com/user-attachments/assets/b9673085-a481-4afb-ba8d-4a5fc213e890" width="700">  


