### PR TITLE
Fix: Missing `test` split for COCO parser

### DIFF
--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -162,7 +162,7 @@ class COCOParser(BaseParser):
             image_dir=val_paths["image_dir"], annotation_path=val_ann_path
         )
 
-        if split_val_to_test and dir_format == Format.FIFTYONE:
+        if split_val_to_test or len(splits) < 3:
             split_point = round(len(_added_val_imgs) * 0.5)
             added_val_imgs = _added_val_imgs[:split_point]
             added_test_imgs = _added_val_imgs[split_point:]

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -163,6 +163,11 @@ class COCOParser(BaseParser):
         )
 
         if split_val_to_test or len(splits) < 3:
+            if not split_val_to_test:
+                logger.warning(
+                    "Splitting validation set into validation and test sets, "
+                    "as no test split is present in the dataset."
+                )
             split_point = round(len(_added_val_imgs) * 0.5)
             added_val_imgs = _added_val_imgs[:split_point]
             added_test_imgs = _added_val_imgs[split_point:]


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable