### PR TITLE
Disabling `albumentation` update check

### DIFF
--- a/luxonis_ml/__init__.py
+++ b/luxonis_ml/__init__.py
@@ -1,7 +1,11 @@
 __version__ = "0.7.0"
 
+import os
+
 from .utils.environ import environ
 from .utils.logging import setup_logging
 
 if not environ.LUXONISML_DISABLE_SETUP_LOGGING:
     setup_logging()
+
+os.environ["NO_ALBUMENTATIONS_UPDATE"] = "1"

--- a/luxonis_ml/__init__.py
+++ b/luxonis_ml/__init__.py
@@ -8,4 +8,5 @@ from .utils.logging import setup_logging
 if not environ.LUXONISML_DISABLE_SETUP_LOGGING:
     setup_logging()
 
-os.environ["NO_ALBUMENTATIONS_UPDATE"] = "1"
+if "NO_ALBUMENTATIONS_UPDATE" not in os.environ:
+    os.environ["NO_ALBUMENTATIONS_UPDATE"] = "1"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Disables check for `albumentation` update to remove an unnecesarry log message.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable