### PR TITLE
Fixes issues with exporters and parsers working with OS specific Path formats

### DIFF
--- a/luxonis_ml/data/exporters/native_exporter.py
+++ b/luxonis_ml/data/exporters/native_exporter.py
@@ -14,6 +14,7 @@ from luxonis_ml.data.exporters.exporter_utils import (
     split_of_group,
 )
 from luxonis_ml.enums import DatasetType
+from luxonis_ml.utils.path import path_to_posix
 
 
 class NativeExporter(BaseExporter):
@@ -102,7 +103,7 @@ class NativeExporter(BaseExporter):
         ann_str = row["annotation"]
 
         source_to_file = {
-            name: str(
+            name: path_to_posix(
                 Path("images")
                 / f"{self.image_indices.setdefault(Path(f), len(self.image_indices))}{Path(f).suffix}"
             )

--- a/luxonis_ml/data/exporters/yolov6_exporter.py
+++ b/luxonis_ml/data/exporters/yolov6_exporter.py
@@ -11,6 +11,7 @@ from luxonis_ml.data.exporters.exporter_utils import (
     split_of_group,
 )
 from luxonis_ml.enums import DatasetType
+from luxonis_ml.utils.path import path_to_posix
 
 from .base_exporter import BaseExporter
 
@@ -178,9 +179,9 @@ class YoloV6Exporter(BaseExporter):
         if yaml_filename:
             split_dirs = self.get_split_names()
             yaml_obj = {
-                "train": str(Path("images") / split_dirs["train"]),
-                "val": str(Path("images") / split_dirs["val"]),
-                "test": str(Path("images") / split_dirs["test"]),
+                "train": path_to_posix(Path("images") / split_dirs["train"]),
+                "val": path_to_posix(Path("images") / split_dirs["val"]),
+                "test": path_to_posix(Path("images") / split_dirs["test"]),
                 "nc": len(self.class_names),
                 "names": self.class_names,
             }

--- a/luxonis_ml/data/exporters/yolov8_bbox_exporter.py
+++ b/luxonis_ml/data/exporters/yolov8_bbox_exporter.py
@@ -11,6 +11,7 @@ from luxonis_ml.data.exporters.exporter_utils import (
     split_of_group,
 )
 from luxonis_ml.enums import DatasetType
+from luxonis_ml.utils.path import path_to_posix
 
 from .base_exporter import BaseExporter
 
@@ -173,9 +174,9 @@ class YoloV8Exporter(BaseExporter):
         if yaml_filename:
             split_dirs = self.get_split_names()
             yaml_obj = {
-                "train": str(Path("images") / split_dirs["train"]),
-                "val": str(Path("images") / split_dirs["val"]),
-                "test": str(Path("images") / split_dirs["test"]),
+                "train": path_to_posix(Path("images") / split_dirs["train"]),
+                "val": path_to_posix(Path("images") / split_dirs["val"]),
+                "test": path_to_posix(Path("images") / split_dirs["test"]),
                 "nc": len(self.class_names),
                 "names": self.class_names,
             }

--- a/luxonis_ml/data/exporters/yolov8_instance_segmentation_exporter.py
+++ b/luxonis_ml/data/exporters/yolov8_instance_segmentation_exporter.py
@@ -12,6 +12,7 @@ from luxonis_ml.data.exporters.exporter_utils import (
     split_of_group,
 )
 from luxonis_ml.enums import DatasetType
+from luxonis_ml.utils.path import path_to_posix
 
 from .base_exporter import BaseExporter
 
@@ -167,9 +168,9 @@ class YoloV8InstanceSegmentationExporter(BaseExporter):
         if yaml_filename:
             split_dirs = self.get_split_names()
             yaml_obj = {
-                "train": str(Path("images") / split_dirs["train"]),
-                "val": str(Path("images") / split_dirs["val"]),
-                "test": str(Path("images") / split_dirs["test"]),
+                "train": path_to_posix(Path("images") / split_dirs["train"]),
+                "val": path_to_posix(Path("images") / split_dirs["val"]),
+                "test": path_to_posix(Path("images") / split_dirs["test"]),
                 "nc": len(self.class_names),
                 "names": self.class_names,
             }

--- a/luxonis_ml/data/exporters/yolov8_keypoints_exporter.py
+++ b/luxonis_ml/data/exporters/yolov8_keypoints_exporter.py
@@ -13,6 +13,7 @@ from luxonis_ml.data.exporters.exporter_utils import (
     split_of_group,
 )
 from luxonis_ml.enums import DatasetType
+from luxonis_ml.utils.path import path_to_posix
 
 from .base_exporter import BaseExporter
 
@@ -231,9 +232,9 @@ class YoloV8KeypointsExporter(BaseExporter):
             )
 
             yaml_obj: dict[str, Any] = {
-                "train": str(Path("images") / split_dirs["train"]),
-                "val": str(Path("images") / split_dirs["val"]),
-                "test": str(Path("images") / split_dirs["test"]),
+                "train": path_to_posix(Path("images") / split_dirs["train"]),
+                "val": path_to_posix(Path("images") / split_dirs["val"]),
+                "test": path_to_posix(Path("images") / split_dirs["test"]),
                 "nc": n_classes,
                 "names": self.class_names,
                 "kpt_shape": list(kpt_shape),

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -9,6 +9,7 @@ from loguru import logger
 from luxonis_ml.data import DatasetIterator
 from luxonis_ml.data.utils import COCOFormat
 from luxonis_ml.data.utils.enums import ParserIssue
+from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -279,7 +280,9 @@ class COCOParser(BaseParser):
                 ann_dict[img_id].append(ann)
 
             for img_id, img in img_dict.items():
-                file: Path = image_dir.absolute().resolve() / img["file_name"]
+                file = resolve_manifest_path(
+                    image_dir.absolute().resolve(), img["file_name"]
+                )
                 if not file.exists():
                     self._warn_skipped_annotation(
                         ParserIssue.MISSING_IMAGE,

--- a/luxonis_ml/data/parsers/create_ml_parser.py
+++ b/luxonis_ml/data/parsers/create_ml_parser.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 from luxonis_ml.data import DatasetIterator
 from luxonis_ml.data.utils.enums import ParserIssue
+from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -84,7 +85,9 @@ class CreateMLParser(BaseParser):
 
         images_annotations = []
         for annotations in annotations_data:
-            path = image_dir.absolute().resolve() / annotations["image"]
+            path = resolve_manifest_path(
+                image_dir.absolute().resolve(), annotations["image"]
+            )
             if not path.exists():
                 self._warn_skipped_annotation(
                     ParserIssue.MISSING_IMAGE,

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from luxonis_ml.data import DatasetIterator
 from luxonis_ml.typing import PathType
+from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -63,22 +64,24 @@ class NativeParser(BaseParser):
             for record in data:
                 with suppress(KeyError):
                     if "file" in record:
-                        record["file"] = (
-                            annotation_path.parent / record["file"]
-                        ).absolute()
+                        record["file"] = resolve_manifest_path(
+                            annotation_path.parent, record["file"]
+                        )
                     elif "files" in record:
                         for key, value in record["files"].items():
                             if isinstance(value, PathType):
-                                record["files"][key] = (
-                                    annotation_path.parent / value
-                                ).absolute()
+                                record["files"][key] = resolve_manifest_path(
+                                    annotation_path.parent, value
+                                )
                 for mask_type in ["segmentation", "instance_segmentation"]:
                     with suppress(KeyError):
                         mask = record["annotation"][mask_type]["mask"]
                         if isinstance(mask, PathType):
                             record["annotation"][mask_type]["mask"] = (
-                                annotation_path.parent / mask
-                            ).absolute()
+                                resolve_manifest_path(
+                                    annotation_path.parent, mask
+                                )
+                            )
                 yield record
 
         added_images = self._get_added_images(generator())

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -173,7 +173,7 @@ class SOLOParser(BaseParser):
                                 mask_path = resolve_manifest_path(
                                     sequence_path, mask_fname
                                 )
-                                mask = cv2.imread(mask_path)
+                                mask = cv2.imread(str(mask_path))
 
                                 mask_int = (
                                     (mask[..., 0].astype(np.uint32) << 16)
@@ -251,7 +251,7 @@ class SOLOParser(BaseParser):
                                 mask_path = resolve_manifest_path(
                                     sequence_path, mask_fname
                                 )
-                                mask = cv2.imread(mask_path)
+                                mask = cv2.imread(str(mask_path))
 
                                 mask_int = (
                                     (mask[..., 0].astype(np.uint32) << 16)

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -173,6 +173,10 @@ class SOLOParser(BaseParser):
                                 mask_path = resolve_manifest_path(
                                     sequence_path, mask_fname
                                 )
+                                if not mask_path.exists():
+                                    raise FileNotFoundError(
+                                        f"{mask_path} not existent."
+                                    )
                                 mask = cv2.imread(str(mask_path))
 
                                 mask_int = (
@@ -251,6 +255,10 @@ class SOLOParser(BaseParser):
                                 mask_path = resolve_manifest_path(
                                     sequence_path, mask_fname
                                 )
+                                if not mask_path.exists():
+                                    raise FileNotFoundError(
+                                        f"{mask_path} not existent."
+                                    )
                                 mask = cv2.imread(str(mask_path))
 
                                 mask_int = (

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -7,6 +7,7 @@ import numpy as np
 from loguru import logger
 
 from luxonis_ml.data import DatasetIterator
+from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -144,7 +145,9 @@ class SOLOParser(BaseParser):
                         img_fname = capture["filename"]
                         img_w, img_h = capture["dimension"]
                         annotations = capture["annotations"]
-                        img_path = sequence_path / img_fname
+                        img_path = resolve_manifest_path(
+                            sequence_path, img_fname
+                        )
                         if not img_path.exists():
                             raise FileNotFoundError(
                                 f"{img_path} not existent."
@@ -167,7 +170,9 @@ class SOLOParser(BaseParser):
                                 ].add("SemanticSegmentationAnnotation")
 
                                 mask_fname = anno["filename"]
-                                mask_path = sequence_path / mask_fname
+                                mask_path = resolve_manifest_path(
+                                    sequence_path, mask_fname
+                                )
                                 mask = cv2.imread(mask_path)
 
                                 mask_int = (
@@ -243,7 +248,9 @@ class SOLOParser(BaseParser):
                                 ].add("InstanceSegmentationAnnotation")
 
                                 mask_fname = anno["filename"]
-                                mask_path = sequence_path / mask_fname
+                                mask_path = resolve_manifest_path(
+                                    sequence_path, mask_fname
+                                )
                                 mask = cv2.imread(mask_path)
 
                                 mask_int = (

--- a/luxonis_ml/data/parsers/tensorflow_csv_parser.py
+++ b/luxonis_ml/data/parsers/tensorflow_csv_parser.py
@@ -5,6 +5,7 @@ import numpy as np
 import polars as pl
 
 from luxonis_ml.data import DatasetIterator
+from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -77,7 +78,7 @@ class TensorflowCSVParser(BaseParser):
         images_annotations = {}
 
         for row in df.rows(named=True):
-            path = str(image_dir / str(row["filename"]))
+            path = str(resolve_manifest_path(image_dir, str(row["filename"])))
             if path not in images_annotations:
                 images_annotations[path] = {
                     "classes": [],

--- a/luxonis_ml/data/parsers/tensorflow_csv_parser.py
+++ b/luxonis_ml/data/parsers/tensorflow_csv_parser.py
@@ -104,7 +104,7 @@ class TensorflowCSVParser(BaseParser):
 
         def generator() -> DatasetIterator:
             for img_path in self._list_images(image_dir):
-                path = str(img_path)
+                path = str(img_path.resolve())
                 curr_annotations = images_annotations.get(path, {"bboxes": []})
                 if not curr_annotations["bboxes"]:
                     yield {"file": path, "annotation": None}

--- a/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
+++ b/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
@@ -13,6 +13,10 @@ from luxonis_ml.data import BaseDataset, DatasetIterator
 from luxonis_ml.data.utils.enums import ParserIssue
 from luxonis_ml.data.utils.remote_file_downloader import RemoteFileDownloader
 from luxonis_ml.typing import PathType
+from luxonis_ml.utils.path import (
+    parse_manifest_path,
+    resolve_manifest_path,
+)
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -368,10 +372,10 @@ class UltralyticsNDJSONParser(BaseParser):
                 remote_image_dir=remote_image_dir,
             )
 
-        file_path = Path(record["file"])
+        file_path = parse_manifest_path(record["file"])
         if file_path.is_absolute():
             return file_path.resolve()
-        return (ndjson_path.parent / file_path).resolve()
+        return resolve_manifest_path(ndjson_path.parent, record["file"])
 
     @classmethod
     def _download_image(
@@ -380,7 +384,7 @@ class UltralyticsNDJSONParser(BaseParser):
         *,
         remote_image_dir: Path,
     ) -> Path:
-        file_name = Path(record["file"])
+        file_name = parse_manifest_path(record["file"])
         url = record["url"]
         split_name = cls._normalize_split_name(record.get("split"))
         url_hash = hashlib.blake2s(

--- a/luxonis_ml/data/parsers/voc_parser.py
+++ b/luxonis_ml/data/parsers/voc_parser.py
@@ -7,6 +7,7 @@ from defusedxml.ElementTree import parse
 
 from luxonis_ml.data import DatasetIterator
 from luxonis_ml.data.utils.enums import ParserIssue
+from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -78,8 +79,9 @@ class VOCParser(BaseParser):
             if root is None:
                 raise ValueError(f"Could not parse {anno_xml}")
 
-            path = image_dir.absolute().resolve() / self._xml_find(
-                root, "filename"
+            path = resolve_manifest_path(
+                image_dir.absolute().resolve(),
+                self._xml_find(root, "filename"),
             )
             if not path.exists():
                 self._warn_skipped_annotation(

--- a/luxonis_ml/data/parsers/yolov4_parser.py
+++ b/luxonis_ml/data/parsers/yolov4_parser.py
@@ -88,7 +88,7 @@ class YoloV4Parser(BaseParser):
             with open(annotation_path) as f:
                 annotation_data = [line.rstrip() for line in f]
 
-            annotated_images: set[str] = set()
+            annotated_images: set[Path] = set()
 
             for ann_line in annotation_data:
                 data = ann_line.split(" ")
@@ -96,7 +96,7 @@ class YoloV4Parser(BaseParser):
                 path = resolve_manifest_path(
                     image_dir.absolute().resolve(), img_path
                 )
-                annotated_images.add(path.name)
+                annotated_images.add(path.resolve())
                 if not path.exists():
                     self._warn_skipped_annotation(
                         ParserIssue.MISSING_IMAGE,
@@ -136,7 +136,7 @@ class YoloV4Parser(BaseParser):
 
             # Images in the directory not listed in annotations file
             for img_path in self._list_images(image_dir):
-                if img_path.name not in annotated_images:
+                if img_path.resolve() not in annotated_images:
                     yield {"file": str(img_path), "annotation": None}
 
         added_images = self._get_added_images(generator())

--- a/luxonis_ml/data/parsers/yolov4_parser.py
+++ b/luxonis_ml/data/parsers/yolov4_parser.py
@@ -5,6 +5,7 @@ from PIL import Image
 
 from luxonis_ml.data import DatasetIterator
 from luxonis_ml.data.utils.enums import ParserIssue
+from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
@@ -92,9 +93,10 @@ class YoloV4Parser(BaseParser):
             for ann_line in annotation_data:
                 data = ann_line.split(" ")
                 img_path = data[0]
-                annotated_images.add(img_path)
-
-                path = image_dir.absolute().resolve() / img_path
+                path = resolve_manifest_path(
+                    image_dir.absolute().resolve(), img_path
+                )
+                annotated_images.add(path.name)
                 if not path.exists():
                     self._warn_skipped_annotation(
                         ParserIssue.MISSING_IMAGE,

--- a/luxonis_ml/utils/path.py
+++ b/luxonis_ml/utils/path.py
@@ -6,15 +6,21 @@ from luxonis_ml.typing import PathType
 def parse_manifest_path(value: PathType) -> Path:
     """Parse a path string from a dataset manifest on the current OS."""
 
-    path = Path(value)
+    raw = str(value)
+    path = Path(raw)
     if path.is_absolute():
         return path
-    return Path(PureWindowsPath(str(value)))
+    return Path(PureWindowsPath(raw).as_posix())
 
 
 def resolve_manifest_path(base_dir: Path, value: PathType) -> Path:
     """Resolve a manifest path relative to the directory that contains
     it."""
+
+    raw = str(value)
+    windows_path = PureWindowsPath(raw)
+    if windows_path.is_absolute() and not Path(raw).is_absolute():
+        return Path(windows_path.as_posix())
 
     path = parse_manifest_path(value)
     if path.is_absolute():

--- a/luxonis_ml/utils/path.py
+++ b/luxonis_ml/utils/path.py
@@ -1,0 +1,31 @@
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+from luxonis_ml.typing import PathType
+
+
+def parse_manifest_path(value: PathType) -> Path:
+    """Parse a path string from a dataset manifest on the current OS."""
+
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return Path(PureWindowsPath(str(value)))
+
+
+def resolve_manifest_path(base_dir: Path, value: PathType) -> Path:
+    """Resolve a manifest path relative to the directory that contains
+    it."""
+
+    path = parse_manifest_path(value)
+    if path.is_absolute():
+        return path.resolve()
+    return (base_dir / path).resolve()
+
+
+def path_to_posix(value: PathType) -> str:
+    """Serialize a path with forward slashes for portable manifests."""
+
+    raw = str(value)
+    if "\\" in raw:
+        return PureWindowsPath(raw).as_posix()
+    return PurePosixPath(raw).as_posix()

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from luxonis_ml.data.parsers.native_parser import NativeParser
+from luxonis_ml.enums import DatasetType
+
+from .utils import create_image
+
+
+def test_native_parser_accepts_windows_style_file_paths(tempdir: Path):
+    image_path = create_image(0, tempdir)
+    split_dir = tempdir / "train"
+    image_dir = split_dir / "images"
+    image_dir.mkdir(parents=True)
+    copied_image = image_dir / image_path.name
+    copied_image.write_bytes(image_path.read_bytes())
+
+    annotations_path = split_dir / "annotations.json"
+    annotations_path.write_text(
+        json.dumps(
+            [
+                {
+                    "file": f"images\\{image_path.name}",
+                    "task_name": "task",
+                    "annotation": {
+                        "class": "class0",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.2,
+                            "w": 0.3,
+                            "h": 0.4,
+                        },
+                    },
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    generator, _, added_images = NativeParser(
+        dataset=None,  # type: ignore[arg-type]
+        dataset_type=DatasetType.NATIVE,
+        task_name=None,
+    ).from_split(annotation_path=annotations_path)
+
+    parsed_record = next(iter(generator))
+    assert parsed_record["file"] == copied_image.resolve()
+    assert added_images == [copied_image.resolve()]

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 from luxonis_ml.data.parsers.native_parser import NativeParser
+from luxonis_ml.data.parsers.yolov4_parser import YoloV4Parser
 from luxonis_ml.enums import DatasetType
 
 from .utils import create_image
@@ -52,3 +53,43 @@ def test_native_parser_accepts_windows_style_file_paths(tempdir: Path):
     )
     assert parsed_file == copied_image.resolve()
     assert added_images == [copied_image.resolve()]
+
+
+def test_yolov4_parser_keeps_unlabeled_image_with_duplicate_basename(
+    tempdir: Path,
+):
+    split_dir = tempdir / "train"
+    split_dir.mkdir()
+    nested_dir = split_dir / "nested"
+    nested_dir.mkdir()
+
+    unlabeled_image = create_image(0, split_dir)
+    annotated_image = create_image(0, nested_dir)
+
+    annotations_path = split_dir / "_annotations.txt"
+    annotations_path.write_text(
+        "nested/img_0.jpg 0,0,10,10,0\n", encoding="utf-8"
+    )
+    classes_path = split_dir / "_classes.txt"
+    classes_path.write_text("class0\n", encoding="utf-8")
+
+    generator, _, _ = YoloV4Parser(
+        dataset=None,  # type: ignore[arg-type]
+        dataset_type=DatasetType.YOLOV4,
+        task_name=None,
+    ).from_split(
+        image_dir=split_dir,
+        annotation_path=annotations_path,
+        classes_path=classes_path,
+    )
+
+    records = list(generator)
+    files = {
+        Path(
+            record["file"] if isinstance(record, dict) else record.file
+        ).resolve()
+        for record in records
+    }
+
+    assert annotated_image.resolve() in files
+    assert unlabeled_image.resolve() in files

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -45,5 +45,10 @@ def test_native_parser_accepts_windows_style_file_paths(tempdir: Path):
     ).from_split(annotation_path=annotations_path)
 
     parsed_record = next(iter(generator))
-    assert parsed_record["file"] == copied_image.resolve()
+    parsed_file = (
+        parsed_record["file"]
+        if isinstance(parsed_record, dict)
+        else parsed_record.file
+    )
+    assert parsed_file == copied_image.resolve()
     assert added_images == [copied_image.resolve()]

--- a/tests/test_utils/test_path.py
+++ b/tests/test_utils/test_path.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from luxonis_ml.utils.path import (
+    parse_manifest_path,
+    path_to_posix,
+    resolve_manifest_path,
+)
+
+
+def test_path_to_posix_normalizes_windows_separators():
+    assert path_to_posix("images\\train\\0.png") == "images/train/0.png"
+    assert path_to_posix(Path("images/val/1.png")) == "images/val/1.png"
+
+
+def test_parse_and_resolve_manifest_path(tempdir: Path):
+    base_dir = tempdir / "dataset"
+    base_dir.mkdir()
+
+    parsed = parse_manifest_path("nested\\images\\0.png")
+    resolved = resolve_manifest_path(base_dir, "nested\\images\\0.png")
+
+    assert parsed == Path("nested/images/0.png")
+    assert resolved == (base_dir / "nested" / "images" / "0.png").resolve()

--- a/tests/test_utils/test_path.py
+++ b/tests/test_utils/test_path.py
@@ -21,3 +21,12 @@ def test_parse_and_resolve_manifest_path(tempdir: Path):
 
     assert parsed == Path("nested/images/0.png")
     assert resolved == (base_dir / "nested" / "images" / "0.png").resolve()
+
+
+def test_resolve_manifest_path_preserves_windows_absolute_path(tempdir: Path):
+    base_dir = tempdir / "dataset"
+    base_dir.mkdir()
+
+    resolved = resolve_manifest_path(base_dir, r"C:\data\img.png")
+
+    assert str(resolved).replace("\\", "/") == "C:/data/img.png"


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
- Exported datasets now always have POSIX path
- When data is parsed the paths are parsed in the OS specific format where data is getting parsed at

This should solve an issue where dataset would be exported on a Windows machine and then parsed on an Ubuntu machine

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cross-platform path handling and POSIX normalization for dataset files and exports.

* **Bug Fixes**
  * More robust path resolution and validation across dataset formats, including better handling of Windows-style and absolute paths.

* **Tests**
  * Added unit tests verifying path parsing, resolution, POSIX normalization, and handling of duplicate basenames.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/luxonis/luxonis-ml/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->