### PR TITLE
Feat/remove flip constraint

### DIFF
--- a/luxonis_ml/data/README.md
+++ b/luxonis_ml/data/README.md
@@ -917,13 +917,6 @@ The augmentations are specified as a list of dictionaries, where each dictionary
 
 By default, we support most augmentations from the `albumentations` library. You can find the full list of augmentations and their parameters in the [Albumentations](https://albumentations.ai/docs/api_reference/augmentations/)documentation.
 
-> **Note:** The standard Albumentations flip transforms (`HorizontalFlip`, `VerticalFlip`, `Transpose`)
-> will flip images and keypoints but **do not** swap symmetric keypoints\
-> (e.g., left/right joints in human poses). For tasks with symmetric keypoint structures, use our custom augmentations:
->
-> - `HorizontalSymetricKeypointsFlip`
-> - `VerticalSymetricKeypointsFlip`
-> - `TransposeSymmetricKeypoints`
 
 On top of that, we provide a handful of custom batch augmentations:
 

--- a/luxonis_ml/data/README.md
+++ b/luxonis_ml/data/README.md
@@ -917,6 +917,14 @@ The augmentations are specified as a list of dictionaries, where each dictionary
 
 By default, we support most augmentations from the `albumentations` library. You can find the full list of augmentations and their parameters in the [Albumentations](https://albumentations.ai/docs/api_reference/augmentations/)documentation.
 
+> **Note:** The standard Albumentations flip transforms (`HorizontalFlip`, `VerticalFlip`, `Transpose`)
+> will flip images and keypoints but **do not** swap symmetric keypoints\
+> (e.g., left/right joints in human poses). For tasks with symmetric keypoint structures, use our custom augmentations:
+>
+> - `HorizontalSymetricKeypointsFlip`
+> - `VerticalSymetricKeypointsFlip`
+> - `TransposeSymmetricKeypoints`
+
 On top of that, we provide a handful of custom batch augmentations:
 
 - `Mosaic4` - Mosaic augmentation with 4 images. Combines crops of 4 images into a single image in a mosaic pattern.

--- a/luxonis_ml/data/README.md
+++ b/luxonis_ml/data/README.md
@@ -917,7 +917,6 @@ The augmentations are specified as a list of dictionaries, where each dictionary
 
 By default, we support most augmentations from the `albumentations` library. You can find the full list of augmentations and their parameters in the [Albumentations](https://albumentations.ai/docs/api_reference/augmentations/)documentation.
 
-
 On top of that, we provide a handful of custom batch augmentations:
 
 - `Mosaic4` - Mosaic augmentation with 4 images. Combines crops of 4 images into a single image in a mosaic pattern.

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -241,37 +241,6 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 ...
     """
 
-    def _should_skip_augmentation(
-        self, config_item: dict[str, Any], available_target_types: set
-    ) -> bool:
-        skip_rules = {
-            "keypoints": [
-                "HorizontalFlip",
-                "VerticalFlip",
-                "Flip",
-            ],
-        }
-        augmentation_name = config_item["name"]
-        skipped_for = [
-            target_type
-            for target_type, skip_list in skip_rules.items()
-            if target_type in available_target_types
-            and augmentation_name in skip_list
-        ]
-        if skipped_for:
-            extra_msg = ""
-            if "keypoints" in skipped_for and augmentation_name in [
-                "HorizontalFlip",
-                "VerticalFlip",
-                "Flip",
-            ]:
-                extra_msg = " For keypoints, please use 'HorizontalSymetricKeypointsFlip' or 'VerticalSymetricKeypointsFlip'."
-            logger.warning(
-                f"Skipping augmentation '{augmentation_name}' due to known issues for {skipped_for} target types. {extra_msg}"
-            )
-            return True
-        return False
-
     @override
     def __init__(
         self,

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -249,6 +249,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         if "keypoints" in available_target_types and augmentation_name in [
             "HorizontalFlip",
             "VerticalFlip",
+            "Transpose"
         ]:
             logger.warning(
                 f"Using '{augmentation_name}' with keypoints."
@@ -361,7 +362,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             self._check_augmentation_warnings(
                 config_item, available_target_types
             )
-            cfg = AlbumentationConfigItem(**config_item)
+            cfg = AlbumentationConfigItem(**config_item)  # type: ignore
             transform = self.create_transformation(cfg)
 
             if cfg.use_for_resizing:

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -358,12 +358,10 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         available_target_types = set(self.targets.values())
 
         for config_item in config:
-            cfg = AlbumentationConfigItem(**config_item)
-
             self._check_augmentation_warnings(
                 config_item, available_target_types
             )
-
+            cfg = AlbumentationConfigItem(**config_item)
             transform = self.create_transformation(cfg)
 
             if cfg.use_for_resizing:

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -369,14 +369,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         if is_validation_pipeline:
             config = (a for a in config if a["name"] == "Normalize")
 
-        available_target_types = set(self.targets.values())
-
         for config_item in config:
-            if self._should_skip_augmentation(
-                config_item, available_target_types
-            ):
-                continue
-
             cfg = AlbumentationConfigItem(**config_item)  # type: ignore
 
             transform = self.create_transformation(cfg)
@@ -431,9 +424,11 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 "keypoint_params": A.KeypointParams(
                     format="xy", remove_invisible=False
                 ),
-                "additional_targets": self.targets
-                if is_custom
-                else targets_without_instance_mask,
+                "additional_targets": (
+                    self.targets
+                    if is_custom
+                    else targets_without_instance_mask
+                ),
                 "seed": seed,
             }
 

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -243,13 +243,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
     def _check_augmentation_warnings(
         self, config_item: dict[str, Any], available_target_types: set
-    ) -> bool:
+    ) -> None:
         augmentation_name = config_item["name"]
 
         if "keypoints" in available_target_types and augmentation_name in [
             "HorizontalFlip",
             "VerticalFlip",
-            "Flip",
         ]:
             logger.warning(
                 f"Using '{augmentation_name}' with keypoints."
@@ -359,10 +358,11 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         available_target_types = set(self.targets.values())
 
         for config_item in config:
+            cfg = AlbumentationConfigItem(**config_item)
+
             self._check_augmentation_warnings(
                 config_item, available_target_types
             )
-            cfg = AlbumentationConfigItem(**config_item)
 
             transform = self.create_transformation(cfg)
 

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -249,7 +249,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         if "keypoints" in available_target_types and augmentation_name in [
             "HorizontalFlip",
             "VerticalFlip",
-            "Transpose"
+            "Transpose",
         ]:
             logger.warning(
                 f"Using '{augmentation_name}' with keypoints."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,6 @@ def augmentation_config() -> list[Params]:
         {"name": "MixUp", "params": {"p": 1.0}},
         {"name": "Defocus", "params": {"p": 1.0}},
         {"name": "Sharpen", "params": {"p": 1.0}},
-        {"name": "Flip", "params": {"p": 1.0}},
         {"name": "RandomRotate90", "params": {"p": 1.0}},
     ]
 

--- a/tests/test_data/test_augmentations/test_special.py
+++ b/tests/test_data/test_augmentations/test_special.py
@@ -84,7 +84,6 @@ def test_skip_augmentations():
     batched_transform_names = [
         t.__class__.__name__ for t in augmentations.batch_transform.transforms
     ]
-    print(spatial_transform_names)
     assert spatial_transform_names == [
         "Perspective",
         "Lambda",

--- a/tests/test_data/test_augmentations/test_special.py
+++ b/tests/test_data/test_augmentations/test_special.py
@@ -40,9 +40,6 @@ def test_skip_augmentations():
             "name": "Perspective",
         },
         {
-            "name": "Flip",
-        },
-        {
             "name": "HorizontalFlip",
         },
         {
@@ -87,9 +84,13 @@ def test_skip_augmentations():
     batched_transform_names = [
         t.__class__.__name__ for t in augmentations.batch_transform.transforms
     ]
-
+    print(spatial_transform_names)
     assert spatial_transform_names == [
         "Perspective",
+        "Lambda",
+        "HorizontalFlip",
+        "Lambda",
+        "VerticalFlip",
         "Lambda",
         "Rotate",
         "Lambda",


### PR DESCRIPTION
## Purpose
To remove the constraint that keypoints cannot be transformed using flips.

## Specification
Using albumentations>2.0.0 and testing using the luxonis_ml data inspect [dataset] --aug-config [augmentations] as well as using the debugger to manually check transformations before and after, the effect of horizontally or vertically augmenting an image and its keypoints works correctly and does not change the index of the keypoints. The tests were performed on the COCO tiger dataset.

## Dependencies & Potential Impact
Albumentations>=2.0.0 (already in luxonis-ml/data/requirements.txt)

## Deployment Plan


## Testing & Validation
Test 1: flips by saving the result of the keypoints before and after vertical flip. In this case, width = 1280 and height = 720:

Before:

[[988. 356.   2.], [933. 229.   2.], [766. 177.   2.], [319. 194.   2.], [360. 476.   2.], [395. 566.   2.], [322. 566.   2.], [292. 453.   2.], [806. 378.   2.], [863. 527.   2.], [632. 416.   2.], [584. 545.   2.]]

After:

[[988. 363.   2.], [933. 490.   2.], [766. 542.   2.], [319. 525.   2.], [360. 243.   2.], [395. 153.   2.], [322. 153.   2.], [292. 266.   2.], [806. 341.   2.], [863. 192.   2.], [632. 303.   2.], [584. 174.   2.]]

As you can see, the keypoints after the transformation have the same x coordinate, and their y coordinate is (720 - after_y) = before_y.

Testing on images using luxonis_ml data inspect:

Original image with keypoints

![original_labels](https://github.com/user-attachments/assets/f75dee3b-a2fb-4e56-8dc9-12818b4b879e)

Vertical flip

![vertical_flip](https://github.com/user-attachments/assets/964c2fab-3b99-400c-9ad4-1f04e5d021d6)

Mosaic augmentation

![mosaic_augmentation](https://github.com/user-attachments/assets/0c2b21f3-e52e-4783-ab50-0061651fd949)

MixUp

![mixup](https://github.com/user-attachments/assets/20a346f7-e45f-43ad-b0c6-9f82d4eec215)

Horizontal flip

![horizontal_flip](https://github.com/user-attachments/assets/4aaed478-6c9e-4269-bc12-8e1df516d70c)

As can be seen, the relevant keypoint indices stay the same despite the transformation. For example, index 2 is still the nose, and indices 5, 6, 9 and 11 are still the feet, even if the order of the location of the keypoints changes after transformations.