### PR TITLE
Fix redundant media downloads & improve loader initialization performance

### DIFF
--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -519,7 +519,10 @@ class LuxonisDataset(BaseDataset):
         if df is None:
             return None
 
-        files = df.select(pl.col("file")).unique().to_series().to_list()
+        unique_files = df.select(pl.col("file")).unique()
+        if isinstance(unique_files, pl.LazyFrame):
+            unique_files = unique_files.collect()
+        files = unique_files["file"].to_list()
         resolved = {f: str(Path(f).resolve()) for f in files}
         processed = df.select(
             pl.col("uuid"),

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -519,6 +519,9 @@ class LuxonisDataset(BaseDataset):
         if df is None:
             return None
 
+        if isinstance(df, pl.DataFrame):
+            df = df.lazy()
+
         unique_files = df.select(pl.col("file")).unique().collect()
         files: list[str] = unique_files["file"].to_list()
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -513,7 +513,7 @@ class LuxonisDataset(BaseDataset):
         raise_when_empty: bool = False,
     ) -> pl.DataFrame | pl.LazyFrame | None:
         """Loads unique file entries from annotation data."""
-        df: pl.LazyFrame | pl.DataFrame = self._load_df_offline(
+        df = self._load_df_offline(
             lazy=True, raise_when_empty=raise_when_empty
         )
         if df is None:

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -169,16 +169,15 @@ class LuxonisLoader(BaseLoader):
             self.instances.extend(splits[view])
 
         self.idx_to_df_row: list[list[int]] = []
-        self.instances = [
-            uuid
-            for uuid in self.instances
-            if uuid in self.df["uuid"].to_list()
-        ]
+        uuid_list = self.df["uuid"].to_list()
+        uuid_set = set(uuid_list)
+        self.instances = [uid for uid in self.instances if uid in uuid_set]
 
-        for uuid in self.instances:
-            boolean_mask = self.df["uuid"] == uuid
-            row_indexes = boolean_mask.arg_true().to_list()
-            self.idx_to_df_row.append(row_indexes)
+        idx_map: dict[str, list[int]] = defaultdict(list)
+        for i, uid in enumerate(uuid_list):
+            idx_map[uid].append(i)
+
+        self.idx_to_df_row = [idx_map[uid] for uid in self.instances]
 
         self.tasks_without_background = set()
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->


###  Bug Fix
- **Description:**  
  When a dataset created on one device was pushed to the cloud and then pulled on a new device, media files were always re-downloaded—even if they already existed in the local `media` folder. This didn’t corrupt any data, but it caused unnecessary loading delays.
- **Solution:**  
  Before pulling from the cloud, verify whether each media file already exists in `local_dir/<dataset_name>/media/` and skip downloads for files that are present.

### Performance Improvement
  Loader startup and cloud-pull operations are now much faster, reducing overall load times.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable