### PR TITLE
Improved `export` support

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -436,19 +436,6 @@ def export(
             help="Delete an existing `save_dir` before exporting.",
         ),
     ] = False,
-    task_name_to_keep: Annotated[
-        str | None,
-        typer.Option(
-            "--task-name",
-            "-tn",
-            help=(
-                "Name of the single task to export. "
-                "Required when the dataset contains multiple tasks; "
-                "ignored if the dataset has exactly one task."
-            ),
-            show_default=False,
-        ),
-    ] = None,
     max_partition_size_gb: Annotated[
         float | None,
         typer.Option(
@@ -478,13 +465,7 @@ def export(
     if delete_existing and Path(save_dir).exists():
         shutil.rmtree(save_dir)
     dataset = LuxonisDataset(dataset_name, bucket_storage=bucket_storage)
-    dataset.export(
-        save_dir,
-        dataset_type,
-        task_name_to_keep,
-        max_partition_size_gb,
-        not no_zip,
-    )
+    dataset.export(save_dir, dataset_type, max_partition_size_gb, not no_zip)
 
 
 @app.command()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
The `LuxonisDataset.export` method now also exports multi-task datasets and can handle `"metadata"` fields.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable