### PR TITLE
Log deprecation message only once

### DIFF
--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -25,6 +25,7 @@ from typing_extensions import Self, override
 from luxonis_ml.data.utils.parquet import ParquetRecord
 from luxonis_ml.typing import PathType, check_type
 from luxonis_ml.utils import BaseModelExtraForbid
+from luxonis_ml.utils.logging import log_once
 
 KeypointVisibility: TypeAlias = Literal[0, 1, 2]
 NormalizedFloat: TypeAlias = Annotated[float, Field(ge=0, le=1)]
@@ -548,9 +549,9 @@ class DatasetRecord(BaseModelExtraForbid):
     @classmethod
     def validate_task_name(cls, values: dict[str, Any]) -> dict[str, Any]:
         if "task" in values:
-            warnings.warn(
+            log_once(
+                logger.warning,
                 "The 'task' field is deprecated. Use 'task_name' instead.",
-                stacklevel=2,
             )
             values["task_name"] = values.pop("task")
         return values


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Prevents spamming of warning messages for deprecated fields in `DatasetRecord`.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable