### PR TITLE
List augmentations in `luxonis_ml data inspect` with new flag `--list-augmentations`

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -269,12 +269,11 @@ def inspect(
     bucket_storage: BucketStorage = bucket_option,
 ):
     """Inspects images and annotations in a dataset."""
-    if list_augmentations and aug_config is not None:
+    if aug_config is not None:
         aug_config_path = Path(aug_config)
         if aug_config_path.suffix.lower() not in {".yaml", ".yml", ".json"}:
             raise typer.BadParameter(
-                "--aug-config must point to an augmentation YAML or JSON file "
-                "when --list-augmentations is enabled.",
+                "--aug-config must point to an augmentation YAML or JSON file.",
                 param_hint="--aug-config",
             )
         if not aug_config_path.is_file():

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -36,7 +36,7 @@ from luxonis_ml.data.utils.plot_utils import (
     plot_heatmap,
 )
 from luxonis_ml.data.utils.visualizations import (
-    append_text_block,
+    add_augmentation_footer,
     visualize,
 )
 from luxonis_ml.enums import DatasetType
@@ -423,19 +423,6 @@ def inspect(
 
         if cv2.waitKey() == ord("q"):
             break
-
-
-def add_augmentation_footer(
-    image: np.ndarray, augmentations: list[str]
-) -> np.ndarray:
-    min_dimension = min(image.shape[:2])
-    font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
-    augmentations_text = ", ".join(augmentations) if augmentations else "none"
-    return append_text_block(
-        image,
-        [f"Augmentations: {augmentations_text}"],
-        font_scale=font_scale,
-    )
 
 
 @app.command()

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import rich.box
 import typer
+from loguru import logger
 from rich import print
 from rich.console import Console
 from rich.prompt import Confirm
@@ -18,6 +19,9 @@ from luxonis_ml.data import (
     LuxonisLoader,
     LuxonisParser,
     UpdateMode,
+)
+from luxonis_ml.data.utils.augmentations_collector import (
+    AugmentationsCollector,
 )
 from luxonis_ml.data.utils.cli_utils import (
     check_exists,
@@ -31,7 +35,10 @@ from luxonis_ml.data.utils.plot_utils import (
     plot_class_distribution,
     plot_heatmap,
 )
-from luxonis_ml.data.utils.visualizations import visualize
+from luxonis_ml.data.utils.visualizations import (
+    append_text_block,
+    visualize,
+)
 from luxonis_ml.enums import DatasetType
 
 app = typer.Typer()
@@ -248,9 +255,34 @@ def inspect(
             help="Show each label instance in a separate window.",
         ),
     ] = False,
+    list_augmentations: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            "--list-augmentations",
+            help=(
+                "Show the augmentations applied to each displayed image "
+                "in the footer. Requires --aug-config."
+            ),
+        ),
+    ] = False,
     bucket_storage: BucketStorage = bucket_option,
 ):
     """Inspects images and annotations in a dataset."""
+    if list_augmentations and aug_config is not None:
+        aug_config_path = Path(aug_config)
+        if aug_config_path.suffix.lower() not in {".yaml", ".yml", ".json"}:
+            raise typer.BadParameter(
+                "--aug-config must point to an augmentation YAML or JSON file "
+                "when --list-augmentations is enabled.",
+                param_hint="--aug-config",
+            )
+        if not aug_config_path.is_file():
+            raise typer.BadParameter(
+                f"Augmentation config '{aug_config}' does not exist.",
+                param_hint="--aug-config",
+            )
+
     check_exists(name, bucket_storage)
 
     view = view or ["train"]
@@ -278,6 +310,23 @@ def inspect(
             keep_aspect_ratio=not ignore_aspect_ratio,
             seed=42 if deterministic else None,
         )
+
+    if list_augmentations:
+        if aug_config is None:
+            logger.warning(
+                "--list-augmentations was set but --aug-config was not "
+                "provided. No augmentations will be shown."
+            )
+            get_applied_augmentations = list
+        elif loader.augmentations is not None:
+            collector = AugmentationsCollector(
+                loader.augmentations, Path(aug_config)
+            )
+            get_applied_augmentations = collector.get_applied_augmentations
+        else:
+            get_applied_augmentations = list
+    else:
+        get_applied_augmentations = list
 
     if len(dataset) == 0:
         raise ValueError(f"Dataset '{name}' is empty.")
@@ -336,6 +385,10 @@ def inspect(
                         blend_all=blend_all,
                         categorical_encodings=categorical_encodings,
                     )
+                    if list_augmentations:
+                        instance_image = add_augmentation_footer(
+                            instance_image, get_applied_augmentations()
+                        )
                     cv2.resizeWindow(
                         source_name,
                         instance_image.shape[1],
@@ -358,6 +411,10 @@ def inspect(
                     blend_all=blend_all,
                     categorical_encodings=categorical_encodings,
                 )
+                if list_augmentations:
+                    labeled_image = add_augmentation_footer(
+                        labeled_image, get_applied_augmentations()
+                    )
                 cv2.resizeWindow(
                     source_name, labeled_image.shape[1], labeled_image.shape[0]
                 )
@@ -367,6 +424,19 @@ def inspect(
 
         if cv2.waitKey() == ord("q"):
             break
+
+
+def add_augmentation_footer(
+    image: np.ndarray, augmentations: list[str]
+) -> np.ndarray:
+    min_dimension = min(image.shape[:2])
+    font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
+    augmentations_text = ", ".join(augmentations) if augmentations else "none"
+    return append_text_block(
+        image,
+        [f"Augmentations: {augmentations_text}"],
+        font_scale=font_scale,
+    )
 
 
 @app.command()

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -1,3 +1,4 @@
+from .augmentations_collector import AugmentationsCollector
 from .data_utils import (
     find_duplicates,
     get_class_distributions,
@@ -35,6 +36,7 @@ from .visualizations import (
 )
 
 __all__ = [
+    "AugmentationsCollector",
     "BucketStorage",
     "BucketType",
     "COCOFormat",

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -29,6 +29,7 @@ from .task_utils import (
 )
 from .visualizations import (
     ColorMap,
+    add_augmentation_footer,
     concat_images,
     create_text_image,
     distinct_color_generator,
@@ -46,6 +47,7 @@ __all__ = [
     "ParquetFileManager",
     "ParquetRecord",
     "UpdateMode",
+    "add_augmentation_footer",
     "concat_images",
     "create_text_image",
     "distinct_color_generator",

--- a/luxonis_ml/data/utils/augmentations_collector.py
+++ b/luxonis_ml/data/utils/augmentations_collector.py
@@ -1,5 +1,4 @@
 import inspect as pyinspect
-import inspect as pyinspect
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -74,9 +73,7 @@ class AugmentationsCollector:
 
             current_path = (*parent_path, name)
             paths.append("/".join(current_path))
-            if AugmentationsCollector._is_probabilistic_resize_transform(
-                item
-            ):
+            if AugmentationsCollector._is_probabilistic_resize_transform(item):
                 paths.append("/".join((*parent_path, "OneOf", name)))
 
             params = item.get("params", {})

--- a/luxonis_ml/data/utils/augmentations_collector.py
+++ b/luxonis_ml/data/utils/augmentations_collector.py
@@ -23,9 +23,7 @@ class AugmentationsCollector:
         aug_config: Path | list[dict[str, Any]],
     ):
         self.augmentations = cast(AugmentationsLike, augmentations)
-        self.configured_paths = set(
-            self.load_augmentation_paths(aug_config)
-        )
+        self.configured_paths = set(self.load_augmentation_paths(aug_config))
         self._applied_augmentations: list[str] = []
         self._original_apply = self.augmentations.apply
         self._tracked_transforms = self.get_tracked_transforms(

--- a/luxonis_ml/data/utils/augmentations_collector.py
+++ b/luxonis_ml/data/utils/augmentations_collector.py
@@ -1,0 +1,156 @@
+import inspect as pyinspect
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol, cast
+
+import yaml
+
+
+class AugmentationsLike(Protocol):
+    apply: Callable[..., object]
+    batch_transform: Any
+    spatial_transform: Callable[..., object]
+    custom_transform: Callable[..., object]
+    pixel_transform: Callable[..., object]
+    resize_transform: Callable[..., object]
+
+
+class AugmentationsCollector:
+    def __init__(self, augmentations: object, aug_config_path: Path):
+        self.augmentations = cast(AugmentationsLike, augmentations)
+        self.configured_paths = set(
+            self.load_augmentation_paths(aug_config_path)
+        )
+        self._applied_augmentations: list[str] = []
+        self._original_apply = self.augmentations.apply
+        self._tracked_transforms = self.get_tracked_transforms(
+            self.augmentations
+        )
+        self._instrument()
+
+    def get_applied_augmentations(self) -> list[str]:
+        return self._applied_augmentations.copy()
+
+    def _instrument(self) -> None:
+        def capture_apply(input_batch):
+            self._applied_augmentations.clear()
+            for transform in self._tracked_transforms:
+                self.reset_transform_params(transform)
+
+            output = self._original_apply(input_batch)
+            seen_paths: set[str] = set()
+            for transform in self._tracked_transforms:
+                for path in self.collect_applied_transform_paths(transform):
+                    if (
+                        path in self.configured_paths
+                        and path not in seen_paths
+                    ):
+                        self._applied_augmentations.append(path)
+                        seen_paths.add(path)
+            return output
+
+        self.augmentations.apply = capture_apply
+
+    @staticmethod
+    def load_augmentation_paths(aug_config_path: Path) -> list[str]:
+        with open(aug_config_path) as file:
+            if aug_config_path.suffix.lower() == ".json":
+                config = json.load(file) or []
+            else:
+                config = yaml.safe_load(file) or []
+        return AugmentationsCollector.flatten_config_augmentation_paths(config)
+
+    @staticmethod
+    def flatten_config_augmentation_paths(
+        config: list[dict], parent_path: tuple[str, ...] = ()
+    ) -> list[str]:
+        paths: list[str] = []
+        for item in config:
+            name = item.get("name")
+            if not isinstance(name, str):
+                continue
+
+            current_path = (*parent_path, name)
+            paths.append("/".join(current_path))
+
+            params = item.get("params", {})
+            if not isinstance(params, dict):
+                continue
+
+            nested_transforms = params.get("transforms")
+            if not isinstance(nested_transforms, list):
+                continue
+
+            nested_items = [
+                nested_item
+                for nested_item in nested_transforms
+                if isinstance(nested_item, dict)
+            ]
+            paths.extend(
+                AugmentationsCollector.flatten_config_augmentation_paths(
+                    nested_items, current_path
+                )
+            )
+        return paths
+
+    @staticmethod
+    def get_tracked_transforms(augmentations: AugmentationsLike) -> list[Any]:
+        return [
+            augmentations.batch_transform,
+            AugmentationsCollector.get_wrapped_transform(
+                augmentations.spatial_transform
+            ),
+            AugmentationsCollector.get_wrapped_transform(
+                augmentations.custom_transform
+            ),
+            AugmentationsCollector.get_wrapped_transform(
+                augmentations.pixel_transform
+            ),
+            AugmentationsCollector.get_wrapped_transform(
+                augmentations.resize_transform
+            ),
+        ]
+
+    @staticmethod
+    def get_wrapped_transform(fn: Callable[..., object]) -> Any:
+        closure_vars = pyinspect.getclosurevars(fn)
+        return closure_vars.nonlocals["transform"]
+
+    @staticmethod
+    def reset_transform_params(transform: Any) -> None:
+        if hasattr(transform, "params"):
+            transform.params = {}
+        for child in getattr(transform, "transforms", []):
+            AugmentationsCollector.reset_transform_params(child)
+
+    @staticmethod
+    def collect_applied_transform_paths(
+        transform: Any, parent_path: tuple[str, ...] = ()
+    ) -> list[str]:
+        transform_name = type(transform).__name__
+        child_transforms = getattr(transform, "transforms", None)
+
+        if child_transforms is not None:
+            next_path = (
+                parent_path
+                if transform_name in {"Compose", "BatchCompose"}
+                else (*parent_path, transform_name)
+            )
+            paths: list[str] = []
+            for child in child_transforms:
+                paths.extend(
+                    AugmentationsCollector.collect_applied_transform_paths(
+                        child, next_path
+                    )
+                )
+            return paths
+
+        if transform_name == "Lambda":
+            return []
+
+        params = getattr(transform, "params", {})
+        if not params:
+            return []
+
+        return ["/".join((*parent_path, transform_name))]

--- a/luxonis_ml/data/utils/augmentations_collector.py
+++ b/luxonis_ml/data/utils/augmentations_collector.py
@@ -17,10 +17,14 @@ class AugmentationsLike(Protocol):
 
 
 class AugmentationsCollector:
-    def __init__(self, augmentations: object, aug_config_path: Path):
+    def __init__(
+        self,
+        augmentations: object,
+        aug_config: Path | list[dict[str, Any]],
+    ):
         self.augmentations = cast(AugmentationsLike, augmentations)
         self.configured_paths = set(
-            self.load_augmentation_paths(aug_config_path)
+            self.load_augmentation_paths(aug_config)
         )
         self._applied_augmentations: list[str] = []
         self._original_apply = self.augmentations.apply
@@ -53,12 +57,17 @@ class AugmentationsCollector:
         self.augmentations.apply = capture_apply
 
     @staticmethod
-    def load_augmentation_paths(aug_config_path: Path) -> list[str]:
-        with open(aug_config_path) as file:
-            if aug_config_path.suffix.lower() == ".json":
-                config = json.load(file) or []
-            else:
-                config = yaml.safe_load(file) or []
+    def load_augmentation_paths(
+        aug_config: Path | list[dict[str, Any]],
+    ) -> list[str]:
+        if isinstance(aug_config, Path):
+            with open(aug_config) as file:
+                if aug_config.suffix.lower() == ".json":
+                    config = json.load(file) or []
+                else:
+                    config = yaml.safe_load(file) or []
+        else:
+            config = aug_config
         return AugmentationsCollector.flatten_config_augmentation_paths(config)
 
     @staticmethod

--- a/luxonis_ml/data/utils/augmentations_collector.py
+++ b/luxonis_ml/data/utils/augmentations_collector.py
@@ -1,4 +1,5 @@
 import inspect as pyinspect
+import inspect as pyinspect
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -73,6 +74,10 @@ class AugmentationsCollector:
 
             current_path = (*parent_path, name)
             paths.append("/".join(current_path))
+            if AugmentationsCollector._is_probabilistic_resize_transform(
+                item
+            ):
+                paths.append("/".join((*parent_path, "OneOf", name)))
 
             params = item.get("params", {})
             if not isinstance(params, dict):
@@ -93,6 +98,23 @@ class AugmentationsCollector:
                 )
             )
         return paths
+
+    @staticmethod
+    def _is_probabilistic_resize_transform(item: dict[str, Any]) -> bool:
+        if not item.get("use_for_resizing", False):
+            return False
+
+        params = item.get("params", {})
+        if not isinstance(params, dict):
+            return False
+
+        probability = params.get("p", 1.0)
+        if isinstance(probability, bool) or not isinstance(
+            probability, (int, float)
+        ):
+            return False
+
+        return float(probability) < 1.0
 
     @staticmethod
     def get_tracked_transforms(augmentations: AugmentationsLike) -> list[Any]:

--- a/luxonis_ml/data/utils/augmentations_collector.py
+++ b/luxonis_ml/data/utils/augmentations_collector.py
@@ -33,7 +33,7 @@ class AugmentationsCollector:
         return self._applied_augmentations.copy()
 
     def _instrument(self) -> None:
-        def capture_apply(input_batch):
+        def capture_apply(input_batch: object) -> object:
             self._applied_augmentations.clear()
             for transform in self._tracked_transforms:
                 self.reset_transform_params(transform)

--- a/luxonis_ml/data/utils/visualizations.py
+++ b/luxonis_ml/data/utils/visualizations.py
@@ -392,6 +392,20 @@ def append_text_block(
     return np.vstack((image, footer))
 
 
+def add_augmentation_footer(
+    image: np.ndarray, augmentations: list[str]
+) -> np.ndarray:
+    """Appends the applied augmentations as a footer below the image."""
+    min_dimension = min(image.shape[:2])
+    font_scale = max(0.25, min(1.1, 0.4 * min_dimension / 500))
+    augmentations_text = ", ".join(augmentations) if augmentations else "none"
+    return append_text_block(
+        image,
+        [f"Augmentations: {augmentations_text}"],
+        font_scale=font_scale,
+    )
+
+
 def wrap_text(
     text: str,
     max_width: int,

--- a/tests/test_data/test_augmentations/test_inspect_augmentation_listing.py
+++ b/tests/test_data/test_augmentations/test_inspect_augmentation_listing.py
@@ -100,3 +100,23 @@ def test_flatten_config_augmentation_paths_adds_resize_oneof_alias():
         "AtLeastOneBBoxRandomCrop",
         "OneOf/AtLeastOneBBoxRandomCrop",
     ]
+
+
+def test_load_augmentation_paths_accepts_in_memory_config():
+    config = [
+        {"name": "HorizontalFlip", "params": {"p": 0.5}},
+        {
+            "name": "OneOf",
+            "params": {
+                "transforms": [
+                    {"name": "Blur", "params": {"p": 1.0}},
+                ]
+            },
+        },
+    ]
+
+    assert AugmentationsCollector.load_augmentation_paths(config) == [
+        "HorizontalFlip",
+        "OneOf",
+        "OneOf/Blur",
+    ]

--- a/tests/test_data/test_augmentations/test_inspect_augmentation_listing.py
+++ b/tests/test_data/test_augmentations/test_inspect_augmentation_listing.py
@@ -1,0 +1,80 @@
+from luxonis_ml.data.utils.augmentations_collector import (
+    AugmentationsCollector,
+)
+
+
+def test_collect_applied_transform_paths_collects_nested_paths():
+    rotate = type("Rotate", (), {"params": {"shape": (32, 32, 3)}})()
+    blur = type("Blur", (), {"params": {}})()
+    inner_one_of = type(
+        "OneOf",
+        (),
+        {"transforms": [blur, rotate]},
+    )()
+    horizontal_flip = type(
+        "HorizontalFlip", (), {"params": {"shape": (32, 32, 3)}}
+    )()
+    root_compose = type(
+        "Compose",
+        (),
+        {"transforms": [horizontal_flip, inner_one_of]},
+    )()
+
+    assert AugmentationsCollector.collect_applied_transform_paths(
+        root_compose
+    ) == [
+        "HorizontalFlip",
+        "OneOf/Rotate",
+    ]
+
+
+def test_flatten_config_augmentation_paths_handles_nested_transforms():
+    config = [
+        {"name": "HorizontalFlip", "params": {"p": 0.5}},
+        {
+            "name": "OneOf",
+            "params": {
+                "transforms": [
+                    {"name": "Blur", "params": {"p": 1.0}},
+                    {"name": "Sharpen", "params": {"p": 1.0}},
+                ]
+            },
+        },
+    ]
+
+    assert AugmentationsCollector.flatten_config_augmentation_paths(
+        config
+    ) == [
+        "HorizontalFlip",
+        "OneOf",
+        "OneOf/Blur",
+        "OneOf/Sharpen",
+    ]
+
+
+def test_flatten_config_augmentation_paths_handles_deeply_nested_transforms():
+    config = [
+        {
+            "name": "OneOf",
+            "params": {
+                "transforms": [
+                    {
+                        "name": "OneOf",
+                        "params": {
+                            "transforms": [
+                                {"name": "Rotate", "params": {"p": 1.0}}
+                            ]
+                        },
+                    }
+                ]
+            },
+        }
+    ]
+
+    assert AugmentationsCollector.flatten_config_augmentation_paths(
+        config
+    ) == [
+        "OneOf",
+        "OneOf/OneOf",
+        "OneOf/OneOf/Rotate",
+    ]

--- a/tests/test_data/test_augmentations/test_inspect_augmentation_listing.py
+++ b/tests/test_data/test_augmentations/test_inspect_augmentation_listing.py
@@ -78,3 +78,25 @@ def test_flatten_config_augmentation_paths_handles_deeply_nested_transforms():
         "OneOf/OneOf",
         "OneOf/OneOf/Rotate",
     ]
+
+
+def test_flatten_config_augmentation_paths_adds_resize_oneof_alias():
+    config = [
+        {
+            "name": "AtLeastOneBBoxRandomCrop",
+            "params": {
+                "height": 32,
+                "width": 32,
+                "erosion_factor": 0.0,
+                "p": 0.3,
+            },
+            "use_for_resizing": True,
+        }
+    ]
+
+    assert AugmentationsCollector.flatten_config_augmentation_paths(
+        config
+    ) == [
+        "AtLeastOneBBoxRandomCrop",
+        "OneOf/AtLeastOneBBoxRandomCrop",
+    ]


### PR DESCRIPTION
## Purpose
- Gives clarity on which augmentation in being applied
- Usage: `luxonis_ml data inspect <dataset_name> --aug-config <config.yaml> --list-augmentations`
- Extra text in the footer (not in the image itself)

No augmentations applied:
<img width="936" height="602" alt="show_augs_none" src="https://github.com/user-attachments/assets/bceb66d7-e4af-4a8e-99a2-faa0d6d2227b" />

With nested augmentations the entire trace is shown, separated by `/`
<img width="933" height="599" alt="show_augs_multiple" src="https://github.com/user-attachments/assets/82229c5c-8f8b-4fe3-9a09-07c067d886c4" />
<img width="933" height="598" alt="show_augs_nested" src="https://github.com/user-attachments/assets/6cee29a2-96e5-4bbf-94dc-faf8094f4399" />


A warning is emitted when `--list-augmentations` is set without setting `--aug-config`:
<img width="843" height="28" alt="show_augs_not_passed" src="https://github.com/user-attachments/assets/c27b47d6-ab4a-41fa-a513-99db5cc572cf" />


## Specification


## Dependencies & Potential Impact


## Deployment Plan


## Testing & Validation
