### PR TITLE
Add BOM compatibility tests

### DIFF
--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -1,0 +1,33 @@
+name: BOM Compatibility Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      ml_ref:
+        description: 'luxonis-ml version (branch/tag/SHA)'
+        required: true
+        default: main
+      train_ref_mode:
+        description: 'luxonis-train branch/tag (or "main")'
+        required: true
+        default: main
+
+jobs:
+  bom-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['luxonis-train']
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        uses: cli/gh-action@v2
+
+      - name: Dispatch downstream tests workflow
+        run: |
+          gh workflow run .github/workflows/tests.yaml \
+            --repo Luxonis/${{ matrix.repo }} \
+            --ref ${{ inputs.train_ref_mode }} \
+            --field ml_ref=${{ inputs.ml_ref }}

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   test-luxonis-train:
     name: Test luxonis-train
-    uses: Luxonis/luxonis-train/.github/workflows/tests.yaml@main
+    uses: Luxonis/luxonis-train/.github/workflows/tests.yaml@fix/tests-yaml
     with:
       ml_ref: ${{ inputs.ml_ref }}
     secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -7,11 +7,28 @@ on:
         description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
         default: main
+      train_ref:
+        description: 'luxonis-train version (branch/tag/SHA)'
+        required: true
+        default: main
 
 jobs:
+  checkout-train:
+    runs-on: ubuntu-latest
+    outputs:
+      repo-dir: ${{ steps.checkout.outputs.path }}
+    steps:
+      - name: Checkout luxonis-train
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          repository: Luxonis/luxonis-train
+          ref: ${{ inputs.train_ref }}
+          path: luxonis-train
+
   test-luxonis-train:
-    name: Test luxonis-train
-    uses: Luxonis/luxonis-train/.github/workflows/tests.yaml@fix/tests-yaml
+    needs: checkout-train
+    uses: ./luxonis-train/.github/workflows/tests.yaml
     with:
       ml_ref: ${{ inputs.ml_ref }}
     secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   test-luxonis-train:
     name: Test luxonis-train
-    uses: ./downstream/luxonis-train/.github/workflows/tests.yaml
+    uses: Luxonis/luxonis-train/.github/workflows/tests.yaml@main
     with:
       ml_ref: ${{ inputs.ml_ref }}
     secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -7,14 +7,12 @@ on:
         description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
         default: main
+  push:
 
 jobs:
-  bom-tests:
-    strategy:
-      matrix:
-        repo: ['luxonis-train']
-
-    uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
+  test-luxonis-train:
+    name: Test luxonis-train
+    uses: ./downstream/luxonis-train/.github/workflows/tests.yaml
     with:
       ml_ref: ${{ inputs.ml_ref }}
     secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -7,7 +7,6 @@ on:
         description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
         default: main
-  push:
 
 jobs:
   test-luxonis-train:

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -7,24 +7,23 @@ on:
         description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
         default: main
-  push:
 
-# jobs:
-#   bom-tests:
-#     runs-on: ubuntu-latest
-#     strategy:
-#       matrix:
-#         repo: ['luxonis-train']
-#     steps:
-#       - name: Checkout downstream repo
-#         uses: actions/checkout@v4
-#         with:
-#           repository: Luxonis/${{ matrix.repo }}
-#           ref: main
-#           path: downstream/${{ matrix.repo }}
+jobs:
+  bom-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['luxonis-train']
+    steps:
+      - name: Checkout downstream repo
+        uses: actions/checkout@v4
+        with:
+          repository: Luxonis/${{ matrix.repo }}
+          ref: main
+          path: downstream/${{ matrix.repo }}
 
-#       - name: Run downstream tests
-#         uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
-#         with:
-#           ml_ref: ${{ inputs.ml_ref }}
-#         secrets: inherit
+      - name: Run downstream tests
+        uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
+        with:
+          ml_ref: ${{ inputs.ml_ref }}
+        secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -11,7 +11,6 @@ on:
         description: 'luxonis-train version (branch/tag/SHA)'
         required: true
         default: main
-  push:
 
 jobs:
   checkout-train:

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -10,20 +10,11 @@ on:
 
 jobs:
   bom-tests:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         repo: ['luxonis-train']
-    steps:
-      - name: Checkout downstream repo
-        uses: actions/checkout@v4
-        with:
-          repository: Luxonis/${{ matrix.repo }}
-          ref: main
-          path: downstream/${{ matrix.repo }}
 
-      - name: Run downstream tests
-        uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
-        with:
-          ml_ref: ${{ inputs.ml_ref }}
-        secrets: inherit
+    uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
+    with:
+      ml_ref: ${{ inputs.ml_ref }}
+    secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -7,23 +7,24 @@ on:
         description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
         default: main
+  push:
 
-jobs:
-  bom-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        repo: ['luxonis-train']
-    steps:
-      - name: Checkout downstream repo
-        uses: actions/checkout@v4
-        with:
-          repository: Luxonis/${{ matrix.repo }}
-          ref: main
-          path: downstream/${{ matrix.repo }}
+# jobs:
+#   bom-tests:
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         repo: ['luxonis-train']
+#     steps:
+#       - name: Checkout downstream repo
+#         uses: actions/checkout@v4
+#         with:
+#           repository: Luxonis/${{ matrix.repo }}
+#           ref: main
+#           path: downstream/${{ matrix.repo }}
 
-      - name: Run downstream tests
-        uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
-        with:
-          ml_ref: ${{ inputs.ml_ref }}
-        secrets: inherit
+#       - name: Run downstream tests
+#         uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
+#         with:
+#           ml_ref: ${{ inputs.ml_ref }}
+#         secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -7,10 +7,6 @@ on:
         description: 'luxonis-ml version (branch/tag/SHA)'
         required: true
         default: main
-      train_ref_mode:
-        description: 'luxonis-train branch/tag (or "main")'
-        required: true
-        default: main
 
 jobs:
   bom-tests:
@@ -19,15 +15,15 @@ jobs:
       matrix:
         repo: ['luxonis-train']
     steps:
-      - name: Checkout this repo
+      - name: Checkout downstream repo
         uses: actions/checkout@v4
+        with:
+          repository: Luxonis/${{ matrix.repo }}
+          ref: main
+          path: downstream/${{ matrix.repo }}
 
-      - name: Install GitHub CLI
-        uses: cli/gh-action@v2
-
-      - name: Dispatch downstream tests workflow
-        run: |
-          gh workflow run .github/workflows/tests.yaml \
-            --repo Luxonis/${{ matrix.repo }} \
-            --ref ${{ inputs.train_ref_mode }} \
-            --field ml_ref=${{ inputs.ml_ref }}
+      - name: Run downstream tests
+        uses: ./downstream/${{ matrix.repo }}/.github/workflows/tests.yaml
+        with:
+          ml_ref: ${{ inputs.ml_ref }}
+        secrets: inherit

--- a/.github/workflows/bom-tests.yaml
+++ b/.github/workflows/bom-tests.yaml
@@ -11,6 +11,7 @@ on:
         description: 'luxonis-train version (branch/tag/SHA)'
         required: true
         default: main
+  push:
 
 jobs:
   checkout-train:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

This workflow lets you manually run “BOM Compatibility” checks between two repos:

- **Inputs:** choose a `luxonis-ml` ref (`ml_ref`) and a `luxonis-train` ref (`train_ref`).
- **Steps:**  
  1. Checkout `luxonis-train` at `train_ref`.  
  2. Invoke its `tests.yaml`, passing in `ml_ref` so you test compatibility against that version of `luxonis-ml`.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable