### PR TITLE
Remove Invisible Keypoints

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -405,9 +405,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 "bbox_params": A.BboxParams(
                     format="albumentations", min_visibility=min_bbox_visibility
                 ),
-                "keypoint_params": A.KeypointParams(
-                    format="xy", remove_invisible=False
-                ),
+                "keypoint_params": A.KeypointParams(format="xy"),
                 "additional_targets": self.targets
                 if is_custom
                 else targets_without_instance_mask,


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->


**Problem:**  
During a sequence of spatial transforms, keypoints could move outside the image bounds (for example, after a shift) and were not removed. A subsequent transform (for example, a rotation) might then bring those off-image points back inside the frame—only to have them point into empty (padded) areas.

**Solution:**  
We fixed this by setting  
```python
A.KeypointParams(format='xy', remove_invisible=True)
```


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable