### PR TITLE
Fix Gray Norm Issue

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -554,6 +554,8 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         """
         out_labels = {}
         out_image = data.pop("image")
+        if out_image.ndim == 2:
+            out_image = np.expand_dims(out_image, axis=-1)
         image_height, image_width, _ = out_image.shape
 
         bboxes_indices = {}

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -249,10 +249,9 @@ class LuxonisLoader(BaseLoader):
         if not self.exclude_empty_annotations:
             img, labels = self._add_empty_annotations(img, labels)
 
+        # Albumentations needs RGB
         if self.color_space == "BGR":
             img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
-        elif self.color_space == "GRAY":
-            img = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)[..., np.newaxis]
 
         return img, labels
 
@@ -316,7 +315,12 @@ class LuxonisLoader(BaseLoader):
 
         img_path = self.idx_to_img_path[idx]
 
-        img = cv2.cvtColor(cv2.imread(str(img_path)), cv2.COLOR_BGR2RGB)
+        if self.color_space == "GRAY":
+            img = cv2.cvtColor(cv2.imread(str(img_path)), cv2.COLOR_RGB2GRAY)[
+                ..., np.newaxis
+            ]
+        else:
+            img = cv2.cvtColor(cv2.imread(str(img_path)), cv2.COLOR_BGR2RGB)
 
         labels_by_task: dict[str, list[Annotation]] = defaultdict(list)
         class_ids_by_task: dict[str, list[int]] = defaultdict(list)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

**Summary**  
Previously, it wasn’t possible to specify per-channel `mean` and `std` for grayscale normalization—instead, we normalized an RGB image and then converted it to grayscale. Now, you can directly normalize single-channel (grayscale) images with custom `mean` and `std`. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable