### PR TITLE
Allow subsets of splits when parsing datasets

### DIFF
--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -342,6 +342,13 @@ class BaseParser(ABC):
                 "No valid split directories found in dataset. "
                 f"Found directories: {existing_dirs}."
             )
+        if all(
+            len(split_images) == 0
+            for split_images in split_definitions.values()
+        ):
+            raise ValueError(
+                "No samples were parsed from the discovered split directories."
+            )
 
         original_splits: dict[str, Sequence[PathType]] = {
             split_name: split_definitions.get(split_name, [])

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -98,6 +98,12 @@ class BaseParser(ABC):
 
     @classmethod
     def _canonicalize_split_name(cls, split_name: str) -> str:
+        """All current parsers use `train` and `test` split names
+        whereas validation splits can vary in name between `val` `valid`
+        and `validation`.
+
+        This maps `valid` -> `val` and `validation` -> val
+        """
         if split_name in {"valid", "validation"}:
             return "val"
         return split_name

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -349,7 +349,7 @@ class BaseParser(ABC):
         }
 
         if split_ratios is None:
-            self.dataset.make_splits(split_definitions)
+            self.dataset.make_splits(original_splits)
         elif is_counts:
             sampled = self._apply_counts_to_splits(
                 original_splits,

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -23,6 +23,7 @@ ParserOutput = tuple[DatasetIterator, dict[str, dict], list[Path]]
 
 class BaseParser(ABC):
     SPLIT_NAMES: tuple[str, ...] = ("train", "valid", "test")
+    CANONICAL_SPLIT_NAMES: tuple[str, ...] = ("train", "val", "test")
 
     def __init__(
         self,
@@ -94,6 +95,26 @@ class BaseParser(ABC):
             return False
 
         return all(cls.validate_split(dataset_dir / split) for split in splits)
+
+    @classmethod
+    def _canonicalize_split_name(cls, split_name: str) -> str:
+        if split_name in {"valid", "validation"}:
+            return "val"
+        return split_name
+
+    @classmethod
+    def discover_dir_splits(
+        cls, dataset_dir: Path
+    ) -> dict[str, dict[str, Any]]:
+        """Returns present and valid split directories keyed by their
+        canonical split names."""
+        discovered: dict[str, dict[str, Any]] = {}
+        for split_name in cls.SPLIT_NAMES:
+            split_kwargs = cls.validate_split(dataset_dir / split_name)
+            if split_kwargs is None:
+                continue
+            discovered[cls._canonicalize_split_name(split_name)] = split_kwargs
+        return discovered
 
     @abstractmethod
     def from_dir(
@@ -295,24 +316,6 @@ class BaseParser(ABC):
         @return: C{LDF} with all the images and annotations parsed.
         """
         self.reset_parser_issue_messages()
-        # Skip train directory check for parsers that use images/labels
-        # subdirectory structure (YoloV6, YOLOv8) instead of train/valid/test
-        # at root level
-        skip_train_check = self.__class__.__name__ in (
-            "YoloV6Parser",
-            "YOLOv8Parser",
-        )
-        if not skip_train_check:
-            train_dir = dataset_dir / "train"
-            if not train_dir.exists() or not train_dir.is_dir():
-                existing_dirs = [
-                    d.name for d in dataset_dir.iterdir() if d.is_dir()
-                ]
-                raise ValueError(
-                    f"Train split not found in dataset. "
-                    f"Expected a 'train' directory but found: {existing_dirs}."
-                )
-
         split_ratios = kwargs.pop("split_ratios", None)
         is_counts = split_ratios is not None and all(
             isinstance(v, int) for v in split_ratios.values()
@@ -320,19 +323,27 @@ class BaseParser(ABC):
 
         # Disable automatic val-to-test splitting when using explicit counts
         if is_counts and "split_val_to_test" not in kwargs:
-            sig = inspect.signature(self.from_dir)
+            sig = inspect.signature(self._parse_available_splits)
             if "split_val_to_test" in sig.parameters:
                 kwargs["split_val_to_test"] = False
 
-        train, val, test = self.from_dir(dataset_dir, **kwargs)
+        split_definitions = self._parse_available_splits(dataset_dir, **kwargs)
+        if not split_definitions:
+            existing_dirs = [
+                d.name for d in dataset_dir.iterdir() if d.is_dir()
+            ]
+            raise ValueError(
+                "No valid split directories found in dataset. "
+                f"Found directories: {existing_dirs}."
+            )
+
         original_splits: dict[str, Sequence[PathType]] = {
-            "train": train,
-            "val": val,
-            "test": test,
+            split_name: split_definitions.get(split_name, [])
+            for split_name in self.CANONICAL_SPLIT_NAMES
         }
 
         if split_ratios is None:
-            self.dataset.make_splits(original_splits)
+            self.dataset.make_splits(split_definitions)
         elif is_counts:
             sampled = self._apply_counts_to_splits(
                 original_splits,
@@ -349,6 +360,18 @@ class BaseParser(ABC):
             self.dataset.make_splits(split_ratios)
 
         return self.dataset
+
+    def _parse_available_splits(
+        self, dataset_dir: Path, **kwargs
+    ) -> dict[str, list[Path]]:
+        split_definitions: dict[str, list[Path]] = {}
+        for split_name, split_kwargs in self.discover_dir_splits(
+            dataset_dir
+        ).items():
+            split_definitions[split_name] = self._parse_split(
+                **split_kwargs, **kwargs
+            )
+        return split_definitions
 
     def _apply_counts_to_splits(
         self,

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 import pycocotools.mask as mask_util
 from loguru import logger
+from typing_extensions import override
 
 from luxonis_ml.data import DatasetIterator
 from luxonis_ml.data.utils import COCOFormat
@@ -125,6 +126,7 @@ class COCOParser(BaseParser):
         return all(cls.validate_split(dataset_dir / split) for split in splits)
 
     @classmethod
+    @override
     def discover_dir_splits(
         cls, dataset_dir: Path
     ) -> dict[str, dict[str, Any]]:
@@ -418,6 +420,7 @@ class COCOParser(BaseParser):
 
         return generator(), skeletons, added_images
 
+    @override
     def _parse_available_splits(
         self,
         dataset_dir: Path,

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -79,10 +79,16 @@ class COCOParser(BaseParser):
                         else (COCOFormat.ROBOFLOW, rf)
                     )
 
-            if "test" in existing:
-                split_info = COCOParser.validate_split(dataset_dir / "test")
+            # Partial layouts like train-only are ambiguous by directory
+            # names alone, so inspect the annotation filename inside any
+            # present split to distinguish Roboflow from FiftyOne.
+            for split_name in fo:
+                split_info = COCOParser.validate_split(
+                    dataset_dir / split_name
+                )
                 if split_info is not None:
                     annotation_name = split_info["annotation_path"].name
+                    # ROBOFLOW has _annotations.coco.json while FIFTYONE has labels.json
                     if annotation_name == "_annotations.coco.json":
                         return COCOFormat.ROBOFLOW, rf
                     return COCOFormat.FIFTYONE, fo

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -70,6 +70,23 @@ class COCOParser(BaseParser):
         fo = [s for s in fiftyone_splits if s in existing]
         rf = [s for s in roboflow_splits if s in existing]
 
+        if len(fo) != 0 and len(fo) == len(rf):
+            for split_name in ("validation", "valid"):
+                if split_name in existing:
+                    return (
+                        (COCOFormat.FIFTYONE, fo)
+                        if split_name == "validation"
+                        else (COCOFormat.ROBOFLOW, rf)
+                    )
+
+            if "test" in existing:
+                split_info = COCOParser.validate_split(dataset_dir / "test")
+                if split_info is not None:
+                    annotation_name = split_info["annotation_path"].name
+                    if annotation_name == "_annotations.coco.json":
+                        return COCOFormat.ROBOFLOW, rf
+                    return COCOFormat.FIFTYONE, fo
+
         if len(fo) != 0 and len(fo) >= len(rf):
             return COCOFormat.FIFTYONE, fo
         if len(rf) != 0:

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -149,6 +149,24 @@ class COCOParser(BaseParser):
         keypoint_ann_paths: dict[str, str] | None = None,
         split_val_to_test: bool = True,
     ) -> tuple[list[Path], list[Path], list[Path]]:
+        split_definitions = self._parse_available_splits(
+            dataset_dir,
+            use_keypoint_ann=use_keypoint_ann,
+            keypoint_ann_paths=keypoint_ann_paths,
+            split_val_to_test=split_val_to_test,
+        )
+        return (
+            split_definitions.get("train", []),
+            split_definitions.get("val", []),
+            split_definitions.get("test", []),
+        )
+
+    def _resolve_dir_format_and_keypoint_paths(
+        self,
+        dataset_dir: Path,
+        use_keypoint_ann: bool,
+        keypoint_ann_paths: dict[str, str] | None,
+    ) -> tuple[COCOFormat, list[str], dict[str, str] | None]:
         dir_format, splits = COCOParser._detect_dataset_dir_format(dataset_dir)
         if dir_format is None:
             raise ValueError("Dataset is not in any expected format.")
@@ -169,86 +187,31 @@ class COCOParser(BaseParser):
                 # NOTE: this file is not present by default
                 "test": "raw/person_keypoints_test2017.json",
             }
+        return dir_format, splits, keypoint_ann_paths
 
-        train_paths = COCOParser.validate_split(dataset_dir / splits[0])
-        if train_paths is None:
-            raise ValueError("Train split not in expected format")
+    def _finalize_split_definitions(
+        self,
+        split_definitions: dict[str, list[Path]],
+        split_val_to_test: bool,
+    ) -> dict[str, list[Path]]:
+        added_test_imgs = split_definitions.get("test", [])
+        added_val_imgs = split_definitions.get("val", [])
 
-        train_ann_path = (
-            dataset_dir / keypoint_ann_paths["train"]
-            if keypoint_ann_paths
-            and use_keypoint_ann
-            and dir_format is COCOFormat.FIFTYONE
-            else train_paths["annotation_path"]
-        )
-        cleaned_annotation_path = clean_annotations(train_ann_path)
-        added_train_imgs = self._parse_split(
-            image_dir=train_paths["image_dir"],
-            annotation_path=cleaned_annotation_path,
-        )
-
-        val_paths = COCOParser.validate_split(dataset_dir / splits[1])
-        if val_paths is None:
-            raise ValueError("Val split not in expected format")
-
-        val_ann_path = (
-            dataset_dir / keypoint_ann_paths["val"]
-            if keypoint_ann_paths
-            and use_keypoint_ann
-            and dir_format is COCOFormat.FIFTYONE
-            else val_paths["annotation_path"]
-        )
-        _added_val_imgs = self._parse_split(
-            image_dir=val_paths["image_dir"], annotation_path=val_ann_path
-        )
-
-        if len(splits) < 3:
-            # No test split in dataset
-            added_test_imgs = []
-        else:
-            # NOTE: test split annotations are not included by default for FiftyOne format
-            test_paths = COCOParser.validate_split(dataset_dir / splits[2])
-            if test_paths is None:
-                raise ValueError("Test split not in expected format")
-
-            if (
-                keypoint_ann_paths
-                and use_keypoint_ann
-                and dir_format == COCOFormat.FIFTYONE
-            ):
-                kp_path = dataset_dir / keypoint_ann_paths["test"]
-                if kp_path.exists():
-                    added_test_imgs = self._parse_split(
-                        image_dir=test_paths["image_dir"],
-                        annotation_path=kp_path,
-                    )
-                else:
-                    logger.warning(
-                        f"Keypoint annotation file not found: {kp_path}. "
-                        "Skipping test split."
-                    )
-                    added_test_imgs = []
-            else:
-                added_test_imgs = self._parse_split(
-                    image_dir=test_paths["image_dir"],
-                    annotation_path=test_paths["annotation_path"],
-                )
-            if len(added_test_imgs) == 0 and not split_val_to_test:
-                logger.warning(
-                    "Sampling from the test set cannot be done since the "
-                    "labels are missing. This is expected for COCO datasets "
-                    "where the test set annotations are not publicly available."
-                )
-
-        # If test split is empty (no test directory or no annotations), split val into val/test
-        if len(added_test_imgs) == 0 and split_val_to_test:
-            split_point = round(len(_added_val_imgs) * 0.5)
-            added_val_imgs = _added_val_imgs[:split_point]
-            added_test_imgs = _added_val_imgs[split_point:]
-        else:
-            added_val_imgs = _added_val_imgs
-
-        return added_train_imgs, added_val_imgs, added_test_imgs
+        if len(added_test_imgs) == 0 and split_val_to_test and added_val_imgs:
+            split_point = round(len(added_val_imgs) * 0.5)
+            split_definitions["val"] = added_val_imgs[:split_point]
+            split_definitions["test"] = added_val_imgs[split_point:]
+        elif (
+            len(added_test_imgs) == 0
+            and not split_val_to_test
+            and "test" in split_definitions
+        ):
+            logger.warning(
+                "Sampling from the test set cannot be done since the "
+                "labels are missing. This is expected for COCO datasets "
+                "where the test set annotations are not publicly available."
+            )
+        return split_definitions
 
     def from_split(
         self, image_dir: Path, annotation_path: Path
@@ -428,21 +391,13 @@ class COCOParser(BaseParser):
         keypoint_ann_paths: dict[str, str] | None = None,
         split_val_to_test: bool = True,
     ) -> dict[str, list[Path]]:
-        dir_format, splits = COCOParser._detect_dataset_dir_format(dataset_dir)
-        if dir_format is None:
-            raise ValueError("Dataset is not in any expected format.")
-
-        if dir_format is COCOFormat.ROBOFLOW:
-            logger.warning(
-                "Roboflow dataset format detected, following arguments won't be taken "
-                "into account: ['use_keypoint_ann', 'keypoint_ann_paths', 'split_val_to_test']."
+        dir_format, splits, keypoint_ann_paths = (
+            self._resolve_dir_format_and_keypoint_paths(
+                dataset_dir,
+                use_keypoint_ann=use_keypoint_ann,
+                keypoint_ann_paths=keypoint_ann_paths,
             )
-        elif use_keypoint_ann and not keypoint_ann_paths:
-            keypoint_ann_paths = {
-                "train": "raw/person_keypoints_train2017.json",
-                "val": "raw/person_keypoints_val2017.json",
-                "test": "raw/person_keypoints_test2017.json",
-            }
+        )
 
         split_definitions: dict[str, list[Path]] = {}
 
@@ -485,25 +440,9 @@ class COCOParser(BaseParser):
                 annotation_path=annotation_path,
             )
 
-        added_test_imgs = split_definitions.get("test", [])
-        added_val_imgs = split_definitions.get("val", [])
-
-        if len(added_test_imgs) == 0 and split_val_to_test and added_val_imgs:
-            split_point = round(len(added_val_imgs) * 0.5)
-            split_definitions["val"] = added_val_imgs[:split_point]
-            split_definitions["test"] = added_val_imgs[split_point:]
-        elif (
-            len(added_test_imgs) == 0
-            and not split_val_to_test
-            and "test" in split_definitions
-        ):
-            logger.warning(
-                "Sampling from the test set cannot be done since the "
-                "labels are missing. This is expected for COCO datasets "
-                "where the test set annotations are not publicly available."
-            )
-
-        return split_definitions
+        return self._finalize_split_definitions(
+            split_definitions, split_val_to_test
+        )
 
 
 def clean_annotations(annotation_path: Path) -> Path:

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -124,6 +124,22 @@ class COCOParser(BaseParser):
 
         return all(cls.validate_split(dataset_dir / split) for split in splits)
 
+    @classmethod
+    def discover_dir_splits(
+        cls, dataset_dir: Path
+    ) -> dict[str, dict[str, Any]]:
+        dir_format, splits = cls._detect_dataset_dir_format(dataset_dir)
+        if dir_format is None:
+            return {}
+
+        discovered: dict[str, dict[str, Any]] = {}
+        for split_name in splits:
+            split_kwargs = cls.validate_split(dataset_dir / split_name)
+            if split_kwargs is None:
+                continue
+            discovered[cls._canonicalize_split_name(split_name)] = split_kwargs
+        return discovered
+
     def from_dir(
         self,
         dataset_dir: Path,
@@ -401,6 +417,90 @@ class COCOParser(BaseParser):
         added_images = self._get_added_images(generator())
 
         return generator(), skeletons, added_images
+
+    def _parse_available_splits(
+        self,
+        dataset_dir: Path,
+        use_keypoint_ann: bool = False,
+        keypoint_ann_paths: dict[str, str] | None = None,
+        split_val_to_test: bool = True,
+    ) -> dict[str, list[Path]]:
+        dir_format, splits = COCOParser._detect_dataset_dir_format(dataset_dir)
+        if dir_format is None:
+            raise ValueError("Dataset is not in any expected format.")
+
+        if dir_format is COCOFormat.ROBOFLOW:
+            logger.warning(
+                "Roboflow dataset format detected, following arguments won't be taken "
+                "into account: ['use_keypoint_ann', 'keypoint_ann_paths', 'split_val_to_test']."
+            )
+        elif use_keypoint_ann and not keypoint_ann_paths:
+            keypoint_ann_paths = {
+                "train": "raw/person_keypoints_train2017.json",
+                "val": "raw/person_keypoints_val2017.json",
+                "test": "raw/person_keypoints_test2017.json",
+            }
+
+        split_definitions: dict[str, list[Path]] = {}
+
+        for split_name in splits:
+            split_kwargs = COCOParser.validate_split(dataset_dir / split_name)
+            if split_kwargs is None:
+                raise ValueError(
+                    f"{split_name.title()} split not in expected format"
+                )
+
+            canonical_name = self._canonicalize_split_name(split_name)
+            annotation_path = split_kwargs["annotation_path"]
+
+            if (
+                keypoint_ann_paths
+                and use_keypoint_ann
+                and dir_format is COCOFormat.FIFTYONE
+            ):
+                if canonical_name == "test":
+                    kp_path = dataset_dir / keypoint_ann_paths["test"]
+                    if kp_path.exists():
+                        annotation_path = kp_path
+                    else:
+                        logger.warning(
+                            f"Keypoint annotation file not found: {kp_path}. "
+                            "Skipping test split."
+                        )
+                        split_definitions["test"] = []
+                        continue
+                else:
+                    annotation_path = (
+                        dataset_dir / keypoint_ann_paths[canonical_name]
+                    )
+
+            if canonical_name == "train":
+                annotation_path = clean_annotations(annotation_path)
+
+            split_definitions[canonical_name] = self._parse_split(
+                image_dir=split_kwargs["image_dir"],
+                annotation_path=annotation_path,
+            )
+
+        added_test_imgs = split_definitions.get("test", [])
+        added_val_imgs = split_definitions.get("val", [])
+
+        if len(added_test_imgs) == 0 and split_val_to_test and added_val_imgs:
+            split_point = round(len(added_val_imgs) * 0.5)
+            split_definitions["val"] = added_val_imgs[:split_point]
+            split_definitions["test"] = added_val_imgs[split_point:]
+        elif (
+            len(added_test_imgs) == 0
+            and not split_val_to_test
+            and "test" in split_definitions
+        ):
+            logger.warning(
+                "Sampling from the test set cannot be done since the "
+                "labels are missing. This is expected for COCO datasets "
+                "where the test set annotations are not publicly available."
+            )
+
+        return split_definitions
 
 
 def clean_annotations(annotation_path: Path) -> Path:

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -63,6 +63,8 @@ class LuxonisParser(Generic[T]):
         DatasetType.YOLOV8KEYPOINTS: YOLOv8Parser,
     }
 
+    _YOLO_AMBIGUOUS_PARSERS = {YoloV6Parser, YOLOv8Parser}
+
     def __init__(
         self,
         dataset_dir: str,
@@ -137,13 +139,8 @@ class LuxonisParser(Generic[T]):
 
         if dataset_type:
             self.dataset_type = dataset_type
-            self.parser_type = (
-                ParserType.DIR
-                if Path(self.dataset_dir / "train").exists()
-                or Path(
-                    self.dataset_dir / "images" / "train"
-                ).exists()  # temporary fix for yolov6
-                else ParserType.SPLIT
+            self.parser_type = self._infer_parser_type_for_explicit_type(
+                self.dataset_type
             )
         else:
             self.dataset_type, self.parser_type = self._recognize_dataset()
@@ -269,6 +266,30 @@ class LuxonisParser(Generic[T]):
                 logger.info(f"Recognized dataset format as <{typ.name}>")
                 return typ, ParserType.DIR
 
+        subset_matches: dict[type[BaseParser], DatasetType] = {}
+        for typ, parser in self.parsers.items():
+            if parser in subset_matches:
+                continue
+            if parser.discover_dir_splits(self.dataset_dir):
+                subset_matches[parser] = typ
+
+        if len(subset_matches) == 1:
+            typ = next(iter(subset_matches.values()))
+            logger.info(
+                f"Recognized dataset format as <{typ.name}> from partial splits"
+            )
+            return typ, ParserType.DIR
+
+        if len(subset_matches) > 1:
+            matched_parsers = set(subset_matches)
+            if matched_parsers == self._YOLO_AMBIGUOUS_PARSERS:
+                raise ValueError(
+                    "Dataset layout is compatible with multiple parsers when "
+                    "only a subset of splits is present. This layout is "
+                    "ambiguous between YOLOv6 and YOLOv8. Please specify "
+                    "dataset_type."
+                )
+
         for typ, parser in self.parsers.items():
             if parser.validate_split(self.dataset_dir):
                 logger.info(
@@ -278,6 +299,21 @@ class LuxonisParser(Generic[T]):
 
         raise ValueError(
             f"Dataset {self.dataset_dir} is not in expected format for any of the parsers."
+        )
+
+    def _infer_parser_type_for_explicit_type(
+        self, dataset_type: DatasetType
+    ) -> ParserType:
+        parser = self.parsers[dataset_type]
+        if parser.validate(self.dataset_dir) or parser.discover_dir_splits(
+            self.dataset_dir
+        ):
+            return ParserType.DIR
+        if parser.validate_split(self.dataset_dir):
+            return ParserType.SPLIT
+        raise ValueError(
+            f"Dataset {self.dataset_dir} is not in expected format for the "
+            f"{dataset_type.name} parser."
         )
 
     def _parse_dir(self, **kwargs) -> BaseDataset:

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -63,8 +63,6 @@ class LuxonisParser(Generic[T]):
         DatasetType.YOLOV8KEYPOINTS: YOLOv8Parser,
     }
 
-    _YOLO_AMBIGUOUS_PARSERS = {YoloV6Parser, YOLOv8Parser}
-
     def __init__(
         self,
         dataset_dir: str,
@@ -261,41 +259,49 @@ class LuxonisParser(Generic[T]):
         @rtype: Tuple[DatasetType, ParserType]
         @return: Tuple of dataset type and parser type.
         """
-        for typ, parser in self.parsers.items():
+        for dataset_type, parser in self.parsers.items():
             if parser.validate(self.dataset_dir):
-                logger.info(f"Recognized dataset format as <{typ.name}>")
-                return typ, ParserType.DIR
+                logger.info(
+                    f"Recognized dataset format as <{dataset_type.name}>"
+                )
+                return dataset_type, ParserType.DIR
 
         subset_matches: dict[type[BaseParser], DatasetType] = {}
-        for typ, parser in self.parsers.items():
+        for dataset_type, parser in self.parsers.items():
+            # The same YoloV8 or UltralyticsNDJSON parser can correspond to multiple dataset types.
             if parser in subset_matches:
                 continue
             if parser.discover_dir_splits(self.dataset_dir):
-                subset_matches[parser] = typ
+                subset_matches[parser] = dataset_type
 
         if len(subset_matches) == 1:
-            typ = next(iter(subset_matches.values()))
+            dataset_type = next(iter(subset_matches.values()))
             logger.info(
-                f"Recognized dataset format as <{typ.name}> from partial splits"
+                f"Recognized dataset format as <{dataset_type.name}> from partial splits"
             )
-            return typ, ParserType.DIR
+            return dataset_type, ParserType.DIR
 
         if len(subset_matches) > 1:
             matched_parsers = set(subset_matches)
-            if matched_parsers == self._YOLO_AMBIGUOUS_PARSERS:
+            if matched_parsers == {YoloV6Parser, YOLOv8Parser}:
                 raise ValueError(
                     "Dataset layout is compatible with multiple parsers when "
                     "only a subset of splits is present. This layout is "
                     "ambiguous between YOLOv6 and YOLOv8. Please specify "
                     "dataset_type."
                 )
+            raise ValueError(
+                "Dataset layout is compatible with multiple parsers when "
+                "only a subset of splits is present. Please specify "
+                "dataset_type."
+            )
 
-        for typ, parser in self.parsers.items():
+        for dataset_type, parser in self.parsers.items():
             if parser.validate_split(self.dataset_dir):
                 logger.info(
-                    f"Recognized dataset format as a split of <{typ.name}>"
+                    f"Recognized dataset format as a split of <{dataset_type.name}>"
                 )
-                return typ, ParserType.SPLIT
+                return dataset_type, ParserType.SPLIT
 
         raise ValueError(
             f"Dataset {self.dataset_dir} is not in expected format for any of the parsers."

--- a/luxonis_ml/data/parsers/yolov6_parser.py
+++ b/luxonis_ml/data/parsers/yolov6_parser.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from typing_extensions import override
 
 from luxonis_ml.data import DatasetIterator
 
@@ -72,9 +73,11 @@ class YoloV6Parser(BaseParser):
         return all(cls.validate_split(img_root / s) for s in splits)
 
     @classmethod
+    @override
     def discover_dir_splits(
         cls, dataset_dir: Path
     ) -> dict[str, dict[str, Any]]:
+        # Split roots live under images/<split> instead of <split>/.
         img_root = dataset_dir / "images"
         if not img_root.exists():
             return {}

--- a/luxonis_ml/data/parsers/yolov6_parser.py
+++ b/luxonis_ml/data/parsers/yolov6_parser.py
@@ -71,6 +71,22 @@ class YoloV6Parser(BaseParser):
             return False
         return all(cls.validate_split(img_root / s) for s in splits)
 
+    @classmethod
+    def discover_dir_splits(
+        cls, dataset_dir: Path
+    ) -> dict[str, dict[str, Any]]:
+        img_root = dataset_dir / "images"
+        if not img_root.exists():
+            return {}
+
+        discovered: dict[str, dict[str, Any]] = {}
+        for split_name in ("train", "valid", "test"):
+            split_kwargs = cls.validate_split(img_root / split_name)
+            if split_kwargs is None:
+                continue
+            discovered[cls._canonicalize_split_name(split_name)] = split_kwargs
+        return discovered
+
     def from_dir(
         self, dataset_dir: Path
     ) -> tuple[list[Path], list[Path], list[Path]]:

--- a/luxonis_ml/data/parsers/yolov8_parser.py
+++ b/luxonis_ml/data/parsers/yolov8_parser.py
@@ -5,6 +5,7 @@ from typing import Any
 import cv2
 import numpy as np
 import yaml
+from typing_extensions import override
 
 from luxonis_ml.data import DatasetIterator
 
@@ -194,9 +195,11 @@ class YOLOv8Parser(BaseParser):
         return False
 
     @classmethod
+    @override
     def discover_dir_splits(
         cls, dataset_dir: Path
     ) -> dict[str, dict[str, Any]]:
+        # Split roots may live under images/<split> instead of <split>/.
         dir_format, _splits = cls._detect_dataset_dir_format(dataset_dir)
         if dir_format is None:
             return {}

--- a/luxonis_ml/data/parsers/yolov8_parser.py
+++ b/luxonis_ml/data/parsers/yolov8_parser.py
@@ -184,12 +184,43 @@ class YOLOv8Parser(BaseParser):
                 for d in (dataset_dir / "images").iterdir()
                 if d.is_dir()
             ]
+            if "train" not in subfolders or len(subfolders) < 2:
+                return False
             return all(
                 cls.validate_split(dataset_dir / "images" / split)
                 for split in subfolders
             )
 
         return False
+
+    @classmethod
+    def discover_dir_splits(
+        cls, dataset_dir: Path
+    ) -> dict[str, dict[str, Any]]:
+        dir_format, _splits = cls._detect_dataset_dir_format(dataset_dir)
+        if dir_format is None:
+            return {}
+
+        discovered: dict[str, dict[str, Any]] = {}
+        if dir_format is Format.ROBOFLOW:
+            split_paths = [
+                dataset_dir / split_name
+                for split_name in ("train", "valid", "test")
+            ]
+        else:
+            split_paths = [
+                dataset_dir / "images" / split_name
+                for split_name in ("train", "val", "test")
+            ]
+
+        for split_path in split_paths:
+            split_kwargs = cls.validate_split(split_path)
+            if split_kwargs is None:
+                continue
+            discovered[cls._canonicalize_split_name(split_path.name)] = (
+                split_kwargs
+            )
+        return discovered
 
     def from_dir(
         self, dataset_dir: Path

--- a/luxonis_ml/data/parsers/yolov8_parser.py
+++ b/luxonis_ml/data/parsers/yolov8_parser.py
@@ -97,13 +97,16 @@ class YOLOv8Parser(BaseParser):
     ) -> tuple[Format | None, list[str]]:
         """Checks if dataset directory structure is in Ultralytics or
         Roboflow format."""
-        roboflow_folders = ["train", "valid"]  # test folder is optional
+        roboflow_splits = ("train", "valid", "test")
         ultralytics_folders = ["images", "labels"]
 
         existing = [d.name for d in dataset_dir.iterdir() if d.is_dir()]
 
-        if all(folder in existing for folder in roboflow_folders):
-            return Format.ROBOFLOW, existing
+        present_roboflow_splits = [
+            split for split in roboflow_splits if split in existing
+        ]
+        if present_roboflow_splits:
+            return Format.ROBOFLOW, present_roboflow_splits
         if all(folder in existing for folder in ultralytics_folders):
             return Format.ULTRALYTICS, existing
         return None, []

--- a/tests/test_data/test_coco_imagenet_parsing.py
+++ b/tests/test_data/test_coco_imagenet_parsing.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -314,6 +315,54 @@ class TestCoco2017Keypoints:
 
         assert len(dataset) > 0
         assert "keypoints" in _task_types(dataset)
+
+    def test_keypoints_validation_only_keeps_coco_exception(
+        self,
+        coco_2017_source: Path,
+        dataset_name: str,
+        tempdir: Path,
+    ):
+        dataset_dir = tempdir / "coco-2017-validation-only"
+        shutil.copytree(coco_2017_source, dataset_dir)
+        shutil.rmtree(dataset_dir / "train", ignore_errors=True)
+        shutil.rmtree(dataset_dir / "test", ignore_errors=True)
+
+        parser = LuxonisParser(
+            str(dataset_dir),
+            dataset_name=dataset_name,
+            delete_local=True,
+        )
+        dataset = parser.parse(use_keypoint_ann=True)
+
+        counts = _split_counts(dataset)
+        assert "train" not in counts
+        assert counts.get("val", 0) > 0
+        assert counts.get("test", 0) > 0
+        assert counts["val"] == counts["test"]
+
+    def test_keypoints_validation_only_explicit_type(
+        self,
+        coco_2017_source: Path,
+        dataset_name: str,
+        tempdir: Path,
+    ):
+        dataset_dir = tempdir / "coco-2017-validation-only-explicit"
+        shutil.copytree(coco_2017_source, dataset_dir)
+        shutil.rmtree(dataset_dir / "train", ignore_errors=True)
+        shutil.rmtree(dataset_dir / "test", ignore_errors=True)
+
+        parser = LuxonisParser(
+            str(dataset_dir),
+            dataset_name=dataset_name,
+            dataset_type="coco",  # type: ignore[arg-type]
+            delete_local=True,
+        )
+        dataset = parser.parse(use_keypoint_ann=True)
+
+        counts = _split_counts(dataset)
+        assert "train" not in counts
+        assert counts.get("val", 0) > 0
+        assert counts.get("test", 0) > 0
 
 
 class TestImagenetSample:

--- a/tests/test_data/test_coco_imagenet_parsing.py
+++ b/tests/test_data/test_coco_imagenet_parsing.py
@@ -335,7 +335,7 @@ class TestCoco2017Keypoints:
         dataset = parser.parse(use_keypoint_ann=True)
 
         counts = _split_counts(dataset)
-        assert "train" not in counts
+        assert counts.get("train", 0) == 0
         assert counts.get("val", 0) > 0
         assert counts.get("test", 0) > 0
         assert counts["val"] == counts["test"]
@@ -360,7 +360,7 @@ class TestCoco2017Keypoints:
         dataset = parser.parse(use_keypoint_ann=True)
 
         counts = _split_counts(dataset)
-        assert "train" not in counts
+        assert counts.get("train", 0) == 0
         assert counts.get("val", 0) > 0
         assert counts.get("test", 0) > 0
 

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -532,8 +532,10 @@ def test_partial_split_clsdir_is_preserved(
 
     splits = dataset.get_splits()
     assert splits is not None
-    assert set(splits) == {"val"}
+    assert set(splits) == {"train", "val", "test"}
+    assert len(splits["train"]) == 0
     assert len(splits["val"]) == 1
+    assert len(splits["test"]) == 0
     dataset.delete_dataset(delete_local=True)
 
 
@@ -556,8 +558,54 @@ def test_partial_split_clsdir_explicit_type_uses_dir_mode(
 
     splits = dataset.get_splits()
     assert splits is not None
-    assert set(splits) == {"test"}
+    assert set(splits) == {"train", "val", "test"}
+    assert len(splits["train"]) == 0
+    assert len(splits["val"]) == 0
     assert len(splits["test"]) == 1
+    dataset.delete_dataset(delete_local=True)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_split_sizes", "loader_view"),
+    [
+        (
+            "coco_valid_only_debug.zip",
+            {"train": 0, "val": 2, "test": 1},
+            "val",
+        ),
+        (
+            "native_val_only_debug.zip",
+            {"train": 0, "val": 3, "test": 0},
+            "val",
+        ),
+    ],
+)
+def test_partial_split_fixture_is_preserved(
+    dataset_name: str,
+    storage_url: str,
+    tempdir: Path,
+    url: str,
+    expected_split_sizes: dict[str, int],
+    loader_view: str,
+):
+    dataset = LuxonisParser(
+        f"{storage_url.rstrip('/')}/{url}",
+        dataset_name=dataset_name,
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+
+    splits = dataset.get_splits()
+    assert splits is not None
+    assert set(splits) == {"train", "val", "test"}
+    assert {
+        split_name: len(group_ids) for split_name, group_ids in splits.items()
+    } == expected_split_sizes
+
+    loader = LuxonisLoader(dataset, view=loader_view)
+    _, ann = next(iter(loader))
+    task_types = {get_task_type(task) for task in ann}
+    assert task_types == {"boundingbox", "classification"}
     dataset.delete_dataset(delete_local=True)
 
 

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -634,3 +634,54 @@ def test_partial_ultralytics_layout_reports_yolov6_yolov8_ambiguity(
             delete_local=True,
             save_dir=tempdir,
         ).parse()
+
+
+def test_partial_split_train_only_roboflow_coco_keeps_format_detection(
+    dataset_name: str,
+    tempdir: Path,
+):
+    dataset_dir = tempdir / "coco_train_only_roboflow"
+    train_dir = dataset_dir / "train"
+    train_dir.mkdir(parents=True)
+    create_image(16, train_dir)
+    (train_dir / "_annotations.coco.json").write_text(
+        json.dumps(
+            {
+                "images": [
+                    {
+                        "id": 1,
+                        "file_name": "img_16.jpg",
+                        "width": 512,
+                        "height": 512,
+                    }
+                ],
+                "annotations": [
+                    {
+                        "id": 1,
+                        "image_id": 1,
+                        "category_id": 0,
+                        "bbox": [128, 128, 256, 256],
+                        "area": 65536,
+                        "iscrowd": 0,
+                    }
+                ],
+                "categories": [{"id": 0, "name": "budgie"}],
+            }
+        )
+    )
+
+    dataset = LuxonisParser(
+        str(dataset_dir),
+        dataset_name=dataset_name,
+        dataset_type="coco",  # type: ignore[arg-type]
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse(use_keypoint_ann=True)
+
+    splits = dataset.get_splits()
+    assert splits is not None
+    assert set(splits) == {"train", "val", "test"}
+    assert len(splits["train"]) == 1
+    assert len(splits["val"]) == 0
+    assert len(splits["test"]) == 0
+    dataset.delete_dataset(delete_local=True)

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -512,3 +512,77 @@ def test_ultralytics_ndjson_remote_urls_parser_rejects_existing_remote_dir(
             delete_local=True,
             save_dir=tempdir,
         ).parse()
+
+
+def test_partial_split_clsdir_is_preserved(
+    dataset_name: str,
+    tempdir: Path,
+):
+    dataset_dir = tempdir / "clsdir_partial"
+    split_dir = dataset_dir / "valid" / "budgie"
+    split_dir.mkdir(parents=True)
+    create_image(16, split_dir)
+
+    dataset = LuxonisParser(
+        str(dataset_dir),
+        dataset_name=dataset_name,
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+
+    splits = dataset.get_splits()
+    assert splits is not None
+    assert set(splits) == {"val"}
+    assert len(splits["val"]) == 1
+    dataset.delete_dataset(delete_local=True)
+
+
+def test_partial_split_clsdir_explicit_type_uses_dir_mode(
+    dataset_name: str,
+    tempdir: Path,
+):
+    dataset_dir = tempdir / "clsdir_partial_explicit"
+    split_dir = dataset_dir / "test" / "finch"
+    split_dir.mkdir(parents=True)
+    create_image(16, split_dir)
+
+    dataset = LuxonisParser(
+        str(dataset_dir),
+        dataset_name=dataset_name,
+        dataset_type="clsdir",  # type: ignore[arg-type]
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+
+    splits = dataset.get_splits()
+    assert splits is not None
+    assert set(splits) == {"test"}
+    assert len(splits["test"]) == 1
+    dataset.delete_dataset(delete_local=True)
+
+
+def test_partial_ultralytics_layout_reports_yolov6_yolov8_ambiguity(
+    dataset_name: str,
+    tempdir: Path,
+):
+    dataset_dir = tempdir / "yolo_partial"
+    image_dir = dataset_dir / "images" / "test"
+    label_dir = dataset_dir / "labels" / "test"
+    image_dir.mkdir(parents=True)
+    label_dir.mkdir(parents=True)
+    create_image(16, image_dir)
+    (label_dir / "img_16.txt").write_text("0 0.5 0.5 0.4 0.4\n")
+    (dataset_dir / "data.yaml").write_text("names:\n  0: budgie\n")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"ambiguous between YOLOv6 and YOLOv8\. Please specify dataset_type\."
+        ),
+    ):
+        LuxonisParser(
+            str(dataset_dir),
+            dataset_name=dataset_name,
+            delete_local=True,
+            save_dir=tempdir,
+        ).parse()


### PR DESCRIPTION
## Purpose
- Change `BaseParser.parse_dir()` to discover and parse only the present split directories instead of assuming the full train/val/test layout.
- Update `LuxonisParser` so passing `dataset_type=..`. works even when `train/` is absent
- YoloV8 and Yolov6 layouts are distinguished by `val` vs. `valid` for the validation split, so if this split doesn't exist then ask for explicit `dataset_type` to be passed

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
- Added `native_val_only_debug.zip` and `coco_valid_only_debug.zip` to GCP and wrote tests from these

Manual testing:

1) COCO only val still splits into test
<img width="486" height="738" alt="parse_coco_val_only" src="https://github.com/user-attachments/assets/18413ed3-9355-4aca-aa36-27324507e1e5" />

2) Parse Native format with only validation
<img width="510" height="736" alt="parse_native_only_val" src="https://github.com/user-attachments/assets/38b36efb-3295-4530-91f4-20a13c5d37e9" />

3) With only one split, we can still use `--split-ratio "[0.33,0.33,0.34]"` to re-distribute images across splits
<img width="491" height="738" alt="parse_native_only_val_split_ratio" src="https://github.com/user-attachments/assets/56d13e0b-674a-46da-9edd-03412a730845" />

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Codex

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical split discovery and handling across parsers, with support for partial and validation-only layouts and smarter format detection.
  * Improved automatic val→test splitting and handling of keypoint/annotation overrides; preserves sampling behavior and cleans training annotations.

* **Bug Fixes**
  * Clearer errors and warnings for ambiguous or missing split layouts; more reliable behavior when train/val/test folders are absent.

* **Tests**
  * Added coverage for partial splits, validation-only datasets, explicit-type handling, and format-ambiguity cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->