### PR TITLE
Hotfix: Recursion in tracker artifact logging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         python-version: [ '3.8', '3.10' ]
 
     if: ${{ github.event_name == 'pull_request' }}

--- a/luxonis_ml/tracker/tracker.py
+++ b/luxonis_ml/tracker/tracker.py
@@ -534,7 +534,7 @@ class LuxonisTracker:
                         self.upload_artifact, path, name, typ
                     )  # Stores details for retrying later
                     self.log_stored_logs_to_mlflow(
-                        _retry_counter=_retry_counter
+                        _retry_counter=_retry_counter + 1
                     )
                 else:
                     raise

--- a/luxonis_ml/tracker/tracker.py
+++ b/luxonis_ml/tracker/tracker.py
@@ -527,17 +527,18 @@ class LuxonisTracker:
                     mlflow_instance=self.experiment.get("mlflow"),
                 )
             except Exception as e:
-                time.sleep(5)
+                time.sleep(2)
                 if _retry_counter < 10:
-                    logger.warning(f"Failed to upload artifact to MLflow: {e}")
-                    self.store_log_locally(
-                        self.upload_artifact, path, name, typ
-                    )  # Stores details for retrying later
-                    self.log_stored_logs_to_mlflow(
-                        _retry_counter=_retry_counter + 1
+                    time.sleep(2)
+                    logger.warning(
+                        f"Failed to upload artifact to MLflow (retry {_retry_counter}/10): {e}"
                     )
-                else:
-                    raise
+                    return self.upload_artifact(
+                        path, name, typ, _retry_counter=_retry_counter + 1
+                    )
+                logger.error("Reached maximum retries. Storing logs locally.")
+                self.store_log_locally(self.upload_artifact, path, name, typ)
+                raise
 
     @rank_zero_only
     def log_matrix(self, matrix: np.ndarray, name: str, step: int) -> None:

--- a/luxonis_ml/tracker/tracker.py
+++ b/luxonis_ml/tracker/tracker.py
@@ -531,6 +531,7 @@ class LuxonisTracker:
                 )
             except Exception as e:
                 if _retry_counter < 10:
+                    time.sleep(1)
                     logger.warning(
                         f"Failed to upload artifact to MLflow (retry {_retry_counter}/10): {e}"
                     )


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Removes an infinite recursion in `upload_artifact`
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added hidden argument `_retry_counter` which is increased by 1 after each retry, if it reaches 10, the upload fails
- Also added five second sleep before every try

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable