### PR TITLE
Faster parsing and note regarding symlinks

### DIFF
--- a/luxonis_ml/data/README.md
+++ b/luxonis_ml/data/README.md
@@ -638,6 +638,9 @@ After initializing the parser, you can parse the dataset to create a `LuxonisDat
 dataset = parser.parse()
 ```
 
+> [!NOTE]
+> The dataset parsers do not follow symbolic links. Datasets that rely on symlinks may not be parsed correctly.
+
 ### LuxonisParser CLI
 
 The parser can be invoked using the `luxonis_ml data parse` command.

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -564,7 +564,7 @@ class DatasetRecord(BaseModelExtraForbid):
         if "files" in values:
             files_dict = values["files"]
             values["files"] = {
-                k: Path(v).resolve() for k, v in files_dict.items()
+                k: Path(v).absolute() for k, v in files_dict.items()
             }
         return values
 


### PR DESCRIPTION
## Purpose
Halves the parsing time for COCO and Native parsers

## Specification
- Path(k).resolve() performs full path normalization + symlink resolution + filesystem access, which was one of the bottlenecks in  parsing. Replacing it by Path(k).absolute() instead more than halves the parsing time.
- Different datasets were created artificially with 30, 300, 3000 and 30,000 images of COCO_people_subset, and it was found that parsing speed always scales linearly with the number of annotations.
- Turning every annotation into an instance of DatasetRecord takes up 99% of the parsing time, so any further improvement should be based on this

## Dependencies & Potential Impact
Symlinks for images in the dataset are no longer supported and a note is written about this in the README.md

## Deployment Plan


## Testing & Validation
- Test out the parsing speed on NATIVE and COCO for different dataset sizes with Path(k).resolve() and Path(k).absolute(). For example, for 30,000 images, NATIVE parser with Path(k).resolve() takes 654 seconds whereas Path(k).absolute() takes 273 seconds.