### PR TITLE
Added resizable cv2 window

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -397,6 +397,7 @@ def inspect(
             new_h, new_w = int(h * size_multiplier), int(w * size_multiplier)
             image = cv2.resize(image, (new_w, new_h))
 
+            cv2.namedWindow(source_name, cv2.WINDOW_NORMAL)
             if per_instance and matched_instance_keys:
                 extra_keys = [
                     k for k in labels if k not in matched_instance_keys
@@ -419,6 +420,11 @@ def inspect(
                         classes,
                         blend_all=blend_all,
                     )
+                    cv2.resizeWindow(
+                        source_name,
+                        instance_image.shape[1],
+                        instance_image.shape[0],
+                    )
                     cv2.imshow(source_name, instance_image)
                     if cv2.waitKey() == ord("q"):
                         break
@@ -430,6 +436,9 @@ def inspect(
                     )
                 labeled_image = visualize(
                     image, source_name, labels, classes, blend_all=blend_all
+                )
+                cv2.resizeWindow(
+                    source_name, labeled_image.shape[1], labeled_image.shape[0]
                 )
                 cv2.imshow(source_name, labeled_image)
 


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Added option to resize the cv2 window when it is displayed for inference
  - By default it shows up in full res but you have the option to resize it

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable