### PR TITLE
Enabled file only logs

### DIFF
--- a/luxonis_ml/utils/logging.py
+++ b/luxonis_ml/utils/logging.py
@@ -68,6 +68,7 @@ def setup_logging(
         # https://github.com/Delgan/loguru/issues/1172
         format=lambda _: "{message}",
         backtrace=False,
+        filter=lambda record: "file_only" not in record["extra"],
     )
 
     if file is not None:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Allows for pushing some specific logs only to the file and not the terminal.
Example usage:
`logger.bind(file_only=True).info("test")` 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable