### PR TITLE
Fix the dataset merge, export on Machine B

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -828,6 +828,15 @@ def clone(
         ),
     ] = True,
     bucket_storage: BucketStorage = bucket_option,
+    team_id: Annotated[
+        str | None,
+        typer.Option(
+            "--team-id",
+            "-t",
+            help="Team ID to use for the new dataset. If not provided, the dataset's current team ID will be used.",
+            show_default=False,
+        ),
+    ] = None,
 ):
     """Clone an existing dataset with a new name.
 
@@ -845,7 +854,9 @@ def clone(
 
     print(f"Cloning dataset '{name}' to '{new_name}'...")
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
-    dataset.clone(new_dataset_name=new_name, push_to_cloud=push_to_cloud)
+    dataset.clone(
+        new_dataset_name=new_name, push_to_cloud=push_to_cloud, team_id=team_id
+    )
     print(f"[green]Dataset '{name}' successfully cloned to '{new_name}'.")
 
 

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -391,6 +391,18 @@ class LuxonisDataset(BaseDataset):
                 update_mode=UpdateMode.MISSING,
             )
 
+        for entry in (
+            df_other.select(["uuid", "file"])
+            .unique(subset=["uuid"])
+            .to_dicts()
+        ):
+            uid, rel_file = entry["uuid"], entry["file"]
+            src_path = other.media_path / f"{uid}{Path(rel_file).suffix}"
+            dst_path = target_dataset.media_path / src_path.name
+            if src_path.exists() and not dst_path.exists():
+                dst_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(src_path, dst_path)
+
         target_dataset._merge_metadata_with(other)
 
         return target_dataset

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -269,7 +269,10 @@ class LuxonisDataset(BaseDataset):
         self._write_metadata()
 
     def clone(
-        self, new_dataset_name: str, push_to_cloud: bool = True
+        self,
+        new_dataset_name: str,
+        push_to_cloud: bool = True,
+        team_id: str | None = None,
     ) -> "LuxonisDataset":
         """Create a new LuxonisDataset that is a local copy of the
         current dataset. Cloned dataset will overwrite the existing
@@ -281,10 +284,12 @@ class LuxonisDataset(BaseDataset):
         @param push_to_cloud: Whether to push the new dataset to the
             cloud. Only if the current dataset is remote.
         """
+        if team_id is None:
+            team_id = self.team_id
 
         new_dataset = LuxonisDataset(
             dataset_name=new_dataset_name,
-            team_id=self.team_id,
+            team_id=team_id,
             bucket_type=self.bucket_type,
             bucket_storage=self.bucket_storage,
             delete_local=True,

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1532,6 +1532,10 @@ class LuxonisDataset(BaseDataset):
                 record["annotation"][task_type] = data
                 annotations[split].append(record)
 
+            elif task_type == "metadata/text":
+                record["annotation"]["metadata"] = {"text": data}
+                annotations[split].append(record)
+
         _dump_annotations(annotations, output_path, self.identifier, part)
 
         if zip_output:

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1,6 +1,7 @@
 import json
 import math
 import shutil
+import sys
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -1461,9 +1462,13 @@ class LuxonisDataset(BaseDataset):
 
             if file not in image_indices:
                 file_size = file.stat().st_size
+                annotations_size = sum(
+                    sys.getsizeof(lst) for lst in annotations.values()
+                )
                 if (
                     max_partition_size
-                    and current_size + file_size > max_partition_size
+                    and current_size + file_size + annotations_size
+                    > max_partition_size
                 ):
                     _dump_annotations(
                         annotations, output_path, self.identifier, part

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1439,12 +1439,11 @@ class LuxonisDataset(BaseDataset):
             description="Exporting ...",
         ):
             uuid = row[7]
-            if self.is_remote:
+            file = Path(row[-1])
+            if self.is_remote or not file.exists():
                 file_extension = row[0].rsplit(".", 1)[-1]
                 file = self.media_path / f"{uuid}.{file_extension}"
                 assert file.exists()
-            else:
-                file = Path(row[-1])
 
             split = None
             for s, uuids in splits.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,7 +155,9 @@ def tempdir(base_tempdir: Path, randint: int) -> Path:
 
     path.mkdir(exist_ok=True)
 
-    return path
+    yield path
+
+    shutil.rmtree(path, ignore_errors=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def base_tempdir(worker_id: str):
 
 
 @pytest.fixture
-def tempdir(base_tempdir: Path, randint: int) -> Path:
+def tempdir(base_tempdir: Path, randint: int) -> Generator[Path, None, None]:
     t = time.time()
     unique_id = randint
     while True:

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -976,3 +976,14 @@ def test_merge_on_different_machines(dataset_name: str, tempdir: Path):
     )
     loader = LuxonisLoader(dataset3)
     assert sum(1 for _ in loader) == 6
+    dataset3.export(tempdir)
+    assert (
+        len(
+            list(
+                Path.cwd().glob(
+                    f"{tempdir}/{dataset3.dataset_name}/train/images/*"
+                )
+            )
+        )
+        == 6
+    )

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -967,7 +967,6 @@ def test_merge_on_different_machines(dataset_name: str, tempdir: Path):
     dataset2.pull_from_cloud()
     dataset1.delete_dataset(delete_remote=True)
     dataset2.delete_dataset(delete_remote=True)
-    del dataset1, dataset2
     dataset1 = LuxonisDataset(dataset_name + "_1")
     dataset2 = LuxonisDataset(dataset_name + "_2")
     assert len(list(dataset1.media_path.glob("*"))) == 3


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

**Bug description:**
When a dataset created on GCS is pulled down to Machine B and used as a local dataset, attempting to merge it with another local dataset on Machine B produces an invalid dataset. Notably, merging two datasets directly on the cloud from different machines worked correctly prior to this.

This edge case has been addressed in this PR, and a corresponding test has been added.

Additionally, the export now includes metadata such as text for OCR.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable