### PR TITLE
Allow for yolo annotations with zero bounding box labels to be parsed

### DIFF
--- a/luxonis_ml/data/parsers/yolov6_parser.py
+++ b/luxonis_ml/data/parsers/yolov6_parser.py
@@ -45,9 +45,8 @@ class YoloV6Parser(BaseParser):
         if not label_split.exists():
             return None
 
-        labels = label_split.glob("*.txt")
         images = BaseParser._list_images(split_path)
-        if not BaseParser._compare_stem_files(images, labels):
+        if not images:
             return None
         data_yaml = split_path.parent.parent / "data.yaml"
         if not data_yaml.exists():
@@ -118,8 +117,14 @@ class YoloV6Parser(BaseParser):
             for img_path in self._list_images(image_dir):
                 ann_path = annotation_dir / img_path.with_suffix(".txt").name
 
-                with open(ann_path) as f:
-                    annotation_data = f.readlines()
+                annotation_data = []
+                if ann_path.exists():
+                    with open(ann_path) as f:
+                        annotation_data = f.readlines()
+
+                if not annotation_data:
+                    yield {"file": str(img_path), "annotation": None}
+                    continue
 
                 for ann_line in annotation_data:
                     class_id, x_center, y_center, width, height = list(


### PR DESCRIPTION
## Purpose
YOLOv4: empty/whitespace .txt file or missing .txt file handled
YOLOv6 and YOLOV8: same + if not annotation_data, and removed _compare_stem_files validation check so a missing label file passes

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
In a YOLOv8 dataset, I removed all train images except for 4 of them. Out of these 4, removed 3 labels. Parsing still correctly works now, with all 4 images in the resulting LDF. Training with a batch_size of 2 on this dataset works, giving 2 batches (meaning all 4 images are being trained on). Overfitting on the images works correctly: the three images with no annotations show no prediction box, and the image with the annotation shows a correct prediction box.