### PR TITLE
Ultralytics dataset auto-download

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,6 +155,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_S3_ENDPOINT_URL: ${{ secrets.AWS_S3_ENDPOINT_URL }}
       ROBOFLOW_API_KEY: ${{ secrets.ROBOFLOW_API_KEY }}
+      ULTRALYTICS_API_KEY: ${{ secrets.ULTRALYTICS_API_KEY }}
       LUXONISML_BUCKET: luxonis-test-bucket
       GHC_ENABLED: ${{ secrets.GCP_CREDENTIALS != null }}
 

--- a/luxonis_ml/data/augmentations/batch_transform.py
+++ b/luxonis_ml/data/augmentations/batch_transform.py
@@ -57,6 +57,8 @@ class BatchTransform(ABC, A.DualTransform):
     ) -> np.ndarray: ...
 
     def apply_to_array(self, array_batch: list[np.ndarray], **_) -> np.ndarray:
+        if all(arr.size == 0 for arr in array_batch):
+            return np.array([])
         return np.concatenate([arr for arr in array_batch if arr.size > 0])
 
     def apply_to_classification(

--- a/luxonis_ml/data/parsers/README.md
+++ b/luxonis_ml/data/parsers/README.md
@@ -28,7 +28,7 @@ The `LuxonisParser` class provides functionality for converting various dataset 
 
 | Parameter        | Type                                   | Default  | Description                                                                                                                     |
 | ---------------- | -------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `dataset_dir`    | `str`                                  | Required | Path or URL to dataset directory (local path, `gcs://`, `s3://` or `roboflow://`)                                               |
+| `dataset_dir`    | `str`                                  | Required | Path or URL to dataset directory (local path, `gcs://`, `s3://`, `roboflow://` or `ultralytics://`)                             |
 | `dataset_name`   | `Optional[str]`                        | `None`   | Name for the dataset (if None, derived from directory name)                                                                     |
 | `save_dir`       | `Optional[Union[Path, str]]`           | `None`   | Where to save downloaded datasets if remote URL is provided (if None, uses current directory)                                   |
 | `dataset_plugin` | `Optional[str]`                        | `None`   | Dataset plugin to use (if None, uses `LuxonisDataset`)                                                                          |

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -92,8 +92,8 @@ class LuxonisParser(Generic[T]):
                 - C{roboflow://} for Roboflow datasets.
                   - Expected format: C{roboflow://workspace/project/version/format}.
                 - C{ultralytics://} for Ultralytics Platform datasets.
-                  - Expected format:
-                    - C{ultralytics://username/datasets/slug}
+                    - Expected format: C{ultralytics://username/datasets/slug}
+                    - Optional version: append C{?v=<version>} to export a specific dataset version.
             Can be a remote URL supported by L{LuxonisFileSystem}.
         @type dataset_name: Optional[str]
         @param dataset_name: Name of the dataset. If C{None}, the name

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -501,7 +501,11 @@ class LuxonisParser(Generic[T]):
         file_stem = dataset["slug"]
         dataset_name = dataset["name"]
         local_path = local_path or Path.cwd()
-        destination = local_path / f"{file_stem}.ndjson"
+        destination = (
+            local_path / f"{file_stem}.v{version}.ndjson"
+            if version is not None
+            else local_path / f"{file_stem}.ndjson"
+        )
         download_remote_file(download_url, destination, timeout=120.0)
 
         return destination, dataset_name

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -5,11 +5,14 @@ from enum import Enum
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Generic, TypeVar, overload
+from urllib.parse import parse_qs, urlsplit
 
+import requests
 from loguru import logger
 
 from luxonis_ml.data import DATASETS_REGISTRY, BaseDataset, LuxonisDataset
 from luxonis_ml.data.utils.enums import ParserIssueMessage
+from luxonis_ml.data.utils.remote_file_downloader import download_remote_file
 from luxonis_ml.enums import DatasetType
 from luxonis_ml.utils import LuxonisFileSystem, environ
 from luxonis_ml.utils.filesystem import _pip_install
@@ -88,6 +91,9 @@ class LuxonisParser(Generic[T]):
                   - C{s3://} for Amazon S3
                 - C{roboflow://} for Roboflow datasets.
                   - Expected format: C{roboflow://workspace/project/version/format}.
+                - C{ultralytics://} for Ultralytics Platform datasets.
+                  - Expected format:
+                    - C{ultralytics://username/datasets/slug}
             Can be a remote URL supported by L{LuxonisFileSystem}.
         @type dataset_name: Optional[str]
         @param dataset_name: Name of the dataset. If C{None}, the name
@@ -118,6 +124,10 @@ class LuxonisParser(Generic[T]):
         save_dir = Path(save_dir) if save_dir else None
         if dataset_dir.startswith("roboflow://"):
             self.dataset_dir, name = self._download_roboflow_dataset(
+                dataset_dir, save_dir
+            )
+        elif dataset_dir.startswith("ultralytics://"):
+            self.dataset_dir, name = self._download_ultralytics_dataset(
                 dataset_dir, save_dir
             )
         else:
@@ -335,6 +345,12 @@ class LuxonisParser(Generic[T]):
     def _download_roboflow_dataset(
         self, dataset_dir: str, local_path: Path | None
     ) -> tuple[Path, str]:
+        if environ.ROBOFLOW_API_KEY is None:
+            raise RuntimeError(
+                "ROBOFLOW_API_KEY environment variable is not set. "
+                "Please set it to your Roboflow API key."
+            )
+
         if find_spec("roboflow") is None:  # pragma: no cover
             _pip_install("roboflow", "roboflow~=1.1.0")
             subprocess.run(
@@ -362,12 +378,6 @@ class LuxonisParser(Generic[T]):
 
         from roboflow import Roboflow
 
-        if environ.ROBOFLOW_API_KEY is None:
-            raise RuntimeError(
-                "ROBOFLOW_API_KEY environment variable is not set. "
-                "Please set it to your Roboflow API key."
-            )
-
         rf = Roboflow(api_key=environ.ROBOFLOW_API_KEY.get_secret_value())
         parts = dataset_dir.split("roboflow://")[1].split("/")
         if len(parts) != 4:
@@ -393,3 +403,105 @@ class LuxonisParser(Generic[T]):
             .download(format, str(local_path / project))
         )
         return Path(dataset.location), project
+
+    def _download_ultralytics_dataset(
+        self,
+        dataset_dir: str,
+        local_path: Path | None,
+    ) -> tuple[Path, str]:
+        if environ.ULTRALYTICS_API_KEY is None:
+            raise RuntimeError(
+                "ULTRALYTICS_API_KEY environment variable is not set. "
+                "Please set it to your Ultralytics API key."
+            )
+
+        ultralytics_api_base_url = "https://platform.ultralytics.com/api"
+        headers = {
+            "Authorization": (
+                f"Bearer {environ.ULTRALYTICS_API_KEY.get_secret_value()}"
+            ),
+            "User-Agent": "luxonis-ml",
+        }
+
+        parsed = urlsplit(dataset_dir)
+        raw_version = parse_qs(parsed.query).get("v", [None])[0]
+        version: int | None = None
+        if raw_version is not None:
+            try:
+                version = int(raw_version)
+            except ValueError as e:
+                raise ValueError(
+                    "Ultralytics dataset export version must be an integer, "
+                    f"got `{raw_version}`."
+                ) from e
+            if version < 1:
+                raise ValueError(
+                    "Ultralytics dataset export version must be >= 1, "
+                    f"got `{version}`."
+                )
+
+        path_parts = [part for part in parsed.path.split("/") if part]
+        if not (
+            parsed.scheme == "ultralytics"
+            and parsed.netloc
+            and len(path_parts) == 2
+            and path_parts[0] == "datasets"
+        ):
+            raise ValueError(
+                f"Incorrect Ultralytics dataset reference: `{dataset_dir}`. "
+                "Expected `ultralytics://username/datasets/slug`."
+            )
+
+        dataset_response = requests.get(
+            f"{ultralytics_api_base_url}/datasets",
+            headers=headers,
+            params={
+                "username": parsed.netloc,
+                "slug": path_parts[1],
+            },
+            timeout=30.0,
+        )
+        if not dataset_response.ok:
+            try:
+                error = dataset_response.json().get("error")
+            except ValueError:
+                error = dataset_response.text
+
+            raise RuntimeError(
+                f"Ultralytics API request failed "
+                f"({dataset_response.status_code}): {error}"
+            )
+
+        dataset = dataset_response.json()["dataset"]
+
+        dataset_id = dataset["_id"]
+
+        export_params = {"v": version} if version is not None else None
+        export_response = requests.get(
+            f"{ultralytics_api_base_url}/datasets/{dataset_id}/export",
+            headers=headers,
+            params=export_params,
+            timeout=120.0,
+        )
+        if not export_response.ok:
+            error = None
+            try:
+                payload = export_response.json()
+                error = payload.get("error")
+            except ValueError:
+                error = export_response.text.strip() or export_response.reason
+
+            detail = f"{export_response.status_code} {export_response.reason}"
+            if error:
+                detail = f"{detail}: {error}"
+            raise RuntimeError(f"Ultralytics API request failed: {detail}")
+
+        download_url = export_response.json()["downloadUrl"]
+
+        file_stem = dataset["slug"]
+        dataset_name = dataset["name"]
+        local_path = local_path or Path.cwd()
+        destination = local_path / f"{file_stem}.ndjson"
+        download_remote_file(download_url, destination, timeout=120.0)
+
+        return destination, dataset_name

--- a/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
+++ b/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
@@ -192,7 +192,7 @@ class UltralyticsNDJSONParser(BaseParser):
                                     f"Remote NDJSON image directory "
                                     f"'{remote_image_dir}' already exists."
                                 )
-                            logger.info(
+                            logger.warning(
                                 f"Reusing existing remote NDJSON image "
                                 f"directory '{remote_image_dir}'."
                             )

--- a/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
+++ b/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
@@ -40,7 +40,7 @@ class UltralyticsNDJSONParser(BaseParser):
         return cls._load_header(dataset_dir) is not None
 
     def from_dir(
-        self, dataset_dir: Path, reuse_cached: bool = True
+        self, dataset_dir: Path, reuse_cached: bool = True, **kwargs
     ) -> tuple[list[Path], list[Path], list[Path]]:
         ndjson_path = self._resolve_ndjson_path(dataset_dir)
         if ndjson_path is None:

--- a/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
+++ b/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
@@ -40,7 +40,7 @@ class UltralyticsNDJSONParser(BaseParser):
         return cls._load_header(dataset_dir) is not None
 
     def from_dir(
-        self, dataset_dir: Path
+        self, dataset_dir: Path, reuse_cached: bool = True
     ) -> tuple[list[Path], list[Path], list[Path]]:
         ndjson_path = self._resolve_ndjson_path(dataset_dir)
         if ndjson_path is None:
@@ -49,7 +49,7 @@ class UltralyticsNDJSONParser(BaseParser):
             )
 
         generator, added_by_split, _added_images = self._build_record_stream(
-            ndjson_path
+            ndjson_path, reuse_cached=reuse_cached
         )
         self.dataset.add(self._wrap_generator(generator))
         return (
@@ -58,14 +58,23 @@ class UltralyticsNDJSONParser(BaseParser):
             added_by_split["test"],
         )
 
-    def parse_dir(self, dataset_dir: Path, **kwargs) -> BaseDataset:
+    def parse_dir(
+        self,
+        dataset_dir: Path,
+        reuse_cached: bool = True,
+        **kwargs,
+    ) -> BaseDataset:
         self.reset_parser_issue_messages()
         split_ratios = kwargs.pop("split_ratios", None)
         is_counts = split_ratios is not None and all(
             isinstance(v, int) for v in split_ratios.values()
         )
 
-        train, val, test = self.from_dir(dataset_dir, **kwargs)
+        train, val, test = self.from_dir(
+            dataset_dir,
+            reuse_cached=reuse_cached,
+            **kwargs,
+        )
         original_splits: dict[str, Sequence[PathType]] = {
             "train": train,
             "val": val,
@@ -91,9 +100,13 @@ class UltralyticsNDJSONParser(BaseParser):
 
         return self.dataset
 
-    def from_split(self, ndjson_path: Path) -> ParserOutput:
+    def from_split(
+        self,
+        ndjson_path: Path,
+        reuse_cached: bool = True,
+    ) -> ParserOutput:
         generator, _added_by_split, added_images = self._build_record_stream(
-            ndjson_path
+            ndjson_path, reuse_cached=reuse_cached
         )
         return generator, {}, added_images
 
@@ -103,6 +116,7 @@ class UltralyticsNDJSONParser(BaseParser):
         split: str | None = None,
         random_split: bool = True,
         split_ratios: dict[str, float | int] | None = None,
+        reuse_cached: bool = True,
         **kwargs,
     ) -> BaseDataset:
         self.reset_parser_issue_messages()
@@ -111,7 +125,7 @@ class UltralyticsNDJSONParser(BaseParser):
             raise ValueError("`ndjson_path` is required for NDJSON parsing.")
 
         generator, added_by_split, added_images = self._build_record_stream(
-            ndjson_path
+            ndjson_path, reuse_cached=reuse_cached
         )
         self.dataset.add(self._wrap_generator(generator))
         split_definitions: dict[str, Sequence[PathType]] = dict(added_by_split)
@@ -142,7 +156,7 @@ class UltralyticsNDJSONParser(BaseParser):
         return self.dataset
 
     def _build_record_stream(
-        self, ndjson_path: Path
+        self, ndjson_path: Path, reuse_cached: bool = True
     ) -> tuple[DatasetIterator, dict[str, list[Path]], list[Path]]:
         header = self._load_header(ndjson_path)
         if header is None:
@@ -173,9 +187,14 @@ class UltralyticsNDJSONParser(BaseParser):
 
                     if record.get("url") and not remote_image_dir_checked:
                         if remote_image_dir.exists():
-                            raise ValueError(
-                                f"Remote NDJSON image directory "
-                                f"'{remote_image_dir}' already exists."
+                            if not reuse_cached:
+                                raise ValueError(
+                                    f"Remote NDJSON image directory "
+                                    f"'{remote_image_dir}' already exists."
+                                )
+                            logger.info(
+                                f"Reusing existing remote NDJSON image "
+                                f"directory '{remote_image_dir}'."
                             )
                         remote_image_dir_checked = True
 

--- a/luxonis_ml/utils/environ.py
+++ b/luxonis_ml/utils/environ.py
@@ -39,6 +39,7 @@ class Environ(BaseSettings):
     LUXONISML_DISABLE_SETUP_LOGGING: bool = False
 
     ROBOFLOW_API_KEY: SecretStr | None = None
+    ULTRALYTICS_API_KEY: SecretStr | None = None
 
     GOOGLE_APPLICATION_CREDENTIALS: SecretStr | None = None
 

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -572,7 +572,7 @@ def test_ultralytics_ndjson_remote_urls_parser_rejects_existing_remote_dir_when_
             dataset_name=dataset_name,
             delete_local=True,
             save_dir=tempdir,
-        ).parse(use_cached=False)
+        ).parse(reuse_cached=False)
 
 
 def test_partial_split_clsdir_is_preserved(

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -32,6 +32,10 @@ from .utils import create_image
             {"boundingbox", "classification"},
         ),
         (
+            "ultralytics://ultralytics/datasets/coco8",
+            {"boundingbox", "classification"},
+        ),
+        (
             "Thermal_Dogs_and_People.v1-resize-416x416.voc.zip",
             {"boundingbox", "classification"},
         ),
@@ -103,11 +107,15 @@ def test_dir_parser(
     storage_url: str,
     tempdir: Path,
 ):
-    if not url.startswith("roboflow://"):
+    if not url.startswith(("roboflow://", "ultralytics://")):
         url = f"{storage_url}/{url}"
-
-    elif environ.ROBOFLOW_API_KEY is None:
+    elif url.startswith("roboflow://") and environ.ROBOFLOW_API_KEY is None:
         pytest.skip("Roboflow API key is not set")
+    elif (
+        url.startswith("ultralytics://")
+        and environ.ULTRALYTICS_API_KEY is None
+    ):
+        pytest.skip("Ultralytics API key is not set")
 
     parser = LuxonisParser(
         url,
@@ -146,6 +154,11 @@ def test_dir_parser(
         (
             "roboflow://team-roboflow/coco-128/2/coco",
             "coco",
+            {"boundingbox", "classification"},
+        ),
+        (
+            "ultralytics://ultralytics/datasets/coco8",
+            "ultralytics-ndjson",
             {"boundingbox", "classification"},
         ),
         (
@@ -234,11 +247,15 @@ def test_dir_parser_explicit_type(
     storage_url: str,
     tempdir: Path,
 ):
-    if not url.startswith("roboflow://"):
+    if not url.startswith(("roboflow://", "ultralytics://")):
         url = f"{storage_url}/{url}"
-
-    elif environ.ROBOFLOW_API_KEY is None:
+    elif url.startswith("roboflow://") and environ.ROBOFLOW_API_KEY is None:
         pytest.skip("Roboflow API key is not set")
+    elif (
+        url.startswith("ultralytics://")
+        and environ.ULTRALYTICS_API_KEY is None
+    ):
+        pytest.skip("Ultralytics API key is not set")
 
     parser = LuxonisParser(
         url,

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -487,7 +487,51 @@ def test_ultralytics_ndjson_remote_urls_parser(
     dataset.delete_dataset(delete_local=True)
 
 
-def test_ultralytics_ndjson_remote_urls_parser_rejects_existing_remote_dir(
+def test_ultralytics_ndjson_remote_urls_parser_reuses_existing_remote_dir(
+    dataset_name: str,
+    tempdir: Path,
+):
+    source = create_image(10, tempdir)
+    ndjson_path = tempdir / "budgie.ndjson"
+    ndjson_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "dataset",
+                        "class_names": {"0": "budgie"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "image",
+                        "file": "train/img1.jpg",
+                        "url": source.resolve().as_uri(),
+                        "split": "train",
+                        "width": 512,
+                        "height": 512,
+                        "annotations": {"boxes": [[0, 0.5, 0.5, 0.4, 0.4]]},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tempdir / "budgie").mkdir()
+
+    dataset = LuxonisParser(
+        str(ndjson_path),
+        dataset_name=dataset_name,
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+    try:
+        assert len(dataset) == 1
+    finally:
+        dataset.delete_dataset(delete_local=True)
+
+
+def test_ultralytics_ndjson_remote_urls_parser_rejects_existing_remote_dir_when_cache_disabled(
     dataset_name: str,
     tempdir: Path,
 ):
@@ -528,4 +572,4 @@ def test_ultralytics_ndjson_remote_urls_parser_rejects_existing_remote_dir(
             dataset_name=dataset_name,
             delete_local=True,
             save_dir=tempdir,
-        ).parse()
+        ).parse(use_cached=False)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Added support for auto-download of Ultralytics dataset from Ultralytics Platform through LuxonisParser. The format of the dataset_name is `ultralytics://username/datasets/slug` or `ultralytics://username/datasets/slug?v=1` for specific version.
For this to work you need to have `ULTRALYTICS_API_KEY` env variable set.

Usage example:
```python3
dataset = LuxonisParser(
        dataset_name="ultralytics_coco8",
        dataset_dir="ultralytics://ultralytics/datasets/coco8",
    ).parse()
```
 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for using `ultralytics://` dataset references (including optional versioning) and downloading exports from the Ultralytics platform.
  * Added `ULTRALYTICS_API_KEY` configuration via environment variables.
  * Introduced a `reuse_cached` option for Ultralytics NDJSON parsing to control handling of existing remote image directories.
* **Bug Fixes**
  * Improved batch transformation behavior when all inputs are empty.
* **Documentation**
  * Updated parser documentation to include `ultralytics://` as an allowed dataset source.
* **Tests**
  * Expanded Ultralytics URL and remote-directory caching test coverage.
* **Chores**
  * Updated CI to provide `ULTRALYTICS_API_KEY` to the test job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->