### PR TITLE
Use _list_images for image iteration in CLSDIR parser.

### DIFF
--- a/luxonis_ml/data/parsers/classification_directory_parser.py
+++ b/luxonis_ml/data/parsers/classification_directory_parser.py
@@ -65,7 +65,7 @@ class ClassificationDirectoryParser(BaseParser):
 
         def generator() -> DatasetIterator:
             for class_name in class_names:
-                for img_path in (class_dir / class_name).iterdir():
+                for img_path in self._list_images(class_dir / class_name):
                     yield {
                         "file": str(img_path.absolute().resolve()),
                         "annotation": {"class": class_name},


### PR DESCRIPTION
## Purpose
Previously, we were iterating over all files in the directory including hidden files (e.g. .DS_Store file that MacOS attaches), this breaks the image loading with `LuxonisLoader` because cv2 can not read such files.

## Specification
Replaces direct directory iteration with the _list_images method in ClassificationDirectoryParser. This ensures consistent image file filtering and handling.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable