### PR TITLE
Error on empty `make_splits`

### DIFF
--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1118,6 +1118,8 @@ class LuxonisDataset(BaseDataset):
             if isinstance(splits, tuple):
                 ratios = splits
             elif isinstance(splits, dict):
+                if not splits:
+                    raise ValueError("Splits cannot be empty")
                 value = next(iter(splits.values()))
                 if isinstance(value, float):
                     ratios = splits  # type: ignore

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -237,6 +237,9 @@ def test_make_splits(
     with pytest.raises(ValueError, match="No new files"):
         dataset.make_splits()
 
+    with pytest.raises(ValueError, match="Splits cannot be empty"):
+        dataset.make_splits({})
+
     with pytest.raises(ValueError, match="Ratios must sum to 1.0"):
         dataset.make_splits((0.7, 0.1, 1))
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
More meaningful error when an empty split definitions are passed to `make_splits`
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable