### PR TITLE
Default delete & dataset creation fix

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -333,7 +333,7 @@ def inspect(
     bucket_storage: BucketStorage = bucket_option,
 ):
     """Inspects images and annotations in a dataset."""
-
+    check_exists(name, bucket_storage)
     if deterministic:
         np.random.seed(42)
         random.seed(42)

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -862,7 +862,7 @@ class LuxonisDataset(BaseDataset):
 
     @override
     def delete_dataset(
-        self, *, delete_remote: bool = False, delete_local: bool = False
+        self, *, delete_remote: bool = False, delete_local: bool = True
     ) -> None:
         """Deletes the dataset from local storage and optionally from
         the cloud.


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

- Delete the local dataset by default when calling `.delete_dataset()` on `LuxonisDataset`.
- Prevent unintended dataset creation when inspecting a non-existent dataset.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable