### PR TITLE
Dense prediction tasks: allow images with no ground truth labels

### DIFF
--- a/luxonis_ml/data/exporters/tensorflow_csv_exporter.py
+++ b/luxonis_ml/data/exporters/tensorflow_csv_exporter.py
@@ -149,9 +149,6 @@ class TensorflowCSVExporter(BaseExporter):
         output_path: Path,
         part: int | None = None,
     ) -> None:
-        if all(len(rows) == 0 for rows in rows_by_split.values()):
-            return
-
         base = (
             output_path / f"{self.dataset_identifier}_part{part}"
             if part is not None

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -272,6 +272,11 @@ class COCOParser(BaseParser):
                 img_h = img["height"]
                 img_w = img["width"]
 
+                if not img_anns:
+                    # Register image with no annotations (valid COCO case)
+                    yield {"file": file, "annotation": None}
+                    continue
+
                 for i, ann in enumerate(img_anns):
                     if ann.get("iscrowd"):
                         continue

--- a/luxonis_ml/data/parsers/darknet_parser.py
+++ b/luxonis_ml/data/parsers/darknet_parser.py
@@ -30,9 +30,7 @@ class DarknetParser(BaseParser):
             return None
         if not (split_path / "_darknet.labels").exists():
             return None
-        images = BaseParser._list_images(split_path)
-        labels = split_path.glob("*.txt")
-        if not BaseParser._compare_stem_files(images, labels):
+        if not BaseParser._list_images(split_path):
             return None
         return {
             "image_dir": split_path,
@@ -77,8 +75,15 @@ class DarknetParser(BaseParser):
             for img_path in self._list_images(image_dir):
                 ann_path = img_path.with_suffix(".txt")
                 file = str(img_path)
-                with open(ann_path) as f:
-                    annotation_data = f.readlines()
+                if ann_path.exists():
+                    with open(ann_path) as f:
+                        annotation_data = f.readlines()
+                else:
+                    annotation_data = []
+
+                if not annotation_data:
+                    yield {"file": file, "annotation": None}
+                    continue
 
                 for ann_line in annotation_data:
                     class_id, x_center, y_center, width, height = list(

--- a/luxonis_ml/data/parsers/tensorflow_csv_parser.py
+++ b/luxonis_ml/data/parsers/tensorflow_csv_parser.py
@@ -102,7 +102,12 @@ class TensorflowCSVParser(BaseParser):
             images_annotations[path]["bboxes"].append((class_name, bbox_xywh))
 
         def generator() -> DatasetIterator:
-            for path, curr_annotations in images_annotations.items():
+            for img_path in self._list_images(image_dir):
+                path = str(img_path)
+                curr_annotations = images_annotations.get(path, {"bboxes": []})
+                if not curr_annotations["bboxes"]:
+                    yield {"file": path, "annotation": None}
+                    continue
                 for bbox_class, (x, y, w, h) in curr_annotations["bboxes"]:
                     yield {
                         "file": path,

--- a/luxonis_ml/data/parsers/voc_parser.py
+++ b/luxonis_ml/data/parsers/voc_parser.py
@@ -114,6 +114,9 @@ class VOCParser(BaseParser):
         def generator() -> DatasetIterator:
             for curr_annotations in images_annotations:
                 path = str(curr_annotations["path"])
+                if not curr_annotations["bboxes"]:
+                    yield {"file": path, "annotation": None}
+                    continue
                 for bbox_class, bbox in curr_annotations["bboxes"]:
                     yield {
                         "file": path,


### PR DESCRIPTION
## Purpose
- Export/parse behavior more closely in line with COCO base behavior: if an image does not have annotations, don't export with dummy empty annotations. An image can have an entry in the "images" registry of the _annotations_coco.json and have no corresponding entry in "annotations". To account for that the COCO parser now registers images without annotations.
- TensorFlowCSV, Darknet and VOC parsers all accept images without ground truth annotations, including missing .txt files in the case of DarkNet.
- TensorFlowCSV exporter now always writes the CSV (headers)
- The native parser/exporter just passed the JSON through as-is and exports it as-is and this includes accepting annotation=None (so no changes there)
## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
`test_parse_export_equivalence.py` is definitely helpful for this, also manually exported a yolov8 dataset with missing annotations to specific formats (in this case VOC and COCO) then re-parsed these datasets and saw the same number of entries per-split, so nothing was dropped in the export -> parse -> export process.