### PR TITLE
Feature: Support for export of segmentation masks

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -245,6 +245,16 @@ def inspect(
             help="Deterministic mode. Useful for debugging.",
         ),
     ] = False,
+    force_update: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            "--force-update",
+            "-f",
+            help="Force synchronization of the dataset with the "
+            "remote storage. Only relevant for remote datasets.",
+        ),
+    ] = False,
     blend_all: Annotated[
         bool,
         typer.Option(
@@ -266,7 +276,11 @@ def inspect(
 
     view = view or ["train"]
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
-    loader = LuxonisLoader(dataset, view=view)
+    loader = LuxonisLoader(
+        dataset,
+        view=view,
+        update_mode="always" if force_update else "if_empty",
+    )
 
     if aug_config is not None:
         h, w, _ = loader[0][0].shape
@@ -315,7 +329,7 @@ def export(
             help="Format of the exported dataset",
             show_default=False,
         ),
-    ] = "coco",  # type: ignore
+    ] = "native",  # type: ignore
     delete_existing: Annotated[
         bool,
         typer.Option(

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1353,6 +1353,8 @@ class LuxonisDataset(BaseDataset):
             for root, _, files in os.walk(output_path / self.identifier):
                 for file in files:
                     file = Path(root, file)
-                    zipf.write(file, file.relative_to(output_path))
+                    zipf.write(
+                        file, file.relative_to(output_path / self.identifier)
+                    )
         logger.info(f"Dataset '{self.identifier}' exported to '{zip_path}'")
         return zip_path

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -24,13 +24,12 @@ from typing import (
     overload,
 )
 
-import cv2
 import numpy as np
 import polars as pl
 import pyarrow.parquet as pq
-from bidict import bidict
 from filelock import FileLock
 from loguru import logger
+from rich.progress import track
 from semver.version import Version
 from typing_extensions import Self, override
 
@@ -43,14 +42,12 @@ from luxonis_ml.data.utils import (
     warn_on_duplicates,
 )
 from luxonis_ml.data.utils.constants import LDF_VERSION
-from luxonis_ml.data.utils.task_utils import get_task_type
 from luxonis_ml.enums.enums import DatasetType
 from luxonis_ml.typing import PathType
 from luxonis_ml.utils import (
     LuxonisFileSystem,
     deprecated,
     environ,
-    log_once,
     make_progress_bar,
 )
 
@@ -58,7 +55,6 @@ from .annotation import (
     Category,
     DatasetRecord,
     Detection,
-    SegmentationAnnotation,
 )
 from .base_dataset import BaseDataset, DatasetIterator
 from .metadata import Metadata
@@ -1249,7 +1245,7 @@ class LuxonisDataset(BaseDataset):
     def export(
         self,
         output_path: PathType,
-        dataset_type: DatasetType = DatasetType.COCO,
+        dataset_type: DatasetType = DatasetType.NATIVE,
     ) -> Path:
         """Exportes the dataset into on of the supported formats.
 
@@ -1262,12 +1258,11 @@ class LuxonisDataset(BaseDataset):
         @rtype: Path
         @return: Path to the zip file containing the exported dataset.
         """
-        if dataset_type is not DatasetType.COCO:
+        if dataset_type is not DatasetType.NATIVE:
             raise NotImplementedError(
-                "Only COCO dataset export is supported at the moment"
+                "Only 'NATIVE' dataset export is supported at the moment"
             )
         logger.info(f"Exporting '{self.identifier}' to COCO format")
-        from luxonis_ml.data import LuxonisLoader
 
         splits = self.get_splits()
         if splits is None:
@@ -1282,127 +1277,76 @@ class LuxonisDataset(BaseDataset):
                 f"Export path '{output_path}' already exists. Please remove it first."
             )
         output_path.mkdir(parents=True)
-        for i, split in enumerate(splits):
-            loader = LuxonisLoader(
-                self,
-                view=[split],
-                update_mode="always" if i == 0 else "if_empty",
-            )
-            classes = bidict(
-                loader.classes[next(iter(self.get_tasks()))]
-            ).inverse
-            if split == "val":
-                split = "valid"
+        image_indices = {}
+        annotations = {"train": [], "val": [], "test": []}
+        df = self._load_df_offline(raise_when_empty=True)
+        splits = self.get_splits()
+        assert splits is not None
+        for row in track(
+            df.iter_rows(),
+            total=len(df),
+            description=f"Exporting '{self.identifier}'",
+        ):
+            uuid = row[-1]
+            if self.is_remote:
+                file_extension = row[0].rsplit(".", 1)[-1]
+                file = self.media_path / f"{uuid}.{file_extension}"
+                assert file.exists()
+            else:
+                file = Path(row[0])
+
+            split = None
+            for s, uuids in splits.items():
+                if uuid in uuids:
+                    split = s
+                    break
+
+            assert split is not None
             split_path = output_path / self.identifier / split
-            data_path = split_path / "data"
+            data_path = split_path / "images"
             data_path.mkdir(parents=True, exist_ok=True)
-            coco_annotations = []
-            coco_images = []
-            coco_categories = [
-                {"id": i, "name": name} for i, name in classes.items()
-            ]
-            segmentation_categories = []
-            skeletons = self.get_skeletons()
-            if skeletons:
-                labels, edges = next(iter(skeletons.values()))
-                for cat in coco_categories:
-                    cat["skeleton"] = [
-                        [in_edge + 1, out_edge + 1]
-                        for in_edge, out_edge in edges
-                    ]
-                    cat["keypoints"] = labels
 
-            for image_id, (img, labels) in enumerate(loader):
-                img_h, img_w = img.shape[:2]
-                img_path = data_path / f"{image_id:06}.png"
-                cv2.imwrite(
-                    str(img_path), cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
-                )
-                instances = defaultdict(dict)
-                for task, arrays in labels.items():
-                    task_type = get_task_type(task)
-                    if task_type == "boundingbox":
-                        for instance_id, arr in enumerate(arrays):
-                            class_id = arr[0].astype(int).item()
-                            instances[instance_id].update(
-                                {"image_id": image_id, "category_id": class_id}
-                            )
-                            bbox = arr[1:]
-                            bbox[::2] *= img_w
-                            bbox[1::2] *= img_h
-                            instances[instance_id]["bbox"] = bbox.tolist()
+            if file not in image_indices:
+                image_indices[file] = len(image_indices)
+            task_name: str = row[2]
+            class_name: Optional[str] = row[3]
+            instance_id: int = row[4]
+            task_type: str = row[5]
+            ann_str: Optional[str] = row[6]
+            if ann_str is None:
+                continue
+            data = []
+            data = json.loads(ann_str)
+            shutil.copy(
+                file, (data_path / f"{image_indices[file]}{file.suffix}")
+            )
+            record = {
+                "file": str(
+                    Path(
+                        data_path.name,
+                        str(image_indices[file]) + file.suffix,
+                    )
+                ),
+                "task_name": task_name,
+                "annotation": {
+                    "instance_id": instance_id,
+                    "class": class_name,
+                },
+            }
+            if task_type in {
+                "instance_segmentation",
+                "segmentation",
+                "boundingbox",
+                "keypoints",
+            }:
+                record["annotation"][task_type] = data
+                annotations[split].append(record)
 
-                    elif task_type == "keypoints":
-                        for instance_id, arr in enumerate(arrays):
-                            arr = arr.reshape(-1, 3)
-                            arr[:, 0] *= img_w
-                            arr[:, 1] *= img_h
-                            instances[instance_id]["keypoints"] = arr.tolist()
-                    elif task_type == "instance_segmentation":
-                        for instance_id, mask in enumerate(arrays):
-                            rle = SegmentationAnnotation._numpy_to_rle(mask)
-                            coco_rle = {
-                                "size": [rle["height"], rle["width"]],
-                                "counts": rle["counts"],
-                            }
-                            instances[instance_id]["segmentation"] = coco_rle
-                    elif task_type == "segmentation":
-                        for class_id, mask in enumerate(arrays):
-                            rle = SegmentationAnnotation._numpy_to_rle(mask)
-                            coco_rle = {
-                                "size": [rle["height"], rle["width"]],
-                                "counts": rle["counts"],
-                            }
-                            instances[class_id].update(
-                                {
-                                    "image_id": image_id,
-                                    "category_id": -class_id,
-                                    "segmentation": coco_rle,
-                                    "bbox": [0, 0, img_w, img_h],
-                                }
-                            )
-                            class_name = coco_categories[class_id]["name"]
-                            if class_name != "background":
-                                class_name = (
-                                    f"{class_name}_semantic_segmentation"
-                                )
-                            if {
-                                "id": -class_id,
-                                "name": class_name,
-                            } not in segmentation_categories:
-                                segmentation_categories.append(
-                                    {"id": -class_id, "name": class_name}
-                                )
-                    else:
-                        log_once(
-                            logger.warning,
-                            f"Task type '{task_type}' is currently "
-                            "unsupported. It won't be included in "
-                            "the exported dataset.",
-                        )
-
-                coco_annotations.extend(instances.values())
-
-                coco_images.append(
-                    {
-                        "id": image_id,
-                        "file_name": img_path.name,
-                        "width": img_w,
-                        "height": img_h,
-                    }
-                )
-
-            with open(split_path / "labels.json", "w") as f:
-                json.dump(
-                    {
-                        "annotations": coco_annotations,
-                        "images": coco_images,
-                        "categories": coco_categories
-                        + segmentation_categories,
-                    },
-                    f,
-                    indent=4,
-                )
+        for split, annotation in annotations.items():
+            split_path = output_path / self.identifier / split
+            split_path.mkdir(parents=True, exist_ok=True)
+            with open(split_path / "annotations.json", "w") as f:
+                json.dump(annotation, f, indent=4)
 
         zip_path = output_path / f"{self.identifier}.zip"
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zipf:

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1291,7 +1291,7 @@ class LuxonisDataset(BaseDataset):
         for row in track(
             df.iter_rows(),
             total=len(df),
-            description=f"Exporting '{self.identifier}'",
+            description="Exporting ...",
         ):
             uuid = row[7]
             if self.is_remote:

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1262,7 +1262,9 @@ class LuxonisDataset(BaseDataset):
             raise NotImplementedError(
                 "Only 'NATIVE' dataset export is supported at the moment"
             )
-        logger.info(f"Exporting '{self.identifier}' to COCO format")
+        logger.info(
+            f"Exporting '{self.identifier}' to '{dataset_type.name}' format"
+        )
 
         splits = self.get_splits()
         if splits is None:

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -276,12 +276,12 @@ class LuxonisLoader(BaseLoader):
         ann_indices = self.idx_to_df_row[idx]
 
         ann_rows = [self.df.row(row) for row in ann_indices]
-        if not self.dataset.is_remote:
-            img_path = ann_rows[0][-1]
-        else:
+        if self.dataset.is_remote:
             uuid = ann_rows[0][7]
             file_extension = ann_rows[0][0].rsplit(".", 1)[-1]
             img_path = self.dataset.media_path / f"{uuid}.{file_extension}"
+        else:
+            img_path = ann_rows[0][-1]
 
         img = cv2.cvtColor(cv2.imread(str(img_path)), cv2.COLOR_BGR2RGB)
 

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -1,4 +1,3 @@
-import os
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from pathlib import Path
@@ -107,19 +106,15 @@ class BaseParser(ABC):
         @rtype: List[str]
         @return: List of added images.
         """
-        old_cwd = Path.cwd()
-        try:
-            generator, skeletons, added_images = self.from_split(**kwargs)
-            self.dataset.add(self._wrap_generator(generator))
-            if skeletons:
-                for skeleton in skeletons.values():
-                    self.dataset.set_skeletons(
-                        skeleton.get("labels"),
-                        skeleton.get("edges"),
-                    )
-            return added_images
-        finally:
-            os.chdir(old_cwd)
+        generator, skeletons, added_images = self.from_split(**kwargs)
+        self.dataset.add(self._wrap_generator(generator))
+        if skeletons:
+            for skeleton in skeletons.values():
+                self.dataset.set_skeletons(
+                    skeleton.get("labels"),
+                    skeleton.get("edges"),
+                )
+        return added_images
 
     def parse_split(
         self,

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -1,4 +1,5 @@
 import json
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -66,10 +67,15 @@ class NativeParser(BaseParser):
 
         def generator() -> DatasetIterator:
             for record in data:
-                record["file"] = (
-                    annotation_path.parent / record["file"]
-                ).absolute()
-
+                with suppress(KeyError):
+                    record["file"] = (
+                        annotation_path.parent / record["file"]
+                    ).absolute()
+                    mask = record["annotation"]["segmentation"]["mask"]
+                    if isinstance(mask, (str, Path)):
+                        record["annotation"]["segmentation"]["mask"] = (
+                            annotation_path.parent / mask
+                        ).absolute()
                 yield record
 
         added_images = self._get_added_images(generator())

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -71,11 +71,13 @@ class NativeParser(BaseParser):
                     record["file"] = (
                         annotation_path.parent / record["file"]
                     ).absolute()
-                    mask = record["annotation"]["segmentation"]["mask"]
-                    if isinstance(mask, (str, Path)):
-                        record["annotation"]["segmentation"]["mask"] = (
-                            annotation_path.parent / mask
-                        ).absolute()
+                for mask_type in ["segmentation", "instance_segmentation"]:
+                    with suppress(KeyError):
+                        mask = record["annotation"][mask_type]["mask"]
+                        if isinstance(mask, (str, Path)):
+                            record["annotation"][mask_type]["mask"] = (
+                                annotation_path.parent / mask
+                            ).absolute()
                 yield record
 
         added_images = self._get_added_images(generator())

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -32,7 +32,7 @@ class NativeParser(BaseParser):
 
     @staticmethod
     def validate(dataset_dir: Path) -> bool:
-        for split in ["train", "valid", "test"]:
+        for split in ["train", "val", "test"]:
             split_path = dataset_dir / split
             if NativeParser.validate_split(split_path) is None:
                 return False

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -1,5 +1,4 @@
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -43,16 +42,13 @@ class NativeParser(BaseParser):
         self, dataset_dir: Path
     ) -> Tuple[List[Path], List[Path], List[Path]]:
         added_train_imgs = self._parse_split(
-            image_dir=dataset_dir / "train",
-            annotation_dir=dataset_dir / "train",
+            annotation_path=dataset_dir / "train" / "annotations.json",
         )
         added_val_imgs = self._parse_split(
-            image_dir=dataset_dir / "valid",
-            annotation_dir=dataset_dir / "valid",
+            annotation_path=dataset_dir / "val" / "annotations.json",
         )
         added_test_imgs = self._parse_split(
-            image_dir=dataset_dir / "test",
-            annotation_dir=dataset_dir / "test",
+            annotation_path=dataset_dir / "test" / "annotations.json",
         )
         return added_train_imgs, added_val_imgs, added_test_imgs
 
@@ -67,10 +63,14 @@ class NativeParser(BaseParser):
         """
 
         data = json.loads(annotation_path.read_text())
-        os.chdir(annotation_path.parent)
 
         def generator() -> DatasetIterator:
-            yield from data
+            for record in data:
+                record["file"] = (
+                    annotation_path.parent / record["file"]
+                ).absolute()
+
+                yield record
 
         added_images = self._get_added_images(generator())
 

--- a/luxonis_ml/data/parsers/voc_parser.py
+++ b/luxonis_ml/data/parsers/voc_parser.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ET
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from defusedxml.ElementTree import parse

--- a/luxonis_ml/data/parsers/voc_parser.py
+++ b/luxonis_ml/data/parsers/voc_parser.py
@@ -82,6 +82,8 @@ class VOCParser(BaseParser):
         for anno_xml in annotation_dir.glob("*.xml"):
             annotation_data = parse(anno_xml)
             root = annotation_data.getroot()
+            if root is None:
+                raise ValueError(f"Could not parse {anno_xml}")
 
             path = image_dir.absolute().resolve() / self._xml_find(
                 root, "filename"

--- a/luxonis_ml/utils/__init__.py
+++ b/luxonis_ml/utils/__init__.py
@@ -5,7 +5,7 @@ with guard_missing_extra("utils"):
     from .environ import Environ, environ
     from .filesystem import PUT_FILE_REGISTRY, LuxonisFileSystem
     from .graph import is_acyclic, traverse_graph
-    from .logging import deprecated, setup_logging
+    from .logging import deprecated, log_once, setup_logging
     from .pydantic_utils import BaseModelExtraForbid
     from .registry import AutoRegisterMeta, Registry
     from .rich_utils import make_progress_bar
@@ -22,6 +22,7 @@ __all__ = [
     "deprecated",
     "environ",
     "is_acyclic",
+    "log_once",
     "make_progress_bar",
     "setup_logging",
     "traverse_graph",

--- a/luxonis_ml/utils/logging.py
+++ b/luxonis_ml/utils/logging.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 from functools import wraps
-from typing import Any, Callable, Dict, Literal, Optional, Type
+from typing import Any, Callable, Dict, Literal, Optional, Set, Type
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -161,6 +161,24 @@ def deprecated(
         return wrapper
 
     return decorator
+
+
+def log_once(logger: Callable[[str], None], message: str) -> None:
+    """Logs a message only once.
+
+    @type logger: Logger
+    @param logger: The logger to use.
+    @type message: str
+    @param message: The message to log.
+    """
+    _cache: Set[str]
+
+    if not hasattr(log_once, "_cache"):
+        log_once._cache = set()
+
+    if message not in log_once._cache:
+        logger(message)
+        log_once._cache.add(message)
 
 
 def _warn_deprecated(

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -4,6 +4,7 @@ import polars as pl
 import pytest
 
 from luxonis_ml.data import LuxonisParser
+from luxonis_ml.enums.enums import DatasetType
 
 
 @pytest.mark.parametrize("url", ["COCO_people_subset.zip"])
@@ -23,6 +24,7 @@ def test_dir_parser(
 
     metadata = dataset._metadata.model_dump()
     del metadata["tasks"]
+    del metadata["skeletons"]
     df = dataset._load_df_offline(raise_when_empty=True)
     anns = (
         df.filter(pl.col("task_type").is_in(["keypoints", "boundingbox"]))
@@ -42,6 +44,7 @@ def test_dir_parser(
     zip = dataset.export(tempdir / "exported")
     exported_dataset = LuxonisParser(
         str(zip),
+        dataset_type=DatasetType.NATIVE,
         dataset_name=dataset_name,
         delete_existing=True,
         save_dir=tempdir,
@@ -63,5 +66,6 @@ def test_dir_parser(
     )
     imported_anns = {k: sorted(v) for k, v in imported_anns.items()}
     del imported_metadata["tasks"]
+    del imported_metadata["skeletons"]
     assert imported_metadata == metadata
     assert imported_anns == anns


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adds support for exporting segmentation tasks using the `export` API. Only supported format is `Native` for now.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Added handling of `"segmentation"` and `"instance_segmentation"` task types in `LuxonisDataset.export`
- Added a helper function `log_once` to `luxonis_ml.utils`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable