### PR TITLE
Compatibility fix for importlib package.

### DIFF
--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -22,14 +22,14 @@ with guard_missing_extra("data"):
 
 def load_dataset_plugins() -> None:  # pragma: no cover
     """Registers any external dataset BaseDataset class plugins."""
-    for entry_point in entry_points().get("dataset_plugins", []):
+    for entry_point in entry_points().select(group="dataset_plugins"):
         plugin_class = entry_point.load()
         DATASETS_REGISTRY.register(module=plugin_class)
 
 
 def load_loader_plugins() -> None:  # pragma: no cover
     """Registers any external dataset BaseLoader class plugins."""
-    for entry_point in entry_points().get("loader_plugins", []):
+    for entry_point in entry_points().select(group="loader_plugins"):
         plugin_class = entry_point.load()
         DATASETS_REGISTRY.register(module=plugin_class)
 

--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -22,16 +22,30 @@ with guard_missing_extra("data"):
 
 def load_dataset_plugins() -> None:  # pragma: no cover
     """Registers any external dataset BaseDataset class plugins."""
-    for entry_point in entry_points().select(group="dataset_plugins"):
+    for entry_point in _get_entry_points_subset("dataset_plugins"):
         plugin_class = entry_point.load()
         DATASETS_REGISTRY.register(module=plugin_class)
 
 
 def load_loader_plugins() -> None:  # pragma: no cover
     """Registers any external dataset BaseLoader class plugins."""
-    for entry_point in entry_points().select(group="loader_plugins"):
+    for entry_point in _get_entry_points_subset("loader_plugins"):
         plugin_class = entry_point.load()
         DATASETS_REGISTRY.register(module=plugin_class)
+
+
+def _get_entry_points_subset(key: str) -> list:
+    """Returns subset of selected entry points.
+
+    Safe function for older (py3.8) and newer py versions
+    """
+    entry_points_obj = entry_points()
+    if isinstance(entry_points_obj, dict):
+        # py3.8 specific
+        selected_entry_points = entry_points_obj.get(key, [])
+    else:
+        selected_entry_points = entry_points_obj.select(group=key)
+    return selected_entry_points
 
 
 load_dataset_plugins()


### PR DESCRIPTION
## Purpose
`.get()` method is not supported in `importlib.metadata.entrypoints()` with Python 3.12 so we replace it with `select` and specify `group` parameter. I think this is the correct usage.

## Specification
`.get()` is replaced with `.select()`

## Dependencies & Potential Impact
None / not applicable

## Deployment Plan
None / not applicable

## Testing & Validation
Test it only with Python 3.12 by creating dataset, listing datasets with CLI and inspecting the dataset with CLI. Further testing is needed.