### PR TITLE
Filter Problematic Augmentations

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -249,8 +249,8 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 "VerticalFlip",
                 "Flip",
             ],
-            "boundingbox": ["Perspective"],
-            "instance_segmentation": ["Perspective"],
+            "bboxes": ["Perspective"],
+            "instance_mask": ["Perspective"],
         }
         augmentation_name = config_item["name"]
         skipped_for = [
@@ -261,7 +261,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         ]
         if skipped_for:
             logger.warning(
-                f"Skipping augmentation '{augmentation_name}' due to known issues for '{skipped_for}' target types."
+                f"Skipping augmentation '{augmentation_name}' due to known issues for {skipped_for} target types."
             )
             return True
         return False

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -241,6 +241,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
     def _should_skip_augmentation(
         self, config_item: Dict[str, Any], available_target_types: set
     ) -> bool:
+        # Perspective issue was fixed in 1.4.19 albumentations version.
         skip_rules = {
             "keypoints": [
                 "Perspective",
@@ -248,7 +249,9 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 "VerticalFlip",
                 "Flip",
             ],
-            "bboxes": ["Perspective"],
+            "boundingbox": ["Perspective"],
+            "segmentation": ["Perspective"],
+            "instance_segmentation": ["Perspective"],
         }
         augmentation_name = config_item["name"]
         skipped_for = [

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -259,7 +259,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         ]
         if skipped_for:
             logger.warning(
-                f"Skipping augmentation '{augmentation_name}' for target types {skipped_for} due to known issues."
+                f"Skipping augmentation '{augmentation_name}' due to known issues for '{skipped_for}' target types."
             )
             return True
         return False

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -250,7 +250,6 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 "Flip",
             ],
             "boundingbox": ["Perspective"],
-            "segmentation": ["Perspective"],
             "instance_segmentation": ["Perspective"],
         }
         augmentation_name = config_item["name"]

--- a/tests/test_data/test_augmentations/test_special.py
+++ b/tests/test_data/test_augmentations/test_special.py
@@ -24,3 +24,58 @@ def test_metadata_no_boxes():
         ]
     )
     assert labels["/metadata/id"].tolist() == [0, 1, 2, 3]
+
+
+def test_skip_augmentations():
+    config = [
+        {
+            "name": "Perspective",
+        },
+        {
+            "name": "Flip",
+        },
+        {
+            "name": "HorizontalFlip",
+        },
+        {
+            "name": "VerticalFlip",
+        },
+        {
+            "name": "Rotate",
+        },
+        {
+            "name": "Mosaic4",
+            "params": {"out_width": 640, "out_height": 640},
+        },
+    ]
+    targets = {
+        "/boundingbox": "boundingbox",
+        "/classification": "classification",
+        "/keypoints": "keypoints",
+        "/instance_segmentation": "instance_segmentation",
+        "/segmentation": "segmentation",
+    }
+    n_classes = {
+        "/boundingbox": 1,
+        "/classification": 1,
+        "/keypoints": 1,
+        "/instance_segmentation": 1,
+        "/segmentation": 1,
+    }
+    augmentations = AlbumentationsEngine(256, 256, targets, n_classes, config)
+
+    spatial_transform_names = next(
+        (
+            [t.__class__.__name__ for t in cell.cell_contents.transforms]
+            for cell in augmentations.spatial_transform.__closure__
+            if hasattr(cell.cell_contents, "transforms")
+        ),
+        [],
+    )
+
+    batched_transform_names = [
+        t.__class__.__name__ for t in augmentations.batch_transform.transforms
+    ]
+
+    assert spatial_transform_names == ["Rotate"]
+    assert batched_transform_names == ["Mosaic4"]

--- a/tests/test_data/test_augmentations/test_special.py
+++ b/tests/test_data/test_augmentations/test_special.py
@@ -67,7 +67,7 @@ def test_skip_augmentations():
     spatial_transform_names = next(
         (
             [t.__class__.__name__ for t in cell.cell_contents.transforms]
-            for cell in augmentations.spatial_transform.__closure__
+            for cell in augmentations.spatial_transform.__closure__  # type: ignore
             if hasattr(cell.cell_contents, "transforms")
         ),
         [],


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

**In this PR, we filter out problematic augmentations based on the `task_types` present in the dataset. However, this approach has a flaw.**  

We don’t actually have information about which annotations are required by *luxonis-train*.  

For example, the dataset may contain multiple `class` values, such as `leeches` and `wounds` under the `task_name` `health`, which corresponds to the `task_type` **segmentation**. Similarly, it may contain the `class` `full salmon` under the `task_name` `localization`, which corresponds to the `task_type` **boundingbox** and **keypoints**.

Since we don’t know which `task_name` will be used in *luxonis-train*, we currently filter out augmentations like **Perspective** for all `task_types` if the dataset contains `keypoints` or `bounding boxes`, even when we only intend to load segmentations.


Additionaly, `Perspective` (that we skiped in case of **boundingbox** and **keypoints**) issue was fixed in 1.4.19 albumentations version.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable