### PR TITLE
Classification and metadata visualizer

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -283,6 +283,7 @@ def inspect(
         raise ValueError(f"Dataset '{name}' is empty.")
 
     classes = dataset.get_classes()
+    categorical_encodings = dataset.get_categorical_encodings()
     prev_windows = set()
 
     for img, labels in loader:
@@ -333,6 +334,7 @@ def inspect(
                         instance_labels,
                         classes,
                         blend_all=blend_all,
+                        categorical_encodings=categorical_encodings,
                     )
                     cv2.resizeWindow(
                         source_name,
@@ -349,7 +351,12 @@ def inspect(
                         f"Showing all labels in one window for '{source_name}'.[/yellow]"
                     )
                 labeled_image = visualize(
-                    image, source_name, labels, classes, blend_all=blend_all
+                    image,
+                    source_name,
+                    labels,
+                    classes,
+                    blend_all=blend_all,
+                    categorical_encodings=categorical_encodings,
                 )
                 cv2.resizeWindow(
                     source_name, labeled_image.shape[1], labeled_image.shape[0]

--- a/luxonis_ml/data/utils/visualizations.py
+++ b/luxonis_ml/data/utils/visualizations.py
@@ -591,10 +591,12 @@ def visualize(
         if isinstance(value, np.generic):
             value = value.item()
 
-        if task in metadata_mappings:
+        if task in metadata_mappings and isinstance(
+            value, (int, str, bytes, bytearray)
+        ):
             try:
                 return metadata_mappings[task].inverse[int(value)]
-            except (KeyError, TypeError, ValueError):
+            except (KeyError, ValueError):
                 pass
 
         if isinstance(value, float):

--- a/luxonis_ml/data/utils/visualizations.py
+++ b/luxonis_ml/data/utils/visualizations.py
@@ -741,11 +741,10 @@ def visualize(
     text_lines: list[str] = []
     if classification_only and len(classification_labels) == 1:
         _, class_names = classification_labels[0]
-        prefix = "Class" if len(class_names) == 1 else "Classes"
-        text_lines.append(f"{prefix}: {', '.join(class_names)}")
+        text_lines.extend(["Classes:", ", ".join(class_names)])
     elif classification_only and classification_labels:
         text_lines.extend(
-            ["Classification labels"]
+            ["Classification labels:"]
             + [
                 f"{task_name}: {', '.join(class_names)}"
                 for task_name, class_names in classification_labels
@@ -753,17 +752,13 @@ def visualize(
         )
 
     if metadata_labels:
-        if len(metadata_labels) == 1 and not text_lines:
-            label_name, values = metadata_labels[0]
-            text_lines.append(f"{label_name}: {', '.join(values)}")
-        else:
-            text_lines.extend(
-                ["Metadata labels"]
-                + [
-                    f"{label_name}: {', '.join(values)}"
-                    for label_name, values in metadata_labels
-                ]
-            )
+        text_lines.extend(
+            ["Metadata labels:"]
+            + [
+                f"{label_name}: {', '.join(values)}"
+                for label_name, values in metadata_labels
+            ]
+        )
 
     if text_lines:
         output = append_text_block(output, text_lines, font_scale)

--- a/luxonis_ml/data/utils/visualizations.py
+++ b/luxonis_ml/data/utils/visualizations.py
@@ -9,7 +9,11 @@ import matplotlib.colors
 import numpy as np
 from bidict import bidict
 
-from luxonis_ml.data.utils import get_task_name, task_type_iterator
+from luxonis_ml.data.utils import (
+    get_task_name,
+    get_task_type,
+    task_type_iterator,
+)
 from luxonis_ml.typing import HSV, RGB, Color, Labels
 
 FONT = cv2.FONT_HERSHEY_SIMPLEX
@@ -271,6 +275,103 @@ def create_text_image(
     return img
 
 
+def wrap_text(
+    text: str,
+    max_width: int,
+    font_scale: float,
+    thickness: int = 1,
+) -> list[str]:
+    """Wraps text into lines that fit within the given width."""
+    if max_width <= 0:
+        return [text]
+
+    words = text.split()
+    if not words:
+        return [""]
+
+    lines: list[str] = []
+    current_line = words[0]
+
+    for word in words[1:]:
+        candidate = f"{current_line} {word}"
+        candidate_width = cv2.getTextSize(
+            candidate, FONT, font_scale, thickness
+        )[0][0]
+        if candidate_width <= max_width:
+            current_line = candidate
+        else:
+            lines.append(current_line)
+            current_line = word
+
+    lines.append(current_line)
+    return lines
+
+
+def append_text_block(
+    image: np.ndarray,
+    lines: list[str],
+    font_scale: float,
+    bg_color: Color = (245, 245, 245),
+    text_color: Color = (32, 32, 32),
+) -> np.ndarray:
+    """Appends a multi-line text block below the image."""
+    if not lines:
+        return image
+
+    font_scale = max(0.4, font_scale)
+    padding_x = max(10, round(18 * font_scale))
+    padding_y = max(8, round(14 * font_scale))
+    line_spacing = max(6, round(8 * font_scale))
+    thickness = 1
+    max_text_width = image.shape[1] - 2 * padding_x
+
+    wrapped_lines: list[str] = []
+    for line in lines:
+        wrapped_lines.extend(wrap_text(line, max_text_width, font_scale))
+
+    if not wrapped_lines:
+        return image
+
+    (_, text_height), baseline = cv2.getTextSize(
+        "Ag", FONT, font_scale, thickness
+    )
+    footer_height = (
+        2 * padding_y
+        + len(wrapped_lines) * text_height
+        + max(0, len(wrapped_lines) - 1) * line_spacing
+        + baseline
+    )
+
+    footer = np.full(
+        (footer_height, image.shape[1], 3),
+        resolve_color(bg_color),
+        dtype=np.uint8,
+    )
+    cv2.line(
+        footer,
+        (0, 0),
+        (footer.shape[1], 0),
+        resolve_color((210, 210, 210)),
+        1,
+    )
+
+    y = padding_y + text_height
+    for line in wrapped_lines:
+        cv2.putText(
+            footer,
+            line,
+            (padding_x, y),
+            FONT,
+            font_scale,
+            resolve_color(text_color),
+            thickness,
+            cv2.LINE_AA,
+        )
+        y += text_height + line_spacing
+
+    return np.vstack((image, footer))
+
+
 def concat_images(
     image_dict: dict[str, np.ndarray],
     padding: int = 10,
@@ -473,6 +574,7 @@ def visualize(
         )
 
     bbox_classes = defaultdict(list)
+    classification_labels: list[tuple[str, list[str]]] = []
 
     for task, arr in task_type_iterator(labels, "segmentation"):
         task_name = get_task_name(task)
@@ -522,6 +624,21 @@ def visualize(
             curr_image, arr, task_name, is_instance=True
         )
 
+    for task, arr in task_type_iterator(labels, "classification"):
+        task_name = get_task_name(task)
+        task_classes = mappings.get(task_name)
+        if task_classes is None:
+            continue
+
+        class_ids = np.flatnonzero(np.asarray(arr).reshape(-1) > 0)
+        if len(class_ids) == 0:
+            continue
+
+        class_names = [
+            task_classes.inverse[int(class_id)] for class_id in class_ids
+        ]
+        classification_labels.append((task_name, class_names))
+
     for task, arr in task_type_iterator(labels, "keypoints"):
         task_name = get_task_name(task)
         image_name = task_name if task_name and not blend_all else "labels"
@@ -566,4 +683,31 @@ def visualize(
 
         images[image_name] = curr_image
 
-    return concat_images(images)
+    output = concat_images(images)
+
+    classification_only = all(
+        (
+            get_task_type(task) == "classification"
+            or get_task_type(task).startswith("metadata/")
+        )
+        for task in labels
+    )
+
+    if classification_only and len(classification_labels) == 1:
+        _, class_names = classification_labels[0]
+        prefix = "Class" if len(class_names) == 1 else "Classes"
+        output = append_text_block(
+            output, [f"{prefix}: {', '.join(class_names)}"], font_scale
+        )
+    elif classification_only and classification_labels:
+        output = append_text_block(
+            output,
+            ["Classification labels"]
+            + [
+                f"{task_name}: {', '.join(class_names)}"
+                for task_name, class_names in classification_labels
+            ],
+            font_scale,
+        )
+
+    return output

--- a/luxonis_ml/data/utils/visualizations.py
+++ b/luxonis_ml/data/utils/visualizations.py
@@ -275,36 +275,56 @@ def create_text_image(
     return img
 
 
-def wrap_text(
-    text: str,
-    max_width: int,
-    font_scale: float,
-    thickness: int = 1,
-) -> list[str]:
-    """Wraps text into lines that fit within the given width."""
-    if max_width <= 0:
-        return [text]
+def concat_images(
+    image_dict: dict[str, np.ndarray],
+    padding: int = 10,
+    label_height: int = 30,
+) -> np.ndarray:
+    """Concatenates images into a single image with labels.
 
-    words = text.split()
-    if not words:
-        return [""]
+    It will attempt to create a square grid of images.
 
-    lines: list[str] = []
-    current_line = words[0]
+    @type image_dict: Dict[str, np.ndarray]
+    @param image_dict: A dictionary mapping image names to images.
+    @type padding: int
+    @param padding: The padding between images. Default is 10.
+    @type label_height: int
+    @param label_height: The height of the label. Default
+    @rtype: np.ndarray
+    @return: The concatenated image.
+    """
+    n_images = len(image_dict)
+    n_cols = math.ceil(math.sqrt(n_images))
+    n_rows = math.ceil(n_images / n_cols)
 
-    for word in words[1:]:
-        candidate = f"{current_line} {word}"
-        candidate_width = cv2.getTextSize(
-            candidate, FONT, font_scale, thickness
-        )[0][0]
-        if candidate_width <= max_width:
-            current_line = candidate
-        else:
-            lines.append(current_line)
-            current_line = word
+    max_h = max(img.shape[0] for img in image_dict.values())
+    max_w = max(img.shape[1] for img in image_dict.values())
 
-    lines.append(current_line)
-    return lines
+    cell_height = max_h + 2 * padding + label_height
+    cell_width = max_w + 2 * padding
+
+    output = np.full(
+        (cell_height * n_rows, cell_width * n_cols, 3), 255, dtype=np.uint8
+    )
+
+    for idx, (name, img) in enumerate(image_dict.items()):
+        i = idx // n_cols
+        j = idx % n_cols
+
+        y_start = i * cell_height
+        x_start = j * cell_width
+
+        label = create_text_image(name, cell_width, label_height)
+        output[
+            y_start : y_start + label_height, x_start : x_start + cell_width
+        ] = label
+
+        h, w = img.shape[:2]
+        y_img = y_start + label_height + padding
+        x_img = x_start + padding
+        output[y_img : y_img + h, x_img : x_img + w] = img
+
+    return output
 
 
 def append_text_block(
@@ -372,56 +392,36 @@ def append_text_block(
     return np.vstack((image, footer))
 
 
-def concat_images(
-    image_dict: dict[str, np.ndarray],
-    padding: int = 10,
-    label_height: int = 30,
-) -> np.ndarray:
-    """Concatenates images into a single image with labels.
+def wrap_text(
+    text: str,
+    max_width: int,
+    font_scale: float,
+    thickness: int = 1,
+) -> list[str]:
+    """Wraps text into lines that fit within the given width."""
+    if max_width <= 0:
+        return [text]
 
-    It will attempt to create a square grid of images.
+    words = text.split()
+    if not words:
+        return [""]
 
-    @type image_dict: Dict[str, np.ndarray]
-    @param image_dict: A dictionary mapping image names to images.
-    @type padding: int
-    @param padding: The padding between images. Default is 10.
-    @type label_height: int
-    @param label_height: The height of the label. Default
-    @rtype: np.ndarray
-    @return: The concatenated image.
-    """
-    n_images = len(image_dict)
-    n_cols = math.ceil(math.sqrt(n_images))
-    n_rows = math.ceil(n_images / n_cols)
+    lines: list[str] = []
+    current_line = words[0]
 
-    max_h = max(img.shape[0] for img in image_dict.values())
-    max_w = max(img.shape[1] for img in image_dict.values())
+    for word in words[1:]:
+        candidate = f"{current_line} {word}"
+        candidate_width = cv2.getTextSize(
+            candidate, FONT, font_scale, thickness
+        )[0][0]
+        if candidate_width <= max_width:
+            current_line = candidate
+        else:
+            lines.append(current_line)
+            current_line = word
 
-    cell_height = max_h + 2 * padding + label_height
-    cell_width = max_w + 2 * padding
-
-    output = np.full(
-        (cell_height * n_rows, cell_width * n_cols, 3), 255, dtype=np.uint8
-    )
-
-    for idx, (name, img) in enumerate(image_dict.items()):
-        i = idx // n_cols
-        j = idx % n_cols
-
-        y_start = i * cell_height
-        x_start = j * cell_width
-
-        label = create_text_image(name, cell_width, label_height)
-        output[
-            y_start : y_start + label_height, x_start : x_start + cell_width
-        ] = label
-
-        h, w = img.shape[:2]
-        y_img = y_start + label_height + padding
-        x_img = x_start + padding
-        output[y_img : y_img + h, x_img : x_img + w] = img
-
-    return output
+    lines.append(current_line)
+    return lines
 
 
 def draw_bbox_label(
@@ -732,19 +732,11 @@ def visualize(
 
     output = concat_images(images)
 
-    classification_only = all(
-        (
-            get_task_type(task) == "classification"
-            or get_task_type(task).startswith("metadata/")
-        )
-        for task in labels
-    )
-
     text_lines: list[str] = []
-    if classification_only and len(classification_labels) == 1:
+    if len(classification_labels) == 1:
         _, class_names = classification_labels[0]
         text_lines.extend(["Classes:", ", ".join(class_names)])
-    elif classification_only and classification_labels:
+    elif classification_labels:
         text_lines.extend(
             ["Classification labels:"]
             + [

--- a/luxonis_ml/data/utils/visualizations.py
+++ b/luxonis_ml/data/utils/visualizations.py
@@ -516,6 +516,7 @@ def visualize(
     labels: Labels,
     classes: dict[str, dict[str, int]],
     blend_all: bool = False,
+    categorical_encodings: dict[str, dict[str, int]] | None = None,
 ) -> np.ndarray:
     """Visualizes the labels on the image.
 
@@ -532,12 +533,21 @@ def visualize(
     @param blend_all: Whether to blend all labels (apart from semantic
         segmentations) into a single image. This means mixing labels
         belonging to different tasks. Default is False.
+    @type categorical_encodings: Optional[Dict[str, Dict[str, int]]]
+    @param categorical_encodings: Optional mapping for categorical
+        metadata tasks. Keys are full task identifiers such as
+        C{"task_name/metadata/key"} and values map string labels to
+        encoded integers.
     @rtype: np.ndarray
     @return: The visualized image.
     """
     h, w, _ = image.shape
     images = {source_name: image}
     mappings = {task: bidict(c) for task, c in classes.items()}
+    metadata_mappings = {
+        task: bidict(encoding)
+        for task, encoding in (categorical_encodings or {}).items()
+    }
 
     min_dimension = min(h, w)
     font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
@@ -575,6 +585,21 @@ def visualize(
 
     bbox_classes = defaultdict(list)
     classification_labels: list[tuple[str, list[str]]] = []
+    metadata_labels: list[tuple[str, list[str]]] = []
+
+    def format_metadata_value(task: str, value: object) -> str:
+        if isinstance(value, np.generic):
+            value = value.item()
+
+        if task in metadata_mappings:
+            try:
+                return metadata_mappings[task].inverse[int(value)]
+            except (KeyError, TypeError, ValueError):
+                pass
+
+        if isinstance(value, float):
+            return f"{value:g}"
+        return str(value)
 
     for task, arr in task_type_iterator(labels, "segmentation"):
         task_name = get_task_name(task)
@@ -639,6 +664,26 @@ def visualize(
         ]
         classification_labels.append((task_name, class_names))
 
+    for task, arr in labels.items():
+        task_type = get_task_type(task)
+        if not task_type.startswith("metadata/"):
+            continue
+
+        metadata_name = task_type.removeprefix("metadata/")
+        task_name = get_task_name(task)
+        label_name = (
+            f"{task_name}/{metadata_name}" if task_name else metadata_name
+        )
+        values = np.asarray(arr).reshape(-1)
+        if len(values) == 0:
+            continue
+
+        formatted_values = [
+            format_metadata_value(task, value) for value in values
+        ]
+        unique_values = list(dict.fromkeys(formatted_values))
+        metadata_labels.append((label_name, unique_values))
+
     for task, arr in task_type_iterator(labels, "keypoints"):
         task_name = get_task_name(task)
         image_name = task_name if task_name and not blend_all else "labels"
@@ -693,21 +738,34 @@ def visualize(
         for task in labels
     )
 
+    text_lines: list[str] = []
     if classification_only and len(classification_labels) == 1:
         _, class_names = classification_labels[0]
         prefix = "Class" if len(class_names) == 1 else "Classes"
-        output = append_text_block(
-            output, [f"{prefix}: {', '.join(class_names)}"], font_scale
-        )
+        text_lines.append(f"{prefix}: {', '.join(class_names)}")
     elif classification_only and classification_labels:
-        output = append_text_block(
-            output,
+        text_lines.extend(
             ["Classification labels"]
             + [
                 f"{task_name}: {', '.join(class_names)}"
                 for task_name, class_names in classification_labels
-            ],
-            font_scale,
+            ]
         )
+
+    if metadata_labels:
+        if len(metadata_labels) == 1 and not text_lines:
+            label_name, values = metadata_labels[0]
+            text_lines.append(f"{label_name}: {', '.join(values)}")
+        else:
+            text_lines.extend(
+                ["Metadata labels"]
+                + [
+                    f"{label_name}: {', '.join(values)}"
+                    for label_name, values in metadata_labels
+                ]
+            )
+
+    if text_lines:
+        output = append_text_block(output, text_lines, font_scale)
 
     return output


### PR DESCRIPTION
## Purpose
Classification and metadata/ tasks did not show any labels when inspected using `luxonis_ml data inspect <dataset-name>`, this PR adds visualization for both.

This was also tested with `luxonis_train inspect --config <config-yaml>`

If `luxonis_train inspect --config <...>` is called on a dataset with multiple metadata labels, but the `task_name` is set in the predefined model config, then only metadata labels pertaining to this task name are shown.

Example with `luxonis_train inspect ...` and predefined model head has `task_name` cars:

<img width="1058" height="532" alt="cars_only" src="https://github.com/user-attachments/assets/8d3dd4f2-a160-4f81-8c32-7c0012bf11ab" />

`task_name` vehicles:

<img width="1059" height="534" alt="only_vehicles" src="https://github.com/user-attachments/assets/750245c5-9c60-47f4-9bc4-a59c192def50" />

Note: the numbers are shown because `luxonis-train`'s loader encodes string metadata as character-coded arrays before passing it to the `inspect`, this will be fixed in a separate `luxonis-train` PR

Examples with `luxonis_ml data inspect`:

<img width="388" height="467" alt="classification_only" src="https://github.com/user-attachments/assets/c8c3206c-e098-48f2-a1ee-aa1c10c766ae" />

<img width="86" height="137" alt="metadataonly" src="https://github.com/user-attachments/assets/e10942fd-dac3-4c34-9043-e4f70d79d1f5" />

Both metadata labels and classification (synthetic dataset for the sake of the example);

![Uploading combined_synthetic.png…]()

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
