### PR TITLE
use_for_resizing augmentation is wrapped in a OneOf with default resize if p < 1

### DIFF
--- a/luxonis_ml/data/augmentations/README.md
+++ b/luxonis_ml/data/augmentations/README.md
@@ -75,7 +75,7 @@ The configuration format for the `AlbumentationsEngine` consists of a list of re
 
 - `name`: The name of the transformation class to be applied (e.g., `HorizontalFlip`, `RandomCrop`, etc.). The name must be either a valid name of an Albumentations transformation (accessible under the `albumentations` namespace), or a name of a custom transformation registered in the `TRANSFORMATIONS` registry.
 - `params`: A dictionary of parameters to be passed to the transformation.
-- `use_for_resizing`: An optional boolean flag that indicates whether the transformation should be used for resizing. If no resizing augmentation is provided, the engine will use either `A.Resize` or `LetterboxResize` depending on the `keep_aspect_ratio` parameter (provided through the `LuxonisLoader`).
+- `use_for_resizing`: An optional boolean flag that indicates whether the transformation should be used for resizing. If no resizing augmentation is provided, the engine will use either `A.Resize` or `LetterboxResize` depending on the `keep_aspect_ratio` parameter (provided through the `LuxonisLoader`). When the designated resize transform has `p < 1`, the engine keeps it in the resize stage and fills the remaining probability mass with the default resize by wrapping both inside an always-on `OneOf`.
 
 **Example:**
 

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -56,6 +56,10 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
     whether the transformation should be used for resizing. If no resizing
     augmentation is provided, the engine will use either L{A.Resize} or
     L{LetterboxResize} depending on the C{keep_aspect_ratio} parameter.
+    When the designated resizing transformation has C{p < 1}, the engine
+    combines it with the default resize through L{A.OneOf}. In this case
+    the transformation C{p} values are used as branch weights so exactly
+    one resize branch is still selected.
 
     The name must be either a valid name of an Albumentations
     transformation (accessible under the C{albumentations} namespace),
@@ -371,6 +375,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 image_h, image_w = self.image_size
                 cfg_h = cfg.params.get("height")
                 cfg_w = cfg.params.get("width")
+                cfg.params.setdefault("p", 1.0)
                 if cfg_h != image_h or cfg_w != image_w:
                     logger.warning(
                         f"Resizing augmentation '{cfg.name}' has "
@@ -380,15 +385,6 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 cfg.params["height"] = image_h
                 cfg.params["width"] = image_w
 
-                cfg_p = cfg.params.get("p")
-                if cfg_p != 1:
-                    if cfg_p is not None:
-                        logger.warning(
-                            f"Resizing augmentation '{cfg.name}' has p={cfg_p}. "
-                            f"Overriding to p=1."
-                        )
-                    cfg.params["p"] = 1
-
             transform = self.create_transformation(cfg)
 
             if cfg.use_for_resizing:
@@ -397,7 +393,30 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                     raise ValueError(
                         "Only one resizing augmentation can be provided."
                     )
-                resize_transform = transform
+                resize_probability = cfg.params["p"]
+                if isinstance(resize_probability, bool) or not isinstance(
+                    resize_probability, (int, float)
+                ):
+                    raise TypeError(
+                        f"Resizing augmentation '{cfg.name}' has invalid "
+                        f"p={resize_probability!r}. Expected a float."
+                    )
+                resize_probability = float(resize_probability)
+                if resize_probability < 1:
+                    resize_transform = A.OneOf(
+                        [
+                            transform,
+                            self._create_default_resize_transform(
+                                keep_aspect_ratio=keep_aspect_ratio,
+                                height=height,
+                                width=width,
+                                p=1 - resize_probability,
+                            ),
+                        ],
+                        p=1.0,
+                    )
+                else:
+                    resize_transform = transform
 
             elif isinstance(transform, A.ImageOnlyTransform):
                 pixel_transforms.append(transform)
@@ -429,10 +448,11 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             wrapped_spatial_ops = spatial_transforms
 
         if resize_transform is None:
-            if keep_aspect_ratio:
-                resize_transform = LetterboxResize(height=height, width=width)
-            else:
-                resize_transform = A.Resize(height=height, width=width)
+            resize_transform = self._create_default_resize_transform(
+                keep_aspect_ratio=keep_aspect_ratio,
+                height=height,
+                width=width,
+            )
 
         def get_params(is_custom: bool = False) -> dict[str, Any]:
             return {
@@ -707,6 +727,21 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         oob = (xs < 0) | (ys < 0) | (xs >= w) | (ys >= h)
         kps[oob, -1] = 0.0
         return kps
+
+    def _create_default_resize_transform(
+        self,
+        keep_aspect_ratio: bool,
+        height: int,
+        width: int,
+        p: float = 1.0,
+    ) -> A.DualTransform:
+        if keep_aspect_ratio:
+            return LetterboxResize(
+                height=height,
+                width=width,
+                p=p,
+            )
+        return A.Resize(height=height, width=width, p=p)
 
     @staticmethod
     def create_transformation(

--- a/tests/test_data/test_augmentations/test_special.py
+++ b/tests/test_data/test_augmentations/test_special.py
@@ -1,4 +1,6 @@
+import albumentations as A
 import numpy as np
+import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
 
@@ -95,3 +97,84 @@ def test_skip_augmentations():
         "Lambda",
     ]
     assert batched_transform_names == ["Mosaic4"]
+
+
+def test_use_for_resizing_wraps_probabilistic_resize_in_oneof():
+    augmentations = AlbumentationsEngine(
+        256,
+        256,
+        {"task/boundingbox": "boundingbox"},
+        {"task/boundingbox": 1},
+        ["image"],
+        [
+            {
+                "name": "AtLeastOneBBoxRandomCrop",
+                "params": {
+                    "height": 32,
+                    "width": 32,
+                    "erosion_factor": 0.0,
+                    "p": 0.3,
+                },
+                "use_for_resizing": True,
+            }
+        ],
+        keep_aspect_ratio=False,
+    )
+
+    resize_ops = next(
+        (
+            cell.cell_contents.transforms
+            for cell in augmentations.resize_transform.__closure__  # type: ignore
+            if hasattr(cell.cell_contents, "transforms")
+        ),
+        [],
+    )
+
+    resize_op = resize_ops[0]
+    assert isinstance(resize_op, A.OneOf)
+    assert len(resize_op.transforms) == 2
+    assert isinstance(resize_op.transforms[0], A.AtLeastOneBBoxRandomCrop)
+    assert isinstance(resize_op.transforms[1], A.Resize)
+    assert resize_op.transforms[0].height == 256
+    assert resize_op.transforms[0].width == 256
+    assert resize_op.transforms[0].p == pytest.approx(0.3)
+    assert resize_op.transforms[1].p == pytest.approx(0.7)
+    assert resize_op.transforms[1].height == 256
+    assert resize_op.transforms[1].width == 256
+
+
+def test_use_for_resizing_falls_back_to_default_resize():
+    # The probabilistic AtLeastOneBBoxRandomCrop with use_for_resizing should still preserve
+    # the required final image size through the default resize fallback.
+    augmentations = AlbumentationsEngine(
+        256,
+        256,
+        {"task/boundingbox": "boundingbox"},
+        {"task/boundingbox": 1},
+        ["image"],
+        [
+            {
+                "name": "AtLeastOneBBoxRandomCrop",
+                "params": {
+                    "height": 32,
+                    "width": 32,
+                    "erosion_factor": 0.0,
+                    "p": 0.0,
+                },
+                "use_for_resizing": True,
+            }
+        ],
+        keep_aspect_ratio=False,
+        seed=42,
+    )
+
+    images, _ = augmentations.apply(
+        [
+            (
+                {"image": np.full((100, 200, 3), 255, dtype=np.uint8)},
+                {"task/boundingbox": np.array([[0.0, 0.5, 0.5, 0.1, 0.1]])},
+            )
+        ]
+    )
+
+    assert images["image"].shape == (256, 256, 3)

--- a/tests/test_data/test_augmentations/test_special.py
+++ b/tests/test_data/test_augmentations/test_special.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
+from luxonis_ml.data.augmentations.custom import LetterboxResize
 
 
 def test_metadata_no_boxes():
@@ -135,6 +136,50 @@ def test_use_for_resizing_wraps_probabilistic_resize_in_oneof():
     assert len(resize_op.transforms) == 2
     assert isinstance(resize_op.transforms[0], A.AtLeastOneBBoxRandomCrop)
     assert isinstance(resize_op.transforms[1], A.Resize)
+    assert resize_op.transforms[0].height == 256
+    assert resize_op.transforms[0].width == 256
+    assert resize_op.transforms[0].p == pytest.approx(0.3)
+    assert resize_op.transforms[1].p == pytest.approx(0.7)
+    assert resize_op.transforms[1].height == 256
+    assert resize_op.transforms[1].width == 256
+
+
+def test_use_for_resizing_uses_letterbox_fallback_when_keeping_aspect_ratio():
+    augmentations = AlbumentationsEngine(
+        256,
+        256,
+        {"task/boundingbox": "boundingbox"},
+        {"task/boundingbox": 1},
+        ["image"],
+        [
+            {
+                "name": "AtLeastOneBBoxRandomCrop",
+                "params": {
+                    "height": 32,
+                    "width": 32,
+                    "erosion_factor": 0.0,
+                    "p": 0.3,
+                },
+                "use_for_resizing": True,
+            }
+        ],
+        keep_aspect_ratio=True,
+    )
+
+    resize_ops = next(
+        (
+            cell.cell_contents.transforms
+            for cell in augmentations.resize_transform.__closure__  # type: ignore
+            if hasattr(cell.cell_contents, "transforms")
+        ),
+        [],
+    )
+
+    resize_op = resize_ops[0]
+    assert isinstance(resize_op, A.OneOf)
+    assert len(resize_op.transforms) == 2
+    assert isinstance(resize_op.transforms[0], A.AtLeastOneBBoxRandomCrop)
+    assert isinstance(resize_op.transforms[1], LetterboxResize)
     assert resize_op.transforms[0].height == 256
     assert resize_op.transforms[0].width == 256
     assert resize_op.transforms[0].p == pytest.approx(0.3)


### PR DESCRIPTION
## Purpose
- Allow a passed-down `use_for_resizing` with p < 1 for an augmentation, but then wrap it inside a p = 1 `OneOf` transform where the other transform is a default-behavior resize transform with a `p - 1` probability
- Even though the probability passed from the luxonis-train is already a float, the validation step `isinstance(resize_probability, bool) or not isinstance(resize_probability, (int, float)):` had to be added for PyRight
- [Corresponding luxonis-train PR](https://github.com/luxonis/luxonis-train/pull/368) that removes the p == 1 restriction/override
- No behavior change from previous code for `p == 1` `use_for_resizing` augmentation, this OneOf is only created if `p < 1.0`

## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
