### PR TITLE
Fix: Replaced `tqdm` with `rich`

### DIFF
--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -13,7 +13,7 @@ from typing import Literal, Protocol, cast
 
 import fsspec
 from loguru import logger
-from tqdm import tqdm
+from rich.progress import track
 from typeguard import typechecked
 
 from luxonis_ml.typing import PathType, PosixPathType
@@ -284,10 +284,10 @@ class LuxonisFileSystem:
                                 self.put_file, local_path, remote_path
                             )
                         )
-                    for _ in tqdm(
+                    for _ in track(
                         as_completed(futures),
                         total=len(futures),
-                        desc="Uploading files",
+                        description="Uploading files",
                     ):
                         pass
                 return upload_dict


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fix for no dependency config loading in `luxonis-train`.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable