### PR TITLE
CLI: Error on "No deletion target"

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -184,7 +184,7 @@ def delete(
         print(
             "[red]No deletion target specified (local or remote). Nothing to delete.[/red]"
         )
-        raise typer.Exit
+        raise typer.Exit(1)
 
     if not Confirm.ask(
         f"Delete dataset '{name}' with specified bucket '{bucket_storage}' from {where} storage?"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes it more clear that no deletion was performed when user doesn't specify the deletion target in `luxonis_ml data delete`.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Changed message color to red
- Changed exit code to 1
## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable