### PR TITLE
Export into multiple zip files

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -392,13 +392,39 @@ def export(
             help="Delete an existing `save_dir` before exporting.",
         ),
     ] = False,
+    task_name: Annotated[
+        Optional[str],
+        typer.Option(
+            "--task-name",
+            "-tn",
+            help=(
+                "Name of the single task to export. "
+                "Required when the dataset contains multiple tasks; "
+                "ignored if the dataset has exactly one task."
+            ),
+            show_default=False,
+        ),
+    ] = None,
+    max_zip_size_gb: Annotated[
+        Optional[float],
+        typer.Option(
+            ...,
+            "--max-zip-size-gb",
+            "-m",
+            help="Maximum size *per* ZIP archive, in gigabytes. "
+            "If the export grows beyond this limit, it is automatically split into "
+            "multiple parts (…_part1.zip, …_part2.zip, etc.). "
+            "Omit this option to create a single ZIP file, regardless of size.",
+            show_default=False,
+        ),
+    ] = None,
     bucket_storage: BucketStorage = bucket_option,
 ):
     save_dir = save_dir or dataset_name
     if delete_existing and Path(save_dir).exists():
         shutil.rmtree(save_dir)
     dataset = LuxonisDataset(dataset_name, bucket_storage=bucket_storage)
-    dataset.export(save_dir, dataset_type)
+    dataset.export(save_dir, dataset_type, max_zip_size_gb, task_name)
 
 
 @app.command()

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -392,7 +392,7 @@ def export(
             help="Delete an existing `save_dir` before exporting.",
         ),
     ] = False,
-    task_name: Annotated[
+    task_name_to_keep: Annotated[
         Optional[str],
         typer.Option(
             "--task-name",
@@ -424,7 +424,7 @@ def export(
     if delete_existing and Path(save_dir).exists():
         shutil.rmtree(save_dir)
     dataset = LuxonisDataset(dataset_name, bucket_storage=bucket_storage)
-    dataset.export(save_dir, dataset_type, max_zip_size_gb, task_name)
+    dataset.export(save_dir, dataset_type, max_zip_size_gb, task_name_to_keep)
 
 
 @app.command()

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -405,26 +405,45 @@ def export(
             show_default=False,
         ),
     ] = None,
-    max_zip_size_gb: Annotated[
+    max_partition_size_gb: Annotated[
         Optional[float],
         typer.Option(
             ...,
-            "--max-zip-size-gb",
+            "--max-partition-size-gb",
             "-m",
-            help="Maximum size *per* ZIP archive, in gigabytes. "
-            "If the export grows beyond this limit, it is automatically split into "
-            "multiple parts (…_part1.zip, …_part2.zip, etc.). "
-            "Omit this option to create a single ZIP file, regardless of size.",
+            help=(
+                "Maximum size of each partition in GB. If the dataset"
+                " exceeds this size, it will be split into multiple partitions named {dataset_name}_part{partition_number}."
+                " Default is None, meaning the dataset will be exported as a single partition named {dataset_name}."
+            ),
             show_default=False,
         ),
     ] = None,
+    zip_output: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            "--zip-output",
+            "-z",
+            help=(
+                "Whether to zip the exported dataset (or each partition)"
+                " after export. Default is False."
+            ),
+        ),
+    ] = False,
     bucket_storage: BucketStorage = bucket_option,
 ):
     save_dir = save_dir or dataset_name
     if delete_existing and Path(save_dir).exists():
         shutil.rmtree(save_dir)
     dataset = LuxonisDataset(dataset_name, bucket_storage=bucket_storage)
-    dataset.export(save_dir, dataset_type, max_zip_size_gb, task_name_to_keep)
+    dataset.export(
+        save_dir,
+        dataset_type,
+        task_name_to_keep,
+        max_partition_size_gb,
+        zip_output,
+    )
 
 
 @app.command()

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -419,16 +419,11 @@ def export(
             show_default=False,
         ),
     ] = None,
-    zip_output: Annotated[
+    no_zip: Annotated[
         bool,
         typer.Option(
-            ...,
-            "--zip-output",
-            "-z",
-            help=(
-                "Whether to zip the exported dataset (or each partition)"
-                " after export. Default is False."
-            ),
+            "--no-zip",
+            help="Skip zipping the exported dataset. By default, the dataset (or each partition) will be zipped.",
         ),
     ] = False,
     bucket_storage: BucketStorage = bucket_option,
@@ -442,7 +437,7 @@ def export(
         dataset_type,
         task_name_to_keep,
         max_partition_size_gb,
-        zip_output,
+        not no_zip,
     )
 
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1375,12 +1375,11 @@ class LuxonisDataset(BaseDataset):
         image_indices = {}
         annotations = {"train": [], "val": [], "test": []}
         df = self._load_df_offline(raise_when_empty=True)
-        self.df = df.filter(
-            pl.col("task_name").is_in([task_name] if task_name else [])
-        )
+        if task_name is not None:
+            df = df.filter(pl.col("task_name").is_in([task_name]))
         if not self.is_remote:
             index = self._get_index()
-            index = index.filter(pl.col("uuid").is_in(self.df["uuid"]))
+            index = index.filter(pl.col("uuid").is_in(df["uuid"]))
             if index is None:  # pragma: no cover
                 raise FileNotFoundError("Cannot find dataset index")
             df = df.join(index, on="uuid").drop("file_right")

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1467,6 +1467,7 @@ class LuxonisDataset(BaseDataset):
                         annotations, output_path, self.identifier, part
                     )
                     current_size = 0
+                    assert part is not None
                     part += 1
                     annotations = {"train": [], "val": [], "test": []}
 
@@ -1529,6 +1530,7 @@ class LuxonisDataset(BaseDataset):
         if zip_output:
             archives = []
             if max_partition_size:
+                assert part is not None
                 for i in range(part + 1):
                     folder = output_path / f"{self.identifier}_part{i}"
                     if folder.exists():

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -135,6 +135,7 @@ def test_export_regular_splits(
     ).parse()
 
     original_splits = dataset.get_splits()
+    assert original_splits is not None
 
     dataset.export(
         output_path=tempdir / "exported",
@@ -154,6 +155,7 @@ def test_export_regular_splits(
         ).parse()
 
     new_splits = dataset.get_splits()
+    assert new_splits is not None
     assert len(new_splits) == len(original_splits)
 
     for split in original_splits:

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -42,9 +42,10 @@ def test_dir_parser(
     )
     anns = {k: sorted(v) for k, v in anns.items()}
 
-    zip = dataset.export(tempdir / "exported")
+    zip_result = dataset.export(tempdir / "exported")
+    zip_path = zip_result[0] if isinstance(zip_result, list) else zip_result
     exported_dataset = LuxonisParser(
-        str(zip / dataset_name),
+        str(zip_path / dataset_name),
         dataset_type=DatasetType.NATIVE,
         dataset_name=dataset_name,
         delete_local=True,

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -44,7 +44,7 @@ def test_dir_parser(
 
     zip = dataset.export(tempdir / "exported")
     exported_dataset = LuxonisParser(
-        str(zip),
+        str(zip / dataset_name),
         dataset_type=DatasetType.NATIVE,
         dataset_name=dataset_name,
         delete_local=True,

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -23,7 +23,7 @@ def test_dir_parser(
         dataset_name=dataset_name,
         delete_local=True,
         save_dir=tempdir,
-    ).parse(random_split=True, split_ratio=(1, 0, 0))
+    ).parse()
 
     metadata = dataset._metadata.model_dump()
     del metadata["tasks"]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

- **Feature**: Added an option to split the exported dataset into multiple ZIP files.
- **Bugfix**: Fixed an issue where parsing a dataset with an empty split would result in a corrupted dataset.
- **Bugfix**: Fixed an issue where exporting a dataset containing files without annotations would cause those images to be ignored and excluded from the exported dataset.
- **Tests**: Added tests to cover the above bug fixes and the new feature for creating multiple ZIP files.



## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->


**Note:** The dataset can be split into smaller parts, each compressed into a separate zip file. The original dataset can then be reconstructed by individually parsing each zip file.