### PR TITLE
CLI: migration to `cyclopts`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
   docs:
     needs: pre-commit
     runs-on: ubuntu-latest
+    if: false
 
     steps:
       - name: Checkout

--- a/luxonis_ml/__main__.py
+++ b/luxonis_ml/__main__.py
@@ -29,8 +29,7 @@ def _register_subapp(module: str, name: str) -> None:
     if not isinstance(subapp, App):
         return
 
-    subapp._name = (name,)
-    app.command(subapp)
+    app.command(subapp, name=name)
 
 
 _register_subapp("luxonis_ml.data.__main__", "data")

--- a/luxonis_ml/__main__.py
+++ b/luxonis_ml/__main__.py
@@ -2,58 +2,43 @@ from importlib.metadata import version
 
 import rich
 import rich.box
-import typer
+from cyclopts import App, Group
 from rich.markup import escape
 from rich.table import Table
 
-app = typer.Typer(
-    name="Luxonis ML CLI",
-    add_completion=True,
-    pretty_exceptions_show_locals=False,
+app = App(
+    name="luxonis_ml",
+    version=lambda: f"LuxonisML: {version('luxonis_ml')}",
+    version_flags=["-v", "--version"],
+    help="MLOps tools for training models for Luxonis devices.",
 )
-
-try:
-    from luxonis_ml.data.__main__ import app as data_app
-
-    app.add_typer(data_app, name="data", help="Dataset utilities.")
-except ImportError:
-    pass
-
-try:
-    from luxonis_ml.utils.__main__ import app as utils_app
-
-    app.add_typer(utils_app, name="fs", help="Filesystem utilities.")
-except ImportError:
-    pass
-
-try:
-    from luxonis_ml.nn_archive.__main__ import app as utils_app
-
-    app.add_typer(utils_app, name="archive", help="NN Archive utilities.")
-except ImportError:
-    pass
+global_group = Group("Global Parameters", sort_key=0)
+app["--help"].group = app["--version"].group = global_group
 
 
-def version_callback(value: bool) -> None:
-    if value:
-        typer.echo(f"LuxonisML: {version('luxonis_ml')}")
-        raise typer.Exit
+app.register_install_completion_command(group=global_group)
 
 
-@app.callback()
-def main(
-    _: bool = typer.Option(
-        None,
-        "--version",
-        callback=version_callback,
-        is_eager=True,
-        help="Show version and exit.",
-    ),
-):
-    return
+def _register_subapp(module: str, name: str) -> None:
+    try:
+        imported = __import__(module, fromlist=["app"])
+        subapp = imported.app
+    except ImportError:
+        return
+
+    if not isinstance(subapp, App):
+        return
+
+    subapp._name = (name,)
+    app.command(subapp)
 
 
-@app.command()
+_register_subapp("luxonis_ml.data.__main__", "data")
+_register_subapp("luxonis_ml.utils.__main__", "fs")
+_register_subapp("luxonis_ml.nn_archive.__main__", "archive")
+
+
+@app.command
 def checkhealth():
     """Check the health of the Luxonis ML library."""
     table = Table(

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -55,8 +55,8 @@ def info(
     """Print information about a dataset.
 
     Args:
-        name (str): Name of the dataset.
-        bucket_storage (BucketStorage): Storage type of the dataset.
+        name: Name of the dataset.
+        bucket_storage: Storage type of the dataset.
     """
     check_exists(name, bucket_storage)
     print_info(LuxonisDataset(name, bucket_storage=bucket_storage))
@@ -79,11 +79,11 @@ def delete(
     """Delete a dataset from local storage, remote storage, or both.
 
     Args:
-        names (str): Name(s) of the dataset to delete.
-        bucket_storage (BucketStorage): Storage type of the dataset.
-        local (bool): If True, delete the dataset from local storage.
-        remote (bool): If True, delete the dataset from remote storage.
-        yes (bool): If True, skip confirmation prompt and delete immediately.
+        names: Name(s) of the dataset to delete.
+        bucket_storage: Storage type of the dataset.
+        local: If True, delete the dataset from local storage.
+        remote: If True, delete the dataset from remote storage.
+        yes: If True, skip confirmation prompt and delete immediately.
     """
     if not local and not remote:
         print(
@@ -146,9 +146,9 @@ def ls(
     """List datasets.
 
     Args:
-        full (bool): If True, show full information about each dataset,
+        full: If True, show full information about each dataset,
             including classes and tasks.
-        bucket_storage (BucketStorage): Storage type of the dataset.
+        bucket_storage: Storage type of the dataset.
     """
     datasets = LuxonisDataset.list_datasets(bucket_storage=bucket_storage)
     table = Table(
@@ -229,23 +229,23 @@ def inspect(
     """Inspect images and annotations in a dataset.
 
     Args:
-        name (str): Name of the dataset to inspect.
-        view (list of str, optional): Which splits of the dataset to inspect.
+        name: Name of the dataset to inspect.
+        view: Which splits of the dataset to inspect.
             If not provided, the "train" split will be inspected by default.
-        aug_config (str, optional): Path to a JSON or YAML config defining
+        aug_config: Path to a JSON or YAML config defining
             augmentations to apply when inspecting the dataset.
             If not provided, no augmentations will be applied.
-        size_multiplier (float, optional): Multiplier for the displayed image size.
-        ignore_aspect_ratio (bool, optional): Do not keep the aspect ratio when
+        size_multiplier: Multiplier for the displayed image size.
+        ignore_aspect_ratio: Do not keep the aspect ratio when
             resizing images.
-        deterministic (bool, optional): Use deterministic augmentation mode.
-        force_update (bool, optional): Force synchronization with remote storage first.
-        blend_all (bool, optional): Draw labels belonging to different tasks on the
+        deterministic: Use deterministic augmentation mode.
+        force_update: Force synchronization with remote storage first.
+        blend_all: Draw labels belonging to different tasks on the
             same image.
-        per_instance (bool, optional): Show each label instance in a separate window.
-        list_augmentations (bool, optional): Show the augmentations applied to each
-            displayed image. Requires --aug-config to be set.
-        bucket_storage (BucketStorage, optional): Storage type of the dataset.
+        per_instance: Show each label instance in a separate window.
+        list_augmentations: Show the augmentations applied to each
+            displayed image. Requires '--aug-config' to be set.
+        bucket_storage: Storage type of the dataset.
     """
     check_exists(name, bucket_storage)
 
@@ -424,19 +424,19 @@ def export(
     """Export a Luxonis dataset to disk.
 
     Args:
-        dataset_name (str): Name of the dataset to export.
-        save_dir (str, optional): Directory where the exported dataset will be
+        name: Name of the dataset to export.
+        save_dir: Directory where the exported dataset will be
             saved. If not provided, a directory with the same name as the
             dataset will be created in the current working directory.
-        dataset_type (DatasetType): Format of the exported dataset.
-        delete_existing (bool): If True, delete any existing directory at
+        dataset_type: Format of the exported dataset.
+        delete_existing: If True, delete any existing directory at
             the save location before exporting.
-        max_partition_size_gb (float, optional): Maximum size of each
+        max_partition_size_gb: Maximum size of each
             partition in GB. If not provided, no partitioning will be done.
-        zip (bool): If True, the exported dataset will be zipped into a
-            single archive. If False, the dataset will be exported as a
+        zip: If ``True``, the exported dataset will be zipped into a
+            single archive. If ``False``, the dataset will be exported as a
             directory with the specified structure.
-        bucket_storage (BucketStorage): Storage type of the dataset.
+        bucket_storage: Storage type of the dataset.
     """
     save_dir = save_dir or name
     if delete_existing and Path(save_dir).exists():
@@ -491,31 +491,30 @@ def parse(
     """Parse a directory with data and create a Luxonis dataset.
 
     Args:
-        dataset (str): Path or URL to the dataset.
-        name (str, optional): Name of the dataset.
+        dataset: Path or URL to the dataset.
+        name: Name of the dataset.
             If not provided, the directory name will be used.
-        dataset_type (DatasetType, optional): Type of the dataset.
+        dataset_type: Type of the dataset.
             If not provided, the parser will attempt to detect it.
-        delete_local (bool): If True, delete any existing local
+        delete_local: If True, delete any existing local
             dataset with the same name before parsing.
-        save_dir (str, optional): If dataset_dir is a remote URL,
+        save_dir: If dataset_dir is a remote URL,
             this is the local directory where the dataset will
             be downloaded before parsing. If not provided,
             the dataset will be downloaded to the current working directory.
-        task_name (str, optional): Task name to use for all records
+        task_name: Task name to use for all records
             parsed from this dataset.
-        split_ratio (str, optional): A string representation of a Python list
+        split_ratio: A string representation of a Python list
             specifying the split ratios for train, val, and test sets.
-            Deprecated in favor of ``--train``,
-            ``--val``, and ``--test`` options.
-        train (float, optional): Ratio or count of records to assign
+            Deprecated in favor of ``--train``, ``--val``, and ``--test``.
+        train: Ratio or count of records to assign
             to the training set. Can be used together with
             ``--val`` and ``--test``. If only some of these options
             are provided, the remaining split(s) receive an equal share
             of the leftover records (only supported for ratios, not counts).
-        val (float, optional): Ratio or count of records to assign
+        val: Ratio or count of records to assign
             to the validation set.
-        test (float, optional): Ratio or count of records to assign
+        test: Ratio or count of records to assign
             to the test set.
     """
     parser = LuxonisParser(
@@ -563,16 +562,16 @@ def health(
     same UUIDs, and files with duplicate annotations.
 
     Args:
-        name (str): Name of the dataset to inspect.
-        view (str, optional): Which split of the dataset to inspect.
+        name: Name of the dataset to inspect.
+        view: Which split of the dataset to inspect.
             If not provided, all splits will be inspected.
-        sample_size (int, optional): Number of annotation rows to sample
+        sample_size: Number of annotation rows to sample
             from the dataset for calculating statistics and plots.
             If not provided, all annotations will be used.
-        save_dir (str, optional): Directory where the generated plots
+        save_dir: Directory where the generated plots
             will be saved. If not provided, the plots will be displayed
             interactively instead of being saved.
-        bucket_storage (BucketStorage): Storage type of the dataset.
+        bucket_storage: Storage type of the dataset.
     """
     check_exists(name, bucket_storage)
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
@@ -726,10 +725,10 @@ def push(
     """Push a local dataset to cloud storage.
 
     Args:
-        name (str): Name of the dataset to push.
-        bucket_storage (BucketStorage): Cloud storage type to push to.
+        name: Name of the dataset to push.
+        bucket_storage: Cloud storage type to push to.
             Cannot be LOCAL.
-        force (bool): If True, push all media files even
+        force: If True, push all media files even
             if they already exist in the target cloud storage.
     """
     check_exists(name, BucketStorage.LOCAL)
@@ -775,10 +774,10 @@ def pull(
     """Pull a remote dataset to local storage.
 
     Args:
-        name (str): Name of the dataset to pull.
-        force (bool): If True, pull all media files even
+        name: Name of the dataset to pull.
+        force: If True, pull all media files even
             if they already exist locally.
-        bucket_storage (BucketStorage): Cloud storage type to pull from.
+        bucket_storage: Cloud storage type to pull from.
             Cannot be LOCAL.
     """
     if bucket_storage == BucketStorage.LOCAL:
@@ -828,13 +827,13 @@ def clone(
     Optionally push it to cloud storage if it is a remote dataset.
 
     Args:
-        name (str): Name of the source dataset to clone.
-        new_name (str): Name of the new cloned dataset.
-        push (bool): If True, upload the newly cloned dataset to cloud storage.
-        bucket_storage (BucketStorage): Storage type of the source dataset.
+        name: Name of the source dataset to clone.
+        new_name: Name of the new cloned dataset.
+        push: If True, upload the newly cloned dataset to cloud storage.
+        bucket_storage: Storage type of the source dataset.
         split: List of split names to clone.
             If not provided, all splits will be cloned.
-        team_id (str, optional): Team ID to use for the new dataset.
+        team_id: Team ID to use for the new dataset.
     """
 
     check_exists(name, bucket_storage)
@@ -881,16 +880,15 @@ def merge(
     """Merge two datasets stored in the same type of bucket.
 
     Args:
-        source_name (str): Name of the source dataset to merge from.
-        target_name (str): Name of the target dataset to merge into.
-        new_name (str, optional): If
-            provided, the name of the new merged dataset.
+        source_name: Name of the source dataset to merge from.
+        target_name: Name of the target dataset to merge into.
+        new_name: If provided, the name of the new merged dataset.
             If not provided, the source dataset will be
             merged into the target dataset in place.
-        splits_to_merge (str, optional): Comma-separated list of split
+        splits_to_merge: Comma-separated list of split
             names to merge. If not provided, all splits will be merged.
-        bucket_storage (BucketStorage): Storage type for both datasets.
-        team_id (str, optional): Team ID to use for the new dataset.
+        bucket_storage: Storage type for both datasets.
+        team_id: Team ID to use for the new dataset.
             If not provided, the team ID of the target dataset will be used.
     """
     check_exists(source_name, bucket_storage)
@@ -955,8 +953,8 @@ def sanitize(
     dataset.
 
     Args:
-        name (str): Name of the dataset to sanitize.
-        bucket_storage (BucketStorage): Storage type of the dataset.
+        name: Name of the dataset to sanitize.
+        bucket_storage: Storage type of the dataset.
     """
     check_exists(name, bucket_storage)
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -814,7 +814,7 @@ def clone(
         Parameter(alias="-p", negative=""),
     ] = True,
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
-    splits: Annotated[
+    split: Annotated[
         list[str] | None,
         Parameter(alias="-s"),
     ] = None,
@@ -832,7 +832,7 @@ def clone(
         new_name (str): Name of the new cloned dataset.
         push (bool): If True, upload the newly cloned dataset to cloud storage.
         bucket_storage (BucketStorage): Storage type of the source dataset.
-        splits (str, optional): List of split names to clone.
+        split: List of split names to clone.
             If not provided, all splits will be cloned.
         team_id (str, optional): Team ID to use for the new dataset.
     """
@@ -851,7 +851,7 @@ def clone(
     dataset.clone(
         new_dataset_name=new_name,
         push_to_cloud=push,
-        splits_to_clone=splits,
+        splits_to_clone=split,
         team_id=team_id,
     )
     print(f"[green]Dataset '{name}' successfully cloned to '{new_name}'.")

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -214,7 +214,7 @@ def inspect(
     ] = False,
     blend_all: Annotated[
         bool,
-        Parameter(alias="-b", negative=""),
+        Parameter(alias="-bl", negative=""),
     ] = False,
     per_instance: Annotated[
         bool,

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -122,7 +122,15 @@ def delete(
             delete_local=local,
             delete_remote=remote,
         )
-        dataset.delete_dataset(delete_local=local)
+        if not local and not remote:
+            print(
+                "[red]No valid deletion target remains for this dataset.[/red]"
+            )
+            raise SystemExit(1)
+        dataset.delete_dataset(
+            delete_local=local,
+            delete_remote=remote,
+        )
         print(f"Dataset '{name}' deleted from {storage} storage.")
 
 
@@ -782,7 +790,7 @@ def pull(
         print(
             f"[red]Dataset '{name}' does not exist in {bucket_storage.value} storage."
         )
-        raise SystemExit
+        raise SystemExit(1)
 
     print(f"Pulling dataset '{name}' from {bucket_storage.value} storage...")
 

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -230,27 +230,31 @@ def inspect(
 
     Args:
         name (str): Name of the dataset to inspect.
-        view (list[str], optional): Which splits of the dataset to inspect.
+        view (list of str, optional): Which splits of the dataset to inspect.
             If not provided, the "train" split will be inspected by default.
         aug_config (str, optional): Path to a JSON or YAML config defining
             augmentations to apply when inspecting the dataset.
             If not provided, no augmentations will be applied.
-        size_multiplier (float): Multiplier for the displayed image size.
-        ignore_aspect_ratio (bool): Do not keep the aspect ratio when
+        size_multiplier (float, optional): Multiplier for the displayed image size.
+        ignore_aspect_ratio (bool, optional): Do not keep the aspect ratio when
             resizing images.
-        deterministic (bool): Use deterministic augmentation mode.
-        force_update (bool): Force synchronization with remote storage first.
-        blend_all (bool): Draw labels belonging to different tasks on the
+        deterministic (bool, optional): Use deterministic augmentation mode.
+        force_update (bool, optional): Force synchronization with remote storage first.
+        blend_all (bool, optional): Draw labels belonging to different tasks on the
             same image.
-        per_instance (bool): Show each label instance in a separate window.
-        list_augmentations (bool): Show the augmentations applied to each
+        per_instance (bool, optional): Show each label instance in a separate window.
+        list_augmentations (bool, optional): Show the augmentations applied to each
             displayed image. Requires --aug-config to be set.
-        bucket_storage (BucketStorage): Storage type of the dataset.
+        bucket_storage (BucketStorage, optional): Storage type of the dataset.
     """
     check_exists(name, bucket_storage)
 
     view = view or ["train"]
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
+
+    if len(dataset) == 0:
+        raise ValueError(f"Dataset '{name}' is empty.")
+
     loader = LuxonisLoader(
         dataset,
         view=view,
@@ -291,9 +295,6 @@ def inspect(
             get_applied_augmentations = list
     else:
         get_applied_augmentations = list
-
-    if len(dataset) == 0:
-        raise ValueError(f"Dataset '{name}' is empty.")
 
     classes = dataset.get_classes()
     categorical_encodings = dataset.get_categorical_encodings()

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -6,7 +6,7 @@ import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import rich.box
-from cyclopts import App, Parameter
+from cyclopts import App, Parameter, validators
 from loguru import logger
 from rich import print
 from rich.console import Console
@@ -42,7 +42,6 @@ from luxonis_ml.data.utils.visualizations import (
 from luxonis_ml.enums import DatasetType
 
 app = App(help="Dataset utilities.")
-
 
 
 BucketStorageT: TypeAlias = Annotated[BucketStorage, Parameter(alias="-b")]

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -1,12 +1,12 @@
 import shutil
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, TypeAlias
 
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import rich.box
-import typer
+from cyclopts import App, Parameter
 from loguru import logger
 from rich import print
 from rich.console import Console
@@ -41,101 +41,110 @@ from luxonis_ml.data.utils.visualizations import (
 )
 from luxonis_ml.enums import DatasetType
 
-app = typer.Typer()
-
-DatasetNameArgument = Annotated[
-    str,
-    typer.Argument(
-        ...,
-        help="Name of the dataset.",
-        autocompletion=complete_dataset_name,
-        show_default=False,
-    ),
-]
-
-bucket_option = typer.Option(
-    "local",
-    "--bucket-storage",
-    "-b",
-    help="Storage type for the dataset.",
-)
+app = App(help="Dataset utilities.")
 
 
-@app.command()
+
+BucketStorageT: TypeAlias = Annotated[BucketStorage, Parameter(alias="-b")]
+DatasetT: TypeAlias = Annotated[str, complete_dataset_name]
+
+
+@app.command
 def info(
-    name: DatasetNameArgument,
-    bucket_storage: BucketStorage = bucket_option,
+    name: DatasetT,
+    *,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
-    """Prints information about a dataset."""
+    """Print information about a dataset.
+
+    Args:
+        name (str): Name of the dataset.
+        bucket_storage (BucketStorage): Storage type of the dataset.
+    """
     check_exists(name, bucket_storage)
     print_info(LuxonisDataset(name, bucket_storage=bucket_storage))
 
 
-@app.command()
+@app.command(alias=["rm", "remove"])
 def delete(
-    name: DatasetNameArgument,
-    bucket_storage: BucketStorage = bucket_option,
-    local: bool = typer.Option(
-        False,
-        "--local/--no-local",
-        help="Delete the dataset from local storage.",
-    ),
-    remote: bool = typer.Option(
-        False,
-        "--remote/--no-remote",
-        help="Delete the dataset from remote storage.",
-    ),
+    *names: DatasetT,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
+    local: Annotated[
+        bool,
+        Parameter(alias="-l", negative=""),
+    ] = False,
+    remote: Annotated[
+        bool,
+        Parameter(alias="-r", negative=""),
+    ] = False,
+    yes: Annotated[bool, Parameter(alias="-y", negative="")] = False,
 ):
-    """Deletes a dataset from local storage or remote storage (or both),
-    based on which options are passed."""
-    check_exists(name, bucket_storage)
+    """Delete a dataset from local storage, remote storage, or both.
 
-    if bucket_storage is BucketStorage.LOCAL and remote:
+    Args:
+        names (str): Name(s) of the dataset to delete.
+        bucket_storage (BucketStorage): Storage type of the dataset.
+        local (bool): If True, delete the dataset from local storage.
+        remote (bool): If True, delete the dataset from remote storage.
+        yes (bool): If True, skip confirmation prompt and delete immediately.
+    """
+    if not local and not remote:
         print(
-            "[yellow]Warning: You specified remote deletion, but the bucket is local. "
-            "Remote deletion will not be performed.[/yellow]"
+            "[red]No deletion target specified (local or remote). "
+            "Nothing to delete.[/red]"
         )
-        remote = False
+        raise SystemExit(1)
 
-    where = " and ".join(
-        filter(None, ["local" if local else "", "remote" if remote else ""])
-    )
+    for name in names:
+        check_exists(name, bucket_storage)
 
-    if not where:
-        print(
-            "[red]No deletion target specified (local or remote). Nothing to delete.[/red]"
+        if bucket_storage is BucketStorage.LOCAL and remote:
+            print(
+                "[yellow]Warning: You specified remote deletion, "
+                "but the bucket is local. "
+                "Remote deletion will not be performed.[/yellow]"
+            )
+            remote = False
+
+        storage = (
+            "local and remote"
+            if local and remote
+            else "local"
+            if local
+            else "remote"
         )
-        raise typer.Exit(1)
+        if not yes and not Confirm.ask(
+            f"Delete dataset '{name}' with specified bucket "
+            f"'{bucket_storage}' from {storage} storage?"
+        ):
+            continue
 
-    if not Confirm.ask(
-        f"Delete dataset '{name}' with specified bucket '{bucket_storage}' from {where} storage?"
-    ):
-        raise typer.Exit
-
-    dataset = LuxonisDataset(
-        name,
-        bucket_storage=bucket_storage,
-        delete_local=local,
-        delete_remote=remote,
-    )
-    dataset.delete_dataset(delete_local=local)
-
-    print(
-        f"Dataset '{name}' deleted from: "
-        f"{'local ' if local else ''}"
-        f"{'remote ' if remote else ''}"
-        f"storage."
-    )
+        dataset = LuxonisDataset(
+            name,
+            bucket_storage=bucket_storage,
+            delete_local=local,
+            delete_remote=remote,
+        )
+        dataset.delete_dataset(delete_local=local)
+        print(f"Dataset '{name}' deleted from {storage} storage.")
 
 
-@app.command()
+@app.command
 def ls(
-    full: bool = typer.Option(
-        False, "--full", "-f", help="Show full information."
-    ),
-    bucket_storage: BucketStorage = bucket_option,
+    *,
+    full: Annotated[
+        bool,
+        Parameter(alias="-f"),
+    ] = False,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
-    """Lists all datasets."""
+    """List datasets.
+
+    Args:
+        full (bool): If True, show full information about each dataset,
+            including classes and tasks.
+        bucket_storage (BucketStorage): Storage type of the dataset.
+    """
     datasets = LuxonisDataset.list_datasets(bucket_storage=bucket_storage)
     table = Table(
         title="Datasets" + (" - Full Table" if full else ""),
@@ -168,120 +177,71 @@ def ls(
     console.print(table)
 
 
-@app.command()
+@app.command
 def inspect(
-    name: DatasetNameArgument,
-    view: Annotated[
-        list[str] | None,
-        typer.Option(
-            ...,
-            "--view",
-            "-v",
-            help="Which splits of the dataset to inspect.",
-            case_sensitive=False,
-            show_default=False,
-        ),
-    ] = None,
+    name: DatasetT,
+    *,
+    view: Annotated[list[str] | None, Parameter(alias="-v")] = None,
     aug_config: Annotated[
-        str | None,
-        typer.Option(
-            ...,
-            "--aug-config",
-            "-a",
-            help="Path to a config defining augmentations. "
-            "This can be either a json or a yaml file.",
-            metavar="PATH",
-            show_default=False,
+        Path | None,
+        Parameter(
+            alias="-a",
+            validator=validators.Path(
+                exists=True, ext={".json", ".yaml", ".yml"}
+            ),
         ),
     ] = None,
     size_multiplier: Annotated[
         float,
-        typer.Option(
-            ...,
-            "--size-multiplier",
-            "-s",
-            help=(
-                "Multiplier for the image size. "
-                "By default the images are shown in their original size."
-            ),
-            show_default=False,
-        ),
+        Parameter(alias="-s"),
     ] = 1.0,
     ignore_aspect_ratio: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--ignore-aspect-ratio",
-            "-i",
-            help="Don't keep the aspect ratio when resizing images.",
-        ),
+        Parameter(alias="-i", negative=""),
     ] = False,
     deterministic: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--deterministic",
-            "-d",
-            help="Deterministic mode. Useful for debugging.",
-        ),
+        Parameter(alias="-d", negative=""),
     ] = False,
     force_update: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--force-update",
-            "-f",
-            help="Force synchronization of the dataset with the "
-            "remote storage. Only relevant for remote datasets.",
-        ),
+        Parameter(alias="-f", negative=""),
     ] = False,
     blend_all: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--blend-all",
-            "-b",
-            help="Whether to draw labels belonging "
-            "to different tasks on the same image. "
-            "Doesn't apply to semantic segmentations.",
-        ),
+        Parameter(alias="-b", negative=""),
     ] = False,
     per_instance: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--per-instance",
-            "-pi",
-            help="Show each label instance in a separate window.",
-        ),
+        Parameter(alias="-pi", negative=""),
     ] = False,
     list_augmentations: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--list-augmentations",
-            help=(
-                "Show the augmentations applied to each displayed image "
-                "in the footer. Requires --aug-config."
-            ),
-        ),
+        Parameter(negative=""),
     ] = False,
-    bucket_storage: BucketStorage = bucket_option,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
-    """Inspects images and annotations in a dataset."""
-    if aug_config is not None:
-        aug_config_path = Path(aug_config)
-        if aug_config_path.suffix.lower() not in {".yaml", ".yml", ".json"}:
-            raise typer.BadParameter(
-                "--aug-config must point to an augmentation YAML or JSON file.",
-                param_hint="--aug-config",
-            )
-        if not aug_config_path.is_file():
-            raise typer.BadParameter(
-                f"Augmentation config '{aug_config}' does not exist.",
-                param_hint="--aug-config",
-            )
+    """Inspect images and annotations in a dataset.
 
+    Args:
+        name (str): Name of the dataset to inspect.
+        view (list[str], optional): Which splits of the dataset to inspect.
+            If not provided, the "train" split will be inspected by default.
+        aug_config (str, optional): Path to a JSON or YAML config defining
+            augmentations to apply when inspecting the dataset.
+            If not provided, no augmentations will be applied.
+        size_multiplier (float): Multiplier for the displayed image size.
+        ignore_aspect_ratio (bool): Do not keep the aspect ratio when
+            resizing images.
+        deterministic (bool): Use deterministic augmentation mode.
+        force_update (bool): Force synchronization with remote storage first.
+        blend_all (bool): Draw labels belonging to different tasks on the
+            same image.
+        per_instance (bool): Show each label instance in a separate window.
+        list_augmentations (bool): Show the augmentations applied to each
+            displayed image. Requires --aug-config to be set.
+        bucket_storage (BucketStorage): Storage type of the dataset.
+    """
     check_exists(name, bucket_storage)
 
     view = view or ["train"]
@@ -319,7 +279,7 @@ def inspect(
             get_applied_augmentations = list
         elif loader.augmentations is not None:
             collector = AugmentationsCollector(
-                loader.augmentations, Path(aug_config)
+                loader.augmentations, aug_config
             )
             get_applied_augmentations = collector.get_applied_augmentations
         else:
@@ -425,199 +385,188 @@ def inspect(
             break
 
 
-@app.command()
+@app.command
 def export(
-    dataset_name: DatasetNameArgument,
+    name: DatasetT,
+    *,
     save_dir: Annotated[
         str | None,
-        typer.Option(
-            ...,
-            "--save-dir",
-            "-s",
-            help="Directory where the dataset should be saved. "
-            "If not provided, the dataset will be saved in the "
-            "current working directory under the name of the dataset.",
-            show_default=False,
-        ),
+        Parameter(alias="-s"),
     ] = None,
     dataset_type: Annotated[
         DatasetType,
-        typer.Option(
-            ...,
-            "--type",
-            "-t",
-            help="Format of the exported dataset",
-            show_default=False,
+        Parameter(
+            name="--type",
+            alias="-t",
         ),
-    ] = "native",  # type: ignore
+    ] = DatasetType.NATIVE,
     delete_existing: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--delete",
-            "-d",
-            help="Delete an existing `save_dir` before exporting.",
+        Parameter(
+            name="--delete",
+            alias="-d",
+            negative="",
         ),
     ] = False,
     max_partition_size_gb: Annotated[
         float | None,
-        typer.Option(
-            ...,
-            "--max-partition-size-gb",
-            "-m",
-            help=(
-                "Maximum size of each partition in GB. If the dataset"
-                " exceeds this size, it will be split into multiple partitions named {dataset_name}_part{partition_number}."
-                " Default is None, meaning the dataset will be exported as a single partition named {dataset_name}."
-            ),
-            show_default=False,
-        ),
+        Parameter(alias="-m"),
     ] = None,
-    no_zip: Annotated[
-        bool,
-        typer.Option(
-            "--no-zip",
-            help="Skip zipping the exported dataset. By default, the dataset (or each partition) will be zipped.",
-        ),
-    ] = False,
-    bucket_storage: BucketStorage = bucket_option,
+    zip: bool = True,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
-    """Export a Luxonis dataset to disk in native format, with optional
-    partitioning and zip compression for flexible storage."""
-    save_dir = save_dir or dataset_name
+    """Export a Luxonis dataset to disk.
+
+    Args:
+        dataset_name (str): Name of the dataset to export.
+        save_dir (str, optional): Directory where the exported dataset will be
+            saved. If not provided, a directory with the same name as the
+            dataset will be created in the current working directory.
+        dataset_type (DatasetType): Format of the exported dataset.
+        delete_existing (bool): If True, delete any existing directory at
+            the save location before exporting.
+        max_partition_size_gb (float, optional): Maximum size of each
+            partition in GB. If not provided, no partitioning will be done.
+        zip (bool): If True, the exported dataset will be zipped into a
+            single archive. If False, the dataset will be exported as a
+            directory with the specified structure.
+        bucket_storage (BucketStorage): Storage type of the dataset.
+    """
+    save_dir = save_dir or name
     if delete_existing and Path(save_dir).exists():
         shutil.rmtree(save_dir)
-    dataset = LuxonisDataset(dataset_name, bucket_storage=bucket_storage)
-    dataset.export(save_dir, dataset_type, max_partition_size_gb, not no_zip)
+    dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
+    dataset.export(save_dir, dataset_type, max_partition_size_gb, zip)
 
 
-@app.command()
+@app.command
 def parse(
-    dataset_dir: Annotated[
-        str, typer.Argument(..., help="Path or URL to the dataset.")
+    dataset: Annotated[
+        str,
+        Parameter(alias="--dataset-dir"),
     ],
+    *,
     name: Annotated[
         str | None,
-        typer.Option(
-            ...,
-            "--name",
-            "-n",
-            autocompletion=complete_dataset_name,
-            help="Name of the dataset.",
-            show_default=False,
-        ),
+        Parameter(alias="-n"),
     ] = None,
     dataset_type: Annotated[
         DatasetType | None,
-        typer.Option(
-            ...,
-            "--type",
-            "-t",
-            help="Type of the dataset. If not provided, "
-            "the parser will try to recognize it automatically.",
-            show_default=False,
+        Parameter(
+            name="--type",
+            alias="-t",
         ),
     ] = None,
     delete_local: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--delete",
-            "-d",
-            help="If an existing local dataset with the same name should "
-            "be deleted before parsing.",
+        Parameter(
+            name="--delete",
+            alias="-d",
+            negative="",
         ),
     ] = False,
     save_dir: Annotated[
         Path | None,
-        typer.Option(
-            ...,
-            "--save-dir",
-            "-s",
-            help="If a remote URL is provided in 'dataset_dir', "
-            "the dataset will be downloaded to this directory. "
-            "Otherwise, the dataset will be downloaded to the "
-            "current working directory.",
-            show_default=False,
-        ),
+        Parameter(alias="-s"),
     ] = None,
     task_name: Annotated[
         str | None,
-        typer.Option(
-            ...,
-            "--task-name",
-            "-tn",
-            help="Name of the task that should be used with this dataset. "
-            "If not provided, the name of the dataset format will be used.",
-            show_default=False,
-        ),
+        Parameter(alias="-tn"),
     ] = None,
     split_ratio: Annotated[
         str | None,
-        typer.Option(
-            ...,
-            "--split-ratio",
-            "-sr",
-            help="Split specification for train,val,test as a Python list. "
-            "Two modes: (1) Percentages like '[0.8, 0.1, 0.1]' must sum to 1.0 and will "
-            "redistribute/shuffle all samples across splits. (2) Raw counts like "
-            "'[1000, 100, 50]' will sample from each original split independently "
-            "(no cross-split redistribution).",
-            show_default=False,
-        ),
+        Parameter(alias="-sr"),
     ] = None,
+    train: float | None = None,
+    val: float | None = None,
+    test: float | None = None,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
-    """Parses a directory with data and creates Luxonis dataset."""
-    split_ratios = parse_split_ratio(split_ratio)
+    """Parse a directory with data and create a Luxonis dataset.
 
+    Args:
+        dataset (str): Path or URL to the dataset.
+        name (str, optional): Name of the dataset.
+            If not provided, the directory name will be used.
+        dataset_type (DatasetType, optional): Type of the dataset.
+            If not provided, the parser will attempt to detect it.
+        delete_local (bool): If True, delete any existing local
+            dataset with the same name before parsing.
+        save_dir (str, optional): If dataset_dir is a remote URL,
+            this is the local directory where the dataset will
+            be downloaded before parsing. If not provided,
+            the dataset will be downloaded to the current working directory.
+        task_name (str, optional): Task name to use for all records
+            parsed from this dataset.
+        split_ratio (str, optional): A string representation of a Python list
+            specifying the split ratios for train, val, and test sets.
+            Deprecated in favor of ``--train``,
+            ``--val``, and ``--test`` options.
+        train (float, optional): Ratio or count of records to assign
+            to the training set. Can be used together with
+            ``--val`` and ``--test``. If only some of these options
+            are provided, the remaining split(s) receive an equal share
+            of the leftover records (only supported for ratios, not counts).
+        val (float, optional): Ratio or count of records to assign
+            to the validation set.
+        test (float, optional): Ratio or count of records to assign
+            to the test set.
+    """
     parser = LuxonisParser(
-        dataset_dir,
+        dataset,
         dataset_name=name,
         dataset_type=dataset_type,
         delete_local=delete_local,
         save_dir=save_dir,
         task_name=task_name,
+        bucket_storage=bucket_storage,
     )
-    dataset = parser.parse(split_ratios=split_ratios)
 
     print()
     print(Rule())
     print()
-    print_info(dataset)
+    print_info(
+        parser.parse(
+            split_ratios=parse_split_ratio(split_ratio, train, val, test)
+        )
+    )
 
 
-@app.command()
+@app.command
 def health(
-    name: DatasetNameArgument,
-    view: str | None = typer.Option(
-        None,
-        "--view",
-        "-v",
-        help="Which splits of the dataset to inspect. If not provided, all dataset will be used.",
-        show_default=False,
-    ),
-    sample_size: int | None = typer.Option(
-        None,
-        "--sample-size",
-        "-n",
-        help="Number of annotation rows to sample from the dataset. Note that each task type annotation is in a separate row.",
-        show_default=False,
-    ),
-    save_dir: str | None = typer.Option(
-        None,
-        "--save-dir",
-        "-s",
-        help="Directory where the plots should be saved. "
-        "If not provided, the plots will be displayed.",
-        show_default=False,
-    ),
-    bucket_storage: BucketStorage = bucket_option,
+    name: DatasetT,
+    *,
+    view: Annotated[
+        str | None,
+        Parameter(alias="-v"),
+    ] = None,
+    sample_size: Annotated[
+        int | None,
+        Parameter(alias="-n"),
+    ] = None,
+    save_dir: Annotated[
+        str | None,
+        Parameter(alias="-s"),
+    ] = None,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
-    """Plots class distributions and heatmaps for every task type and
+    """Plot class distributions and heatmaps for every task type and
     corresponding task name in the dataset.
 
     Also checks for files with missing annotations, files that share the
     same UUIDs, and files with duplicate annotations.
+
+    Args:
+        name (str): Name of the dataset to inspect.
+        view (str, optional): Which split of the dataset to inspect.
+            If not provided, all splits will be inspected.
+        sample_size (int, optional): Number of annotation rows to sample
+            from the dataset for calculating statistics and plots.
+            If not provided, all annotations will be used.
+        save_dir (str, optional): Directory where the generated plots
+            will be saved. If not provided, the plots will be displayed
+            interactively instead of being saved.
+        bucket_storage (BucketStorage): Storage type of the dataset.
     """
     check_exists(name, bucket_storage)
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
@@ -701,7 +650,8 @@ def health(
     if missing_annotations or duplicate_uuids or duplicate_annotations:
         console.print(
             "[bold red]Dataset is unhealthy![/bold red] "
-            "Run [green]luxonis_ml data sanitize[/green] to automatically remove duplicates and missing entries."
+            "Run [green]luxonis_ml data sanitize[/green] "
+            "to automatically remove duplicates and missing entries."
         )
 
     all_task_names = sorted(
@@ -757,81 +707,89 @@ def health(
                 plt.close(fig)
 
 
-@app.command()
+@app.command
 def push(
-    name: DatasetNameArgument,
-    force_update: Annotated[
+    name: DatasetT,
+    *,
+    bucket_storage: BucketStorage,
+    force: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--force-update",
-            "-f",
-            help="Force pushing all media files, even if they already exist in the cloud. Annotations and metadata will always be pushed.",
-        ),
+        Parameter(alias="-f", negative=""),
     ] = False,
-    target_bucket_storage: BucketStorage = bucket_option,
 ):
-    """Push a local dataset to cloud storage."""
+    """Push a local dataset to cloud storage.
+
+    Args:
+        name (str): Name of the dataset to push.
+        bucket_storage (BucketStorage): Cloud storage type to push to.
+            Cannot be LOCAL.
+        force (bool): If True, push all media files even
+            if they already exist in the target cloud storage.
+    """
     check_exists(name, BucketStorage.LOCAL)
     dataset = LuxonisDataset(name, bucket_storage=BucketStorage.LOCAL)
 
-    if target_bucket_storage == BucketStorage.LOCAL:
+    if bucket_storage == BucketStorage.LOCAL:
         print(
             "[red]Cannot push to LOCAL storage. Please specify a cloud target."
         )
-        raise typer.Exit(1)
+        raise SystemExit(1)
 
     if LuxonisDataset.exists(
-        name, bucket_storage=target_bucket_storage
+        name, bucket_storage=bucket_storage
     ) and not Confirm.ask(
-        f"Dataset '{name}' already exists in {target_bucket_storage} bucket. If you are unsure about the dataset, please delete it from the cloud storage and try again. Do you want to overwrite it?"
+        f"Dataset '{name}' already exists in {bucket_storage} bucket. "
+        "If you are unsure about the dataset, please delete it from "
+        "the cloud storage and try again. Do you want to overwrite it?"
     ):
-        raise typer.Exit
+        raise SystemExit
 
-    print(
-        f"Pushing dataset '{name}' to {target_bucket_storage.value} storage..."
-    )
+    print(f"Pushing dataset '{name}' to {bucket_storage.value} storage...")
 
-    update_mode = UpdateMode.ALL if force_update else UpdateMode.MISSING
+    update_mode = UpdateMode.ALL if force else UpdateMode.MISSING
     dataset.push_to_cloud(
-        bucket_storage=target_bucket_storage, update_mode=update_mode
+        bucket_storage=bucket_storage, update_mode=update_mode
     )
 
     print(
-        f"[green]Dataset '{name}' successfully pushed to {target_bucket_storage.value}."
+        f"[green]Dataset '{name}' successfully pushed to {bucket_storage.value}."
     )
 
 
-@app.command()
+@app.command
 def pull(
-    name: DatasetNameArgument,
-    force_update: Annotated[
+    name: DatasetT,
+    *,
+    force: Annotated[
         bool,
-        typer.Option(
-            ...,
-            "--force-update",
-            "-f",
-            help="Force pulling all media files, even if they already exist locally.",
-        ),
+        Parameter(alias="-f", negative=""),
     ] = False,
-    bucket_storage: BucketStorage = bucket_option,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
-    """Pull a remote dataset to local storage."""
+    """Pull a remote dataset to local storage.
+
+    Args:
+        name (str): Name of the dataset to pull.
+        force (bool): If True, pull all media files even
+            if they already exist locally.
+        bucket_storage (BucketStorage): Cloud storage type to pull from.
+            Cannot be LOCAL.
+    """
     if bucket_storage == BucketStorage.LOCAL:
         print(
             "[red]Cannot pull from LOCAL storage. Please specify a cloud source."
         )
-        raise typer.Exit(1)
+        raise SystemExit(1)
 
     if not LuxonisDataset.exists(name, bucket_storage=bucket_storage):
         print(
             f"[red]Dataset '{name}' does not exist in {bucket_storage.value} storage."
         )
-        raise typer.Exit
+        raise SystemExit
 
     print(f"Pulling dataset '{name}' from {bucket_storage.value} storage...")
 
-    update_mode = UpdateMode.ALL if force_update else UpdateMode.MISSING
+    update_mode = UpdateMode.ALL if force else UpdateMode.MISSING
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
     dataset.pull_from_cloud(update_mode=update_mode)
 
@@ -840,50 +798,37 @@ def pull(
     )
 
 
-@app.command()
+@app.command
 def clone(
-    name: DatasetNameArgument,
-    new_name: Annotated[
-        str,
-        typer.Argument(
-            ..., help="Name of the new dataset.", show_default=False
-        ),
-    ],
-    push_to_cloud: Annotated[
+    name: DatasetT,
+    new_name: DatasetT,
+    *,
+    push: Annotated[
         bool,
-        typer.Option(
-            "--push/--no-push",
-            help="Whether to upload the newly cloned remote dataset back to cloud storage.",
-            show_default=True,
-        ),
+        Parameter(alias="-p", negative=""),
     ] = True,
-    bucket_storage: BucketStorage = bucket_option,
-    splits_to_clone: Annotated[
-        str | None,
-        typer.Option(
-            "--split",
-            "-s",
-            help=(
-                "Comma separated list of split names to clone, "
-                "e.g. `-s val,test` or just `-s train`. "
-                "If omitted, clones all splits."
-            ),
-            show_default=False,
-        ),
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
+    splits: Annotated[
+        list[str] | None,
+        Parameter(alias="-s"),
     ] = None,
     team_id: Annotated[
         str | None,
-        typer.Option(
-            "--team-id",
-            "-t",
-            help="Team ID to use for the new dataset. If not provided, the dataset's current team ID will be used.",
-            show_default=False,
-        ),
+        Parameter(alias="-t"),
     ] = None,
 ):
     """Clone an existing dataset with a new name.
 
     Optionally push it to cloud storage if it is a remote dataset.
+
+    Args:
+        name (str): Name of the source dataset to clone.
+        new_name (str): Name of the new cloned dataset.
+        push (bool): If True, upload the newly cloned dataset to cloud storage.
+        bucket_storage (BucketStorage): Storage type of the source dataset.
+        splits (str, optional): List of split names to clone.
+            If not provided, all splits will be cloned.
+        team_id (str, optional): Team ID to use for the new dataset.
     """
 
     check_exists(name, bucket_storage)
@@ -893,96 +838,74 @@ def clone(
     ) and not Confirm.ask(
         f"Dataset '{new_name}' already exists locally. Overwrite it?"
     ):
-        raise typer.Exit
-
-    if splits_to_clone:
-        split_list = [
-            s.strip() for s in splits_to_clone.split(",") if s.strip()
-        ]
-    else:
-        split_list = None
+        raise SystemExit
 
     print(f"Cloning dataset '{name}' to '{new_name}'...")
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
     dataset.clone(
         new_dataset_name=new_name,
-        push_to_cloud=push_to_cloud,
-        splits_to_clone=split_list,
+        push_to_cloud=push,
+        splits_to_clone=splits,
         team_id=team_id,
     )
     print(f"[green]Dataset '{name}' successfully cloned to '{new_name}'.")
 
 
-@app.command()
+@app.command
 def merge(
-    source_name: Annotated[
-        str,
-        typer.Argument(
-            ...,
-            help="Name of the source dataset.",
-            autocompletion=complete_dataset_name,
-        ),
-    ],
-    target_name: Annotated[
-        str,
-        typer.Argument(
-            ...,
-            help="Name of the target dataset.",
-            autocompletion=complete_dataset_name,
-        ),
-    ],
+    source_name: DatasetT,
+    target_name: DatasetT,
     new_name: Annotated[
         str | None,
-        typer.Option(
-            ...,
-            "--new-name",
-            "-n",
-            help="Name for the new merged dataset. If not provided, will merge into the target dataset.",
-            show_default=False,
-        ),
+        Parameter(alias="-n"),
     ] = None,
     splits_to_merge: Annotated[
         str | None,
-        typer.Option(
-            "--split",
-            "-s",
-            help=(
-                "Comma separated list of split names to merge, "
-                "e.g. `-s val,test` or just `-s train`. "
-                "If omitted, merges all splits."
-            ),
-            show_default=False,
+        Parameter(
+            name="--split",
+            alias="-s",
         ),
     ] = None,
-    bucket_storage: BucketStorage = bucket_option,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
     team_id: Annotated[
         str | None,
-        typer.Option(
-            "--team-id",
-            "-t",
-            help="Team ID to use for the new dataset. If not provided, the dataset's current team ID will be used.",
-            show_default=False,
-        ),
+        Parameter(alias="-t"),
     ] = None,
 ):
-    """Merge two datasets stored in the same type of bucket."""
+    """Merge two datasets stored in the same type of bucket.
+
+    Args:
+        source_name (str): Name of the source dataset to merge from.
+        target_name (str): Name of the target dataset to merge into.
+        new_name (str, optional): If
+            provided, the name of the new merged dataset.
+            If not provided, the source dataset will be
+            merged into the target dataset in place.
+        splits_to_merge (str, optional): Comma-separated list of split
+            names to merge. If not provided, all splits will be merged.
+        bucket_storage (BucketStorage): Storage type for both datasets.
+        team_id (str, optional): Team ID to use for the new dataset.
+            If not provided, the team ID of the target dataset will be used.
+    """
     check_exists(source_name, bucket_storage)
     check_exists(target_name, bucket_storage)
 
     inplace = new_name is None
     if inplace and not Confirm.ask(
-        f"This will merge dataset '{source_name}' into '{target_name}'. Continue?"
+        f"This will merge dataset '{source_name}' "
+        f"into '{target_name}'. Continue?"
     ):
-        raise typer.Exit
+        raise SystemExit
 
     if (
         not inplace
         and LuxonisDataset.exists(new_name, bucket_storage=bucket_storage)
         and not Confirm.ask(
-            f"Dataset '{new_name}' already exists in {bucket_storage.value} bucket. Overwrite it?"
+            f"Dataset '{new_name}' already exists in "
+            f"{bucket_storage.value} bucket. Overwrite it?"
         )
     ):
-        raise typer.Exit
+        raise SystemExit
 
     if splits_to_merge:
         split_list = [
@@ -994,10 +917,8 @@ def merge(
     source_dataset = LuxonisDataset(source_name, bucket_storage=bucket_storage)
     target_dataset = LuxonisDataset(target_name, bucket_storage=bucket_storage)
 
-    operation = "into" if inplace else "creating new dataset"
-    print(
-        f"Merging dataset '{source_name}' with '{target_name}', {operation}..."
-    )
+    operation = "in place" if inplace else ""
+    print(f"Merging dataset '{source_name}' with '{target_name}' {operation}")
 
     _ = target_dataset.merge_with(
         source_dataset,
@@ -1009,21 +930,28 @@ def merge(
 
     if inplace:
         print(
-            f"[green]Dataset '{source_name}' successfully merged into '{target_name}'."
+            f"[green]Dataset '{source_name}' "
+            f"successfully merged into '{target_name}'."
         )
     else:
         print(
-            f"[green]Datasets merged successfully into new dataset '{new_name}'."
+            f"[green]Datasets merged successfully "
+            f"into new dataset '{new_name}'."
         )
 
 
-@app.command()
+@app.command
 def sanitize(
-    name: DatasetNameArgument,
-    bucket_storage: BucketStorage = bucket_option,
+    name: DatasetT,
+    bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
     """Remove duplicate annotations and duplicate files from the
-    dataset."""
+    dataset.
+
+    Args:
+        name (str): Name of the dataset to sanitize.
+        bucket_storage (BucketStorage): Storage type of the dataset.
+    """
     check_exists(name, bucket_storage)
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
     dataset.remove_duplicates()

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -831,6 +831,7 @@ def clone(
         bucket_storage: Storage type of the source dataset.
         split: List of split names to clone.
             If not provided, all splits will be cloned.
+            Example: ``--split train --split val`` to clone only the "train" and "val" splits.
         team_id: Team ID to use for the new dataset.
     """
 

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -25,7 +25,6 @@ from luxonis_ml.data.utils.augmentations_collector import (
 )
 from luxonis_ml.data.utils.cli_utils import (
     check_exists,
-    complete_dataset_name,
     get_dataset_info,
     parse_split_ratio,
     print_info,
@@ -45,12 +44,11 @@ app = App(help="Dataset utilities.")
 
 
 BucketStorageT: TypeAlias = Annotated[BucketStorage, Parameter(alias="-b")]
-DatasetT: TypeAlias = Annotated[str, complete_dataset_name]
 
 
 @app.command
 def info(
-    name: DatasetT,
+    name: str,
     *,
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
@@ -66,7 +64,7 @@ def info(
 
 @app.command(alias=["rm", "remove"])
 def delete(
-    *names: DatasetT,
+    *names: str,
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
     local: Annotated[
         bool,
@@ -178,7 +176,7 @@ def ls(
 
 @app.command
 def inspect(
-    name: DatasetT,
+    name: str,
     *,
     view: Annotated[list[str] | None, Parameter(alias="-v")] = None,
     aug_config: Annotated[
@@ -386,7 +384,7 @@ def inspect(
 
 @app.command
 def export(
-    name: DatasetT,
+    name: str,
     *,
     save_dir: Annotated[
         str | None,
@@ -533,7 +531,7 @@ def parse(
 
 @app.command
 def health(
-    name: DatasetT,
+    name: str,
     *,
     view: Annotated[
         str | None,
@@ -708,7 +706,7 @@ def health(
 
 @app.command
 def push(
-    name: DatasetT,
+    name: str,
     *,
     bucket_storage: BucketStorage,
     force: Annotated[
@@ -757,7 +755,7 @@ def push(
 
 @app.command
 def pull(
-    name: DatasetT,
+    name: str,
     *,
     force: Annotated[
         bool,
@@ -799,8 +797,8 @@ def pull(
 
 @app.command
 def clone(
-    name: DatasetT,
-    new_name: DatasetT,
+    name: str,
+    new_name: str,
     *,
     push: Annotated[
         bool,
@@ -852,8 +850,8 @@ def clone(
 
 @app.command
 def merge(
-    source_name: DatasetT,
-    target_name: DatasetT,
+    source_name: str,
+    target_name: str,
     new_name: Annotated[
         str | None,
         Parameter(alias="-n"),
@@ -941,7 +939,7 @@ def merge(
 
 @app.command
 def sanitize(
-    name: DatasetT,
+    name: str,
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
     """Remove duplicate annotations and duplicate files from the

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -85,12 +85,16 @@ def delete(
         remote: If True, delete the dataset from remote storage.
         yes: If True, skip confirmation prompt and delete immediately.
     """
+    if not names:
+        print("[red]At least one dataset name must be provided.[/red]")
+        raise SystemExit(1)
+
     if not local and not remote:
         print(
             "[red]No deletion target specified (local or remote). "
             "Nothing to delete.[/red]"
         )
-        raise SystemExit(1)
+        raise SystemExit(2)
 
     for name in names:
         check_exists(name, bucket_storage)
@@ -116,18 +120,12 @@ def delete(
         ):
             continue
 
-        dataset = LuxonisDataset(
+        LuxonisDataset(
             name,
             bucket_storage=bucket_storage,
             delete_local=local,
             delete_remote=remote,
-        )
-        if not local and not remote:
-            print(
-                "[red]No valid deletion target remains for this dataset.[/red]"
-            )
-            raise SystemExit(1)
-        dataset.delete_dataset(
+        ).delete_dataset(
             delete_local=local,
             delete_remote=remote,
         )

--- a/luxonis_ml/data/utils/cli_utils.py
+++ b/luxonis_ml/data/utils/cli_utils.py
@@ -2,7 +2,6 @@ import ast
 from collections.abc import Iterator
 
 import rich.box
-import typer
 from rich import print as rprint
 from rich.console import RenderableType, group
 from rich.panel import Panel
@@ -11,60 +10,85 @@ from rich.table import Table
 
 from luxonis_ml.data import LuxonisDataset
 from luxonis_ml.data.utils.enums import BucketStorage
+from luxonis_ml.typing import check_type
 
 
 def parse_split_ratio(
     value: str | None,
+    train: float | None = None,
+    val: float | None = None,
+    test: float | None = None,
 ) -> dict[str, float | int] | None:
     """Parse split ratio argument.
 
-    Expects a Python list (e.g., C{"[0.8, 0.1, 0.1]"}). If values sum to
-    1.0, treated as ratios. Otherwise, treated as counts.
+    Args:
+        value: A string representation of a list of 3 values (train, val, test).
+        train: Optional float or int for training split.
+        val: Optional float or int for validation split.
+        test: Optional float or int for test split.
     """
-    if value is None:
+    if all(v is not None for v in (value, train, val, test)):
+        raise ValueError(
+            "Cannot specify split ratio both as a list and as separate "
+            "train/val/test arguments."
+        )
+    if not any(v is not None for v in (value, train, val, test)):
         return None
 
-    try:
-        parsed = ast.literal_eval(value)
-    except (ValueError, SyntaxError) as e:
-        raise typer.BadParameter(f"Invalid list syntax: {e}") from e
+    if value is not None:
+        try:
+            parsed = ast.literal_eval(value)
+        except (ValueError, SyntaxError) as e:
+            raise ValueError(f"Invalid list syntax: {e}") from e
+        if not isinstance(parsed, list) or len(parsed) != 3:
+            raise ValueError(
+                "Split ratio must be a list of 3 values (train, val, test)."
+            )
+        parsed = dict(zip(["train", "val", "test"], parsed, strict=True))
+    else:
+        sum_ = sum(v for v in (train, val, test) if v is not None)
+        if sum_ > 1 + 1e-6:
+            parsed = {
+                "train": int(train or 0),
+                "val": int(val or 0),
+                "test": int(test or 0),
+            }
+        else:
+            n_defined = sum(v is not None for v in (train, val, test))
+            rem = (1 - sum_) / (3 - n_defined) if n_defined < 3 else 0
+            parsed = {
+                "train": train if train is not None else rem,
+                "val": val if val is not None else rem,
+                "test": test if test is not None else rem,
+            }
 
-    if not isinstance(parsed, list) or len(parsed) != 3:
-        raise typer.BadParameter(
-            "Split ratio must be a list of 3 values (train, val, test)."
-        )
+    if not check_type(parsed, dict[str, float | int]):
+        raise ValueError("Split ratio values must be numbers.")
 
-    if not all(isinstance(v, int | float) for v in parsed):
-        raise typer.BadParameter("Split ratio values must be numbers.")
-
-    all_ints = all(isinstance(v, int) for v in parsed)
-    all_floats = all(isinstance(v, float) for v in parsed)
+    all_ints = all(isinstance(v, int) for v in parsed.values())
+    all_floats = all(isinstance(v, float) for v in parsed.values())
 
     if not (all_ints or all_floats):
-        raise typer.BadParameter(
+        raise ValueError(
             "Split ratio values must be all integers (counts) "
             "or all floats (ratios), not a mix."
         )
 
-    if all_floats and abs(sum(parsed) - 1.0) >= 1e-6:
-        raise typer.BadParameter(
-            f"Float ratios must sum to 1.0, but got {sum(parsed):.2f}."
+    if all_floats and abs(sum(parsed.values()) - 1.0) >= 1e-6:
+        raise ValueError(
+            f"Float ratios must sum up to 1.0, "
+            f"but got {sum(parsed.values()):.2f}."
         )
 
-    keys = ["train", "val", "test"]
-    return dict(
-        zip(
-            keys,
-            parsed if all_floats else [int(v) for v in parsed],
-            strict=True,
-        )
-    )
+    if all_ints:
+        return {k: int(v) for k, v in parsed.items()}
+    return {k: float(v) for k, v in parsed.items()}
 
 
 def check_exists(name: str, bucket_storage: BucketStorage) -> None:
     if not LuxonisDataset.exists(name, bucket_storage=bucket_storage):
         rprint(f"[red]Dataset [magenta]'{name}'[red] does not exist.")
-        raise typer.Exit
+        raise SystemExit(1)
 
 
 def get_dataset_info(dataset: LuxonisDataset) -> tuple[set[str], list[str]]:

--- a/luxonis_ml/data/utils/cli_utils.py
+++ b/luxonis_ml/data/utils/cli_utils.py
@@ -22,12 +22,16 @@ def parse_split_ratio(
     """Parse split ratio argument.
 
     Args:
-        value: A string representation of a list of 3 values (train, val, test).
-        train: Optional float or int for training split.
-        val: Optional float or int for validation split.
-        test: Optional float or int for test split.
+        value (str or None): A string representation of a list
+            of 3 values (train, val, test).
+        train (float or None, optional):
+            Optional float or int for training split.
+        val (float or None, optional):
+            Optional float or int for validation split.
+        test (float or None, optional):
+            Optional float or int for test split.
     """
-    if all(v is not None for v in (value, train, val, test)):
+    if value is not None and any(v is not None for v in (train, val, test)):
         raise ValueError(
             "Cannot specify split ratio both as a list and as separate "
             "train/val/test arguments."
@@ -46,7 +50,15 @@ def parse_split_ratio(
             )
         parsed = dict(zip(["train", "val", "test"], parsed, strict=True))
     else:
-        sum_ = sum(v for v in (train, val, test) if v is not None)
+        defined = [v for v in (train, val, test) if v is not None]
+        sum_ = sum(defined)
+        is_count_input = all(float(v).is_integer() for v in defined)
+
+        if sum_ > 1 + 1e-6 and not is_count_input:
+            raise ValueError(
+                "Split ratios must sum to 1.0; use whole numbers for counts."
+            )
+
         if sum_ > 1 + 1e-6:
             parsed = {
                 "train": int(train or 0),

--- a/luxonis_ml/data/utils/cli_utils.py
+++ b/luxonis_ml/data/utils/cli_utils.py
@@ -14,7 +14,7 @@ from luxonis_ml.typing import check_type
 
 
 def parse_split_ratio(
-    value: str | None,
+    value: str | None = None,
     train: float | None = None,
     val: float | None = None,
     test: float | None = None,
@@ -22,14 +22,40 @@ def parse_split_ratio(
     """Parse split ratio argument.
 
     Args:
-        value (str or None): A string representation of a list
+        value: A string representation of a list
             of 3 values (train, val, test).
-        train (float or None, optional):
+        train:
             Optional float or int for training split.
-        val (float or None, optional):
+        val:
             Optional float or int for validation split.
-        test (float or None, optional):
+        test:
             Optional float or int for test split.
+
+    Returns:
+        A dictionary with keys "train", "val", and "test" mapping to their
+        respective ratios or counts, or None if no values were provided.
+
+    Raises:
+        ValueError: If the input format is invalid, if ratios don't sum to 1.0,
+        or if there's a mix of counts and ratios.
+
+    Example:
+        >>> parse_split_ratio("[0.7, 0.2, 0.1]")
+        {'train': 0.7, 'val': 0.2, 'test': 0.1}
+        >>> parse_split_ratio(train=70, val=20, test=10)
+        {'train': 70, 'val': 20, 'test': 10}
+        >>> parse_split_ratio(train=0.7, val=0.2)
+        {'train': 0.7, 'val': 0.2, 'test': 0.1}
+        >>> parse_split_ratio(train=0.7, val=0.2, test=0.1)
+        {'train': 0.7, 'val': 0.2, 'test': 0.1}
+        >>> parse_split_ratio([10, 27])
+        Traceback (most recent call last):
+        ...
+        ValueError: Split ratio must be a list of 3 values (train, val, test).
+        >>> parse_split_ratio(train=0.7, val=0.2, test=0.2)
+        Traceback (most recent call last):
+        ...
+        ValueError: Split ratios must sum to 1.0; use whole numbers for counts.
     """
     if value is not None and any(v is not None for v in (train, val, test)):
         raise ValueError(

--- a/luxonis_ml/nn_archive/__main__.py
+++ b/luxonis_ml/nn_archive/__main__.py
@@ -57,7 +57,7 @@ def inspect(
     """
 
     if not any([inputs, metadata, outputs, heads, buildinfo]):
-        inputs = metadata = outputs = heads = buildinfo = True
+        inputs = metadata = outputs = heads = True
 
     with tarfile.open(path) as tar:
         extracted_cfg = tar.extractfile("config.json")

--- a/luxonis_ml/nn_archive/__main__.py
+++ b/luxonis_ml/nn_archive/__main__.py
@@ -1,3 +1,4 @@
+import json
 import tarfile
 from pathlib import Path
 from typing import Annotated
@@ -20,6 +21,7 @@ def inspect(
     metadata: Annotated[bool, Parameter(alias="-m", negative="")] = False,
     outputs: Annotated[bool, Parameter(alias="-o", negative="")] = False,
     heads: Annotated[bool, Parameter(alias="-h", negative="")] = False,
+    buildinfo: Annotated[bool, Parameter(alias="-b", negative="")] = False,
 ):
     """Print NN Archive configuration.
 
@@ -31,18 +33,28 @@ def inspect(
         metadata (bool): Print metadata.
         outputs (bool): Print outputs info.
         heads (bool): Print heads info.
+        buildinfo (bool): Print build info if available.
     """
+
+    if not any([inputs, metadata, outputs, heads, buildinfo]):
+        inputs = metadata = outputs = heads = buildinfo = True
 
     with tarfile.open(path) as tar:
         extracted_cfg = tar.extractfile("config.json")
+        if buildinfo:
+            extracted_buildinfo = tar.extractfile("buildinfo.json")
+            if extracted_buildinfo is not None:
+                print(
+                    Panel.fit(
+                        Pretty(json.loads(extracted_buildinfo.read())),
+                        title="Build Info",
+                    )
+                )
 
         if extracted_cfg is None:
             raise RuntimeError("Config JSON not found in the archive.")
 
         cfg = Config.model_validate_json(extracted_cfg.read())
-
-    if not any([inputs, metadata, outputs, heads]):
-        inputs = metadata = outputs = heads = True
 
     if metadata:
         print(Panel.fit(Pretty(cfg.model.metadata), title="Metadata"))

--- a/luxonis_ml/nn_archive/__main__.py
+++ b/luxonis_ml/nn_archive/__main__.py
@@ -121,9 +121,15 @@ def extract(
     def safe_members(tar: tarfile.TarFile) -> list[tarfile.TarInfo]:
         """Filter members to prevent path traversal attacks."""
         safe_files = []
+        root = extract_path.resolve()
         for member in tar.getmembers():
             # Normalize path and ensure it's within the extraction folder
-            if not member.name.startswith("/") and ".." not in member.name:
+            if member.issym() or member.islnk():
+                print(f"Skipping unsafe link: {member.name}")
+                continue
+
+            target = (root / member.name).resolve()
+            if target == root or root in target.parents:
                 safe_files.append(member)
             else:
                 print(f"Skipping unsafe file: {member.name}")

--- a/luxonis_ml/nn_archive/__main__.py
+++ b/luxonis_ml/nn_archive/__main__.py
@@ -3,7 +3,7 @@ import tarfile
 from pathlib import Path
 from typing import Annotated
 
-from cyclopts import App, Parameter
+from cyclopts import App, Parameter, validators
 from rich import print
 from rich.panel import Panel
 from rich.pretty import Pretty
@@ -15,25 +15,45 @@ app = App(help="NN Archive utilities.", help_flags="--help")
 
 @app.command
 def inspect(
-    path: str,
+    path: Annotated[
+        Path,
+        Parameter(
+            validator=validators.Path(exists=True),
+        ),
+    ],
     *,
-    inputs: Annotated[bool, Parameter(alias="-i", negative="")] = False,
-    metadata: Annotated[bool, Parameter(alias="-m", negative="")] = False,
-    outputs: Annotated[bool, Parameter(alias="-o", negative="")] = False,
-    heads: Annotated[bool, Parameter(alias="-h", negative="")] = False,
-    buildinfo: Annotated[bool, Parameter(alias="-b", negative="")] = False,
+    inputs: Annotated[
+        bool,
+        Parameter(alias="-i", negative=""),
+    ] = False,
+    metadata: Annotated[
+        bool,
+        Parameter(alias="-m", negative=""),
+    ] = False,
+    outputs: Annotated[
+        bool,
+        Parameter(alias="-o", negative=""),
+    ] = False,
+    heads: Annotated[
+        bool,
+        Parameter(alias="-h", negative=""),
+    ] = False,
+    buildinfo: Annotated[
+        bool,
+        Parameter(alias="-b", negative=""),
+    ] = False,
 ):
     """Print NN Archive configuration.
 
     If no options are provided, all info is printed.
 
     Args:
-        path (str): Path to the NN Archive.
-        inputs (bool): Print inputs info.
-        metadata (bool): Print metadata.
-        outputs (bool): Print outputs info.
-        heads (bool): Print heads info.
-        buildinfo (bool): Print build info if available.
+        path (Path): Path to the NN Archive.
+        inputs (bool, optional): Print inputs info.
+        metadata (bool, optional): Print metadata.
+        outputs (bool, optional): Print outputs info.
+        heads (bool, optional): Print heads info.
+        buildinfo (bool, optional): Print build info if available.
     """
 
     if not any([inputs, metadata, outputs, heads, buildinfo]):
@@ -68,7 +88,12 @@ def inspect(
 
 @app.command
 def extract(
-    path: Path,
+    path: Annotated[
+        Path,
+        Parameter(
+            validator=validators.Path(exists=True),
+        ),
+    ],
     destination: Annotated[
         Path | None,
         Parameter(
@@ -83,8 +108,8 @@ def extract(
     Archive is extracted to the current working directory.
 
     Args:
-        path (str): Path to the NN Archive.
-        destination (str): Path where to extract the Archive.
+        path (Path): Path to the NN Archive.
+        destination (Path or None, optional): Path where to extract the Archive.
             If not provided, the Archive is extracted to the current
             working directory.
     """

--- a/luxonis_ml/nn_archive/__main__.py
+++ b/luxonis_ml/nn_archive/__main__.py
@@ -1,42 +1,36 @@
-import json
 import tarfile
 from pathlib import Path
-from typing import Annotated, TypeAlias
+from typing import Annotated
 
-import typer
+from cyclopts import App, Parameter
 from rich import print
 from rich.panel import Panel
 from rich.pretty import Pretty
 
 from luxonis_ml.nn_archive import Config
 
-app = typer.Typer()
+app = App(help="NN Archive utilities.", help_flags="--help")
 
 
-PathArgument: TypeAlias = Annotated[
-    str, typer.Argument(..., help="Path to the NN Archive.")
-]
-
-
-@app.command()
+@app.command
 def inspect(
-    path: PathArgument,
-    inputs: Annotated[
-        bool, typer.Option(..., "-i", "--inputs", help="Print inputs info.")
-    ] = False,
-    metadata: Annotated[
-        bool, typer.Option(..., "-m", "--metadata", help="Print metadata.")
-    ] = False,
-    outputs: Annotated[
-        bool, typer.Option(..., "-o", "--outputs", help="Print outputs info.")
-    ] = False,
-    heads: Annotated[
-        bool, typer.Option(..., "-h", "--heads", help="Print heads info.")
-    ] = False,
+    path: str,
+    *,
+    inputs: Annotated[bool, Parameter(alias="-i", negative="")] = False,
+    metadata: Annotated[bool, Parameter(alias="-m", negative="")] = False,
+    outputs: Annotated[bool, Parameter(alias="-o", negative="")] = False,
+    heads: Annotated[bool, Parameter(alias="-h", negative="")] = False,
 ):
-    """Prints NN Archive configuration.
+    """Print NN Archive configuration.
 
     If no options are provided, all info is printed.
+
+    Args:
+        path (str): Path to the NN Archive.
+        inputs (bool): Print inputs info.
+        metadata (bool): Print metadata.
+        outputs (bool): Print outputs info.
+        heads (bool): Print heads info.
     """
 
     with tarfile.open(path) as tar:
@@ -45,40 +39,46 @@ def inspect(
         if extracted_cfg is None:
             raise RuntimeError("Config JSON not found in the archive.")
 
-        archive_config = Config(**json.loads(extracted_cfg.read().decode()))
+        cfg = Config.model_validate_json(extracted_cfg.read())
 
     if not any([inputs, metadata, outputs, heads]):
         inputs = metadata = outputs = heads = True
 
     if metadata:
-        print(
-            Panel.fit(Pretty(archive_config.model.metadata), title="Metadata")
-        )
+        print(Panel.fit(Pretty(cfg.model.metadata), title="Metadata"))
     if heads:
-        print(Panel.fit(Pretty(archive_config.model.heads), title="Heads"))
+        print(Panel.fit(Pretty(cfg.model.heads), title="Heads"))
     if inputs:
-        print(Panel.fit(Pretty(archive_config.model.inputs), title="Inputs"))
+        print(Panel.fit(Pretty(cfg.model.inputs), title="Inputs"))
     if outputs:
-        print(Panel.fit(Pretty(archive_config.model.outputs), title="Outputs"))
+        print(Panel.fit(Pretty(cfg.model.outputs), title="Outputs"))
 
 
-@app.command()
+@app.command
 def extract(
-    path: PathArgument,
+    path: Path,
     destination: Annotated[
-        str,
-        typer.Option(
-            "-d", "--dest", help="Path where to extract the Archive."
+        Path | None,
+        Parameter(
+            name="--dest",
+            alias="-d",
         ),
-    ] = ".",
+    ] = None,
 ):
-    """Extracts NN Archive.
+    """Extract an NN Archive.
 
     Extracts the NN Archive to the destination path. By default, the
     Archive is extracted to the current working directory.
+
+    Args:
+        path (str): Path to the NN Archive.
+        destination (str): Path where to extract the Archive.
+            If not provided, the Archive is extracted to the current
+            working directory.
     """
 
-    extract_path = Path(destination) / (Path(path).name.split(".")[0])
+    destination = destination or Path.cwd()
+    extract_path = destination / path.name.split(".")[0]
     extract_path.mkdir(exist_ok=True, parents=True)
 
     def safe_members(tar: tarfile.TarFile) -> list[tarfile.TarInfo]:
@@ -89,11 +89,11 @@ def extract(
             if not member.name.startswith("/") and ".." not in member.name:
                 safe_files.append(member)
             else:
-                typer.echo(f"Skipping unsafe file: {member.name}")
+                print(f"Skipping unsafe file: {member.name}")
         return safe_files
 
     with tarfile.open(path) as tf:
         for member in safe_members(tf):
             tf.extract(member, extract_path)
 
-    typer.echo(f"Archive extracted to: {extract_path}")
+    print(f"Archive extracted to: {extract_path}")

--- a/luxonis_ml/nn_archive/__main__.py
+++ b/luxonis_ml/nn_archive/__main__.py
@@ -48,12 +48,12 @@ def inspect(
     If no options are provided, all info is printed.
 
     Args:
-        path (Path): Path to the NN Archive.
-        inputs (bool, optional): Print inputs info.
-        metadata (bool, optional): Print metadata.
-        outputs (bool, optional): Print outputs info.
-        heads (bool, optional): Print heads info.
-        buildinfo (bool, optional): Print build info if available.
+        path: Path to the NN Archive.
+        inputs: Print inputs info.
+        metadata: Print metadata.
+        outputs: Print outputs info.
+        heads: Print heads info.
+        buildinfo: Print build info if available.
     """
 
     if not any([inputs, metadata, outputs, heads, buildinfo]):
@@ -108,8 +108,8 @@ def extract(
     Archive is extracted to the current working directory.
 
     Args:
-        path (Path): Path to the NN Archive.
-        destination (Path or None, optional): Path where to extract the Archive.
+        path: Path to the NN Archive.
+        destination: Path where to extract the Archive.
             If not provided, the Archive is extracted to the current
             working directory.
     """

--- a/luxonis_ml/utils/__main__.py
+++ b/luxonis_ml/utils/__main__.py
@@ -57,7 +57,7 @@ def ls(
         Parameter(alias="-r", negative=""),
     ] = False,
     typ: Annotated[
-        Literal["file", "dir", "all"],
+        Literal["file", "directory", "all"],
         Parameter(
             name=["--type", "-t"],
         ),
@@ -70,10 +70,6 @@ def ls(
         recursive (bool): Whether to list files recursively.
         typ (str): Type of files to list.
     """
-    if not url.endswith("://"):
-        url = url.rstrip("/")
-    print(url)
-    fs = LuxonisFileSystem(url)
-    print(fs.url)
+    fs = LuxonisFileSystem(url.rstrip("/"))
     for file in fs.walk_dir("", recursive=recursive, typ=typ):
         print(file)

--- a/luxonis_ml/utils/__main__.py
+++ b/luxonis_ml/utils/__main__.py
@@ -1,68 +1,79 @@
-from enum import Enum
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
-import typer
+from cyclopts import App, Parameter
 from rich import print
 
 from luxonis_ml.utils import LuxonisFileSystem
 
-app = typer.Typer()
-
-UrlArgument = Annotated[str, typer.Argument(..., help="URL of the file.")]
+app = App(help="Filesystem utilities.")
 
 
-class TypeEnum(str, Enum):
-    FILE = "file"
-    DIR = "directory"
-    ALL = "all"
-
-
-@app.command()
+@app.command(alias="pull")
 def get(
-    url: UrlArgument,
-    save_dir: Annotated[
-        Path | None, typer.Argument(help="Directory to save the file.")
-    ] = None,
+    url: str,
+    save_dir: Path | None = None,
 ):
-    """Downloads file from remote storage."""
+    """Download a file from remote storage.
+
+    Args:
+        url (str): URL of the file to download.
+        save_dir (Path, optional): Directory to save the file.
+            Defaults to current working directory.
+    """
     LuxonisFileSystem.download(url, save_dir or Path.cwd())
 
 
-@app.command()
+@app.command(alias="push")
 def put(
-    file: Annotated[Path, typer.Argument(help="Path to the file to upload.")],
-    url: UrlArgument,
+    file: Path,
+    url: str,
 ):
-    """Uploads file to remote storage."""
+    """Upload a file to remote storage.
+
+    Args:
+        file (Path): Path to the file to upload.
+        url (str): URL of the file.
+    """
     LuxonisFileSystem.upload(file, url)
 
 
-@app.command()
-def delete(url: UrlArgument):
-    """Deletes file from remote storage."""
-    fs = LuxonisFileSystem(url)
-    fs.delete_file("")
+@app.command(alias=["rm", "remove"])
+def delete(url: str):
+    """Delete a file from remote storage.
+
+    Args:
+        url (str): URL of the file to delete.
+    """
+    LuxonisFileSystem(url).delete_file("")
 
 
-@app.command()
+@app.command
 def ls(
-    url: UrlArgument,
+    url: str,
+    *,
     recursive: Annotated[
         bool,
-        typer.Option(..., "--recursive", "-r", help="List files recursively."),
+        Parameter(alias="-r", negative=""),
     ] = False,
     typ: Annotated[
-        TypeEnum,
-        typer.Option(
-            ...,
-            "--type",
-            "-t",
-            help="Type of the files to list. If not provided, all files will be listed.",
+        Literal["file", "dir", "all"],
+        Parameter(
+            name=["--type", "-t"],
         ),
-    ] = TypeEnum.ALL,
+    ] = "all",
 ):
-    """Lists files in the remote directory."""
-    fs = LuxonisFileSystem(url.rstrip("/"))
-    for file in fs.walk_dir("", recursive=recursive, typ=typ.value):
+    """List files in the remote directory.
+
+    Args:
+        url (str): URL of the directory to list.
+        recursive (bool): Whether to list files recursively.
+        typ (str): Type of files to list.
+    """
+    if not url.endswith("://"):
+        url = url.rstrip("/")
+    print(url)
+    fs = LuxonisFileSystem(url)
+    print(fs.url)
+    for file in fs.walk_dir("", recursive=recursive, typ=typ):
         print(file)

--- a/luxonis_ml/utils/__main__.py
+++ b/luxonis_ml/utils/__main__.py
@@ -17,8 +17,8 @@ def get(
     """Download a file from remote storage.
 
     Args:
-        url (str): URL of the file to download.
-        save_dir (Path, optional): Directory to save the file.
+        url: URL of the file to download.
+        save_dir: Directory to save the file.
             Defaults to current working directory.
     """
     LuxonisFileSystem.download(url, save_dir or Path.cwd())
@@ -32,8 +32,8 @@ def put(
     """Upload a file to remote storage.
 
     Args:
-        file (Path): Path to the file to upload.
-        url (str): URL of the file.
+        file: Path to the file to upload.
+        url: URL of the file.
     """
     LuxonisFileSystem.upload(file, url)
 
@@ -43,7 +43,7 @@ def delete(url: str):
     """Delete a file from remote storage.
 
     Args:
-        url (str): URL of the file to delete.
+        url: URL of the file to delete.
     """
     LuxonisFileSystem(url).delete_file("")
 
@@ -66,9 +66,9 @@ def ls(
     """List files in the remote directory.
 
     Args:
-        url (str): URL of the directory to list.
-        recursive (bool): Whether to list files recursively.
-        typ (str): Type of files to list.
+        url: URL of the directory to list.
+        recursive: Whether to list files recursively.
+        typ: Type of files to list.
     """
     fs = LuxonisFileSystem(url.rstrip("/"))
     for file in fs.walk_dir("", recursive=recursive, typ=typ):

--- a/luxonis_ml/utils/requirements.txt
+++ b/luxonis_ml/utils/requirements.txt
@@ -5,7 +5,7 @@ PyYAML~=6.0
 fsspec>=2023.3.0
 rich~=13.6
 semver~=3.0
-typer~=0.12
+cyclopts~=4.16
 typeguard~=4.1
 aiobotocore<2.18
 loguru~=0.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,11 @@ paths = ["luxonis_train"]
 exclude = ["luxonis_ml/tracker", "examples", "__main__.py"]
 
 [tool.pytest]
-doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER"
+doctest_optionflags = [
+  "NORMALIZE_WHITESPACE",
+  "IGNORE_EXCEPTION_DETAIL",
+  "NUMBER",
+]
 testpaths = ["tests"]
 addopts = ["--disable-warnings"]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+import shutil
+import subprocess
+
+import pytest
+
+
+@pytest.mark.parametrize("cmd", ["data", "archive", "fs", "checkhealth"])
+def test_cli_commands(cmd: str):
+    subprocess.run(
+        [
+            shutil.which("python"),  # type: ignore
+            "-m",
+            "luxonis_ml",
+            cmd,
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,5 @@
-import shutil
 import subprocess
+import sys
 
 import pytest
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 def test_cli_commands(cmd: str):
     subprocess.run(
         [
-            shutil.which("python"),  # type: ignore
+            sys.executable,
             "-m",
             "luxonis_ml",
             cmd,

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -4,7 +4,8 @@ from typing import Annotated
 
 import cv2
 import numpy as np
-import typer
+from cyclopts import App, Parameter
+from rich import print
 
 from luxonis_ml.data import BucketStorage, LuxonisDataset, LuxonisLoader
 from luxonis_ml.data.datasets.base_dataset import DatasetIterator
@@ -52,7 +53,7 @@ def generator(size: int) -> DatasetIterator:
             }
 
 
-app = typer.Typer()
+app = App()
 
 normal_config: list[Params] = [
     {"name": "Defocus", "params": {"p": 1}},
@@ -67,14 +68,17 @@ batched_config: list[Params] = [
 ]
 
 
+@app.default
 def main(
-    repeat: Annotated[int, typer.Option(..., "-r", "--repeat")] = 1,
-    size: Annotated[int, typer.Option(..., "-s", "--size")] = 10_000,
-    no_write: Annotated[bool, typer.Option(..., "-nw", "--no-write")] = False,
-    no_read: Annotated[bool, typer.Option(..., "-nr", "--no-read")] = False,
-    augment: Annotated[bool, typer.Option(..., "-a", "--augment")] = False,
-    batched: Annotated[bool, typer.Option(..., "-b", "--batched")] = False,
+    repeat: Annotated[int, Parameter(alias="-r")] = 1,
+    size: Annotated[int, Parameter(alias="-s")] = 10_000,
+    no_write: Annotated[bool, Parameter(alias="-nw")] = False,
+    no_read: Annotated[bool, Parameter(alias="-nr")] = False,
+    augment: Annotated[bool, Parameter(alias="-a")] = False,
+    batched: Annotated[bool, Parameter(alias="-b")] = False,
 ) -> None:
+    """Benchmark the time taken to write and read a dataset with the
+    given parameters."""
     if not no_write:
         avg = 0
         for _ in range(repeat):
@@ -85,7 +89,7 @@ def main(
             dataset.add(generator(size))
             dataset.make_splits()
             avg += time.time() - t
-        typer.echo(f"Time to write: {avg / repeat:.2f}s")
+        print(f"Time to write: {avg / repeat:.2f}s")
 
     if not no_read:
         avg = 0
@@ -105,8 +109,8 @@ def main(
                 pass
 
             avg += time.time() - t
-        typer.echo(f"Time to read: {avg / repeat:.2f}s")
+        print(f"Time to read: {avg / repeat:.2f}s")
 
 
 if __name__ == "__main__":
-    typer.run(main)
+    app()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Makes the CLI in `luxonis-ml` consistent with `luxonis-train` and `modelconverter`.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- Replaced `typer` with `cyclopts`
- Deprecated `luxonis_ml data parse --split-ratios`
  - `--train`, `--val`, and `--test` instead
  - `luxonis_ml data parse -sr "[0.8,0.1,0.1]"` $\rightarrow$ `luxonis_ml data parse --train 0.8`
- Added an option to print the `buildinfo.json` to `luxonis_ml archive inspect` (`-b`)
- `luxonis_ml data delete` can now delete multiple datasets at once
  - And supports `-y` flag to automatically confirm the deletions 

### Open questions
As opposed to `typer`, `cyclopts` does not yet support dymanic completions ([Issue #641](https://github.com/BrianPugh/cyclopts/issues/641)). This means that shell completions for dataset names will no longer work.
This gives us 3 options:
  1. Implement dynamic completion ourselves
  1. Wait with merge until supported upstream
  1. Merge anyways and add support when available

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated the dataset, NN archive, filesystem utilities, benchmark, and main CLIs to a unified command-line framework with consistent help/version and standardized subcommand behavior.
* **New Features / UX**
  * Dataset delete accepts multiple targets with a `--yes` bypass; parse supports `--train/--val/--test` splits (legacy ratio still supported).
  * Archive inspect adds `-b/--buildinfo`; filesystem `ls` supports `--type file|directory|all`.
* **Bug Fixes**
  * Improved validation for split inputs and missing resources; safer archive extraction and clearer output.
  * Updated push/pull/clone/merge/sanitize CLI options and constraints.
* **Tests / Chores**
  * Added CLI smoke tests for key commands; disabled docs job in CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->