### PR TITLE
Fix: Environ types

### DIFF
--- a/luxonis_ml/utils/environ.py
+++ b/luxonis_ml/utils/environ.py
@@ -30,7 +30,7 @@ class Environ(BaseSettings):
     POSTGRES_USER: str | None = None
     POSTGRES_PASSWORD: str | None = None
     POSTGRES_HOST: str | None = None
-    POSTGRES_PORT: str | None = None
+    POSTGRES_PORT: int | None = None
     POSTGRES_DB: str | None = None
 
     LUXONISML_BUCKET: str | None = None


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Changes the type of `POSTGRES_PORT` from `str` to `int`.
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable