### PR TITLE
Restricting extra fields in `ConfigItem` 

### DIFF
--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -23,8 +23,7 @@ from pydantic_core import core_schema
 from typing_extensions import Self, override
 
 from luxonis_ml.data.utils.parquet import ParquetRecord
-from luxonis_ml.typing import PathType, check_type
-from luxonis_ml.utils import BaseModelExtraForbid
+from luxonis_ml.typing import BaseModelExtraForbid, PathType, check_type
 from luxonis_ml.utils.logging import log_once
 
 KeypointVisibility: TypeAlias = Literal[0, 1, 2]

--- a/luxonis_ml/data/datasets/metadata.py
+++ b/luxonis_ml/data/datasets/metadata.py
@@ -4,7 +4,7 @@ from typing import Literal
 from typing_extensions import TypedDict
 
 from luxonis_ml.data.utils.constants import LDF_VERSION
-from luxonis_ml.utils.pydantic_utils import BaseModelExtraForbid
+from luxonis_ml.typing import BaseModelExtraForbid
 
 from .source import LuxonisSource
 

--- a/luxonis_ml/data/datasets/source.py
+++ b/luxonis_ml/data/datasets/source.py
@@ -3,7 +3,7 @@ from typing import Any
 from pydantic import Field, field_validator
 
 from luxonis_ml.data.utils import ImageType, MediaType
-from luxonis_ml.utils import BaseModelExtraForbid
+from luxonis_ml.typing import BaseModelExtraForbid
 
 
 class LuxonisComponent(BaseModelExtraForbid):

--- a/luxonis_ml/nn_archive/config.py
+++ b/luxonis_ml/nn_archive/config.py
@@ -2,7 +2,7 @@ import re
 
 from pydantic import Field, field_validator
 
-from luxonis_ml.utils import BaseModelExtraForbid
+from luxonis_ml.typing import BaseModelExtraForbid
 
 from .model import Model
 

--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/input.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/input.py
@@ -9,7 +9,7 @@ from luxonis_ml.nn_archive.config_building_blocks.enums import (
     InputType,
 )
 from luxonis_ml.nn_archive.utils import infer_layout
-from luxonis_ml.utils import BaseModelExtraForbid
+from luxonis_ml.typing import BaseModelExtraForbid
 
 
 class PreprocessingBlock(BaseModelExtraForbid):

--- a/luxonis_ml/nn_archive/config_building_blocks/base_models/output.py
+++ b/luxonis_ml/nn_archive/config_building_blocks/base_models/output.py
@@ -5,7 +5,7 @@ from typing_extensions import Self
 
 from luxonis_ml.nn_archive.config_building_blocks.enums import DataType
 from luxonis_ml.nn_archive.utils import infer_layout
-from luxonis_ml.utils import BaseModelExtraForbid
+from luxonis_ml.typing import BaseModelExtraForbid
 
 
 class Output(BaseModelExtraForbid):

--- a/luxonis_ml/nn_archive/model.py
+++ b/luxonis_ml/nn_archive/model.py
@@ -1,6 +1,6 @@
 from pydantic import Field
 
-from luxonis_ml.utils import BaseModelExtraForbid
+from luxonis_ml.typing import BaseModelExtraForbid
 
 from .config_building_blocks import HeadType, Input, Metadata, Output
 

--- a/luxonis_ml/typing.py
+++ b/luxonis_ml/typing.py
@@ -3,7 +3,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias, TypeGuard, TypeVar
 
 import typeguard
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 # When used without installed dependencies
 if TYPE_CHECKING:  # pragma: no cover
@@ -83,7 +83,13 @@ Kwargs: TypeAlias = dict[str, Any]
 """A keyword dictionary of arbitrary parameters."""
 
 
-class ConfigItem(BaseModel):
+class BaseModelExtraForbid(BaseModel):
+    """BaseModel with extra fields forbidden."""
+
+    model_config: ConfigDict = ConfigDict(extra="forbid")
+
+
+class ConfigItem(BaseModelExtraForbid):
     """Configuration schema for dynamic object instantiation. Typically
     used to instantiate objects stored in registries.
 

--- a/luxonis_ml/utils/__init__.py
+++ b/luxonis_ml/utils/__init__.py
@@ -6,7 +6,6 @@ with guard_missing_extra("utils"):
     from .filesystem import PUT_FILE_REGISTRY, LuxonisFileSystem
     from .graph import is_acyclic, traverse_graph
     from .logging import deprecated, log_once, setup_logging
-    from .pydantic_utils import BaseModelExtraForbid
     from .registry import AutoRegisterMeta, Registry
     from .rich_utils import make_progress_bar
 
@@ -14,7 +13,6 @@ with guard_missing_extra("utils"):
 __all__ = [
     "PUT_FILE_REGISTRY",
     "AutoRegisterMeta",
-    "BaseModelExtraForbid",
     "Environ",
     "LuxonisConfig",
     "LuxonisFileSystem",

--- a/luxonis_ml/utils/config.py
+++ b/luxonis_ml/utils/config.py
@@ -5,10 +5,9 @@ from typing import Any, TypeVar
 import yaml
 from typing_extensions import Self
 
-from luxonis_ml.typing import Params, PathType
+from luxonis_ml.typing import BaseModelExtraForbid, Params, PathType
 
 from .filesystem import LuxonisFileSystem
-from .pydantic_utils import BaseModelExtraForbid
 
 T = TypeVar("T", bound="LuxonisConfig")
 

--- a/luxonis_ml/utils/pydantic_utils.py
+++ b/luxonis_ml/utils/pydantic_utils.py
@@ -1,5 +1,0 @@
-from pydantic import BaseModel, ConfigDict
-
-
-class BaseModelExtraForbid(BaseModel):
-    model_config: ConfigDict = ConfigDict(extra="forbid")


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Forbids extra fields in pydantic classes inheriting from `ConfigItem`.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- `ConfigItem` now inherits from `BaseModelExtraForbid`
- Moved `BaseModelExtraForbid` from `utils.pydantic_utils` to `typing`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable