### PR TITLE
Feature: Grayscale Images Support

### DIFF
--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -253,7 +253,7 @@ class LuxonisLoader(BaseLoader):
         if self.color_space == "BGR":
             img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
         elif self.color_space == "GRAY":
-            img = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
+            img = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)[..., np.newaxis]
 
         return img, labels
 

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -46,7 +46,7 @@ class LuxonisLoader(BaseLoader):
         width: int | None = None,
         keep_aspect_ratio: bool = True,
         exclude_empty_annotations: bool = False,
-        color_space: Literal["RGB", "BGR"] = "RGB",
+        color_space: Literal["RGB", "BGR", "GRAY"] = "RGB",
         seed: int | None = None,
         *,
         keep_categorical_as_strings: bool = False,
@@ -90,7 +90,7 @@ class LuxonisLoader(BaseLoader):
         @type keep_aspect_ratio: bool
         @param keep_aspect_ratio: Whether to keep the aspect ratio of the
             images. Defaults to C{True}.
-        @type color_space: Literal["RGB", "BGR"]
+        @type color_space: Literal["RGB", "BGR", "GRAY"]
         @param color_space: The color space of the output images. Defaults
             to C{"RGB"}.
         @type seed: Optional[int]
@@ -117,7 +117,7 @@ class LuxonisLoader(BaseLoader):
         """
 
         self.exclude_empty_annotations = exclude_empty_annotations
-        self.color_space: Literal["RGB", "BGR"] = color_space
+        self.color_space: Literal["RGB", "BGR", "GRAY"] = color_space
         self.height = height
         self.width = width
 
@@ -247,13 +247,15 @@ class LuxonisLoader(BaseLoader):
         else:
             img, labels = self._load_with_augmentations(idx)
 
+        if not self.exclude_empty_annotations:
+            img, labels = self._add_empty_annotations(img, labels)
+
         if self.color_space == "BGR":
             img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+        elif self.color_space == "GRAY":
+            img = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)
 
-        if self.exclude_empty_annotations:
-            return img, labels
-
-        return self._add_empty_annotations(img, labels)
+        return img, labels
 
     def _add_empty_annotations(
         self, img: np.ndarray, labels: Labels


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Allows users to use the `LuxonisLoader` with with grayscale images.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
The `color_space` argument of `LuxonisLoader` now also accepts `"GRAY"` as an option.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Added relevant tests