### PR TITLE
Truncate logged warnings if skipped annotations exceed 50 and add a flag to log all warnings

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -566,6 +566,14 @@ def parse(
             show_default=False,
         ),
     ] = None,
+    full_warnings: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            "--log-all-warnings",
+            help="Log all skipped annotation warnings instead of capping the output at 50.",
+        ),
+    ] = False,
 ):
     """Parses a directory with data and creates Luxonis dataset."""
     split_ratios = parse_split_ratio(split_ratio)
@@ -577,6 +585,7 @@ def parse(
         delete_local=delete_local,
         save_dir=save_dir,
         task_name=task_name,
+        full_warnings=full_warnings,
     )
     dataset = parser.parse(split_ratios=split_ratios)
 

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -24,12 +24,14 @@ ParserOutput = tuple[DatasetIterator, dict[str, dict], list[Path]]
 class BaseParser(ABC):
     SPLIT_NAMES: tuple[str, ...] = ("train", "valid", "test")
     CANONICAL_SPLIT_NAMES: tuple[str, ...] = ("train", "val", "test")
+    SKIPPED_WARNING_LIMIT = 50
 
     def __init__(
         self,
         dataset: BaseDataset,
         dataset_type: DatasetType,
         task_name: str | dict[str, str] | None,
+        full_warnings: bool = False,
     ):
         """
         @type dataset: BaseDataset
@@ -50,13 +52,22 @@ class BaseParser(ABC):
             self.task_name = defaultdict(lambda: task_name)
         else:
             self.task_name = task_name
+        self.full_warnings = full_warnings
         self._parser_issue_messages: list[ParserIssueMessage] = []
         self._seen_parser_issue_messages: set[ParserIssueMessage] = set()
+        self._logged_skipped_annotation_warnings = 0
+        self._suppressed_skipped_annotation_warnings = 0
+        self._skipped_annotation_counts_by_reason: dict[str, int] = (
+            defaultdict(int)
+        )
 
     def reset_parser_issue_messages(self) -> None:
         """Clears collected parser issue messages."""
         self._parser_issue_messages.clear()
         self._seen_parser_issue_messages.clear()
+        self._logged_skipped_annotation_warnings = 0
+        self._suppressed_skipped_annotation_warnings = 0
+        self._skipped_annotation_counts_by_reason.clear()
 
     def get_parser_issue_messages(self) -> list[ParserIssueMessage]:
         """Returns collected parser issue messages from the last
@@ -291,24 +302,27 @@ class BaseParser(ABC):
         @return: C{LDF} with all the images and annotations parsed.
         """
         self.reset_parser_issue_messages()
-        added_images = self._parse_split(**kwargs)
+        try:
+            added_images = self._parse_split(**kwargs)
 
-        if split is not None:
-            self.dataset.make_splits({split: added_images})
-        elif random_split:
-            is_counts = split_ratios is not None and all(
-                isinstance(v, int) for v in split_ratios.values()
-            )
-            if is_counts:
-                sampled = self._apply_counts_to_pool(
-                    added_images,
-                    split_ratios,  # type: ignore[arg-type]
+            if split is not None:
+                self.dataset.make_splits({split: added_images})
+            elif random_split:
+                is_counts = split_ratios is not None and all(
+                    isinstance(v, int) for v in split_ratios.values()
                 )
-                self.dataset.make_splits(sampled)
-                self._remove_unsplit_records()
-            else:
-                self.dataset.make_splits(split_ratios)
-        return self.dataset
+                if is_counts:
+                    sampled = self._apply_counts_to_pool(
+                        added_images,
+                        split_ratios,  # type: ignore[arg-type]
+                    )
+                    self.dataset.make_splits(sampled)
+                    self._remove_unsplit_records()
+                else:
+                    self.dataset.make_splits(split_ratios)
+            return self.dataset
+        finally:
+            self._log_skipped_annotation_summary()
 
     def parse_dir(self, dataset_dir: Path, **kwargs) -> BaseDataset:
         """Parses entire dataset directory to L{LuxonisDataset} format.
@@ -322,57 +336,62 @@ class BaseParser(ABC):
         @return: C{LDF} with all the images and annotations parsed.
         """
         self.reset_parser_issue_messages()
-        split_ratios = kwargs.pop("split_ratios", None)
-        is_counts = split_ratios is not None and all(
-            isinstance(v, int) for v in split_ratios.values()
-        )
-
-        # Disable automatic val-to-test splitting when using explicit counts
-        if is_counts and "split_val_to_test" not in kwargs:
-            sig = inspect.signature(self._parse_available_splits)
-            if "split_val_to_test" in sig.parameters:
-                kwargs["split_val_to_test"] = False
-
-        split_definitions = self._parse_available_splits(dataset_dir, **kwargs)
-        if not split_definitions:
-            existing_dirs = [
-                d.name for d in dataset_dir.iterdir() if d.is_dir()
-            ]
-            raise ValueError(
-                "No valid split directories found in dataset. "
-                f"Found directories: {existing_dirs}."
-            )
-        if all(
-            len(split_images) == 0
-            for split_images in split_definitions.values()
-        ):
-            raise ValueError(
-                "No samples were parsed from the discovered split directories."
+        try:
+            split_ratios = kwargs.pop("split_ratios", None)
+            is_counts = split_ratios is not None and all(
+                isinstance(v, int) for v in split_ratios.values()
             )
 
-        original_splits: dict[str, Sequence[PathType]] = {
-            split_name: split_definitions.get(split_name, [])
-            for split_name in self.CANONICAL_SPLIT_NAMES
-        }
+            # Disable automatic val-to-test splitting when using explicit counts
+            if is_counts and "split_val_to_test" not in kwargs:
+                sig = inspect.signature(self._parse_available_splits)
+                if "split_val_to_test" in sig.parameters:
+                    kwargs["split_val_to_test"] = False
 
-        if split_ratios is None:
-            self.dataset.make_splits(original_splits)
-        elif is_counts:
-            sampled = self._apply_counts_to_splits(
-                original_splits,
-                split_ratios,  # type: ignore[arg-type]
+            split_definitions = self._parse_available_splits(
+                dataset_dir, **kwargs
             )
-            self.dataset.make_splits(sampled)
-            self._remove_unsplit_records()
-        else:
-            logger.warning(
-                "Using percentage-based split ratios will redistribute "
-                "and shuffle all samples across splits. Original split "
-                "boundaries will not be preserved."
-            )
-            self.dataset.make_splits(split_ratios)
+            if not split_definitions:
+                existing_dirs = [
+                    d.name for d in dataset_dir.iterdir() if d.is_dir()
+                ]
+                raise ValueError(
+                    "No valid split directories found in dataset. "
+                    f"Found directories: {existing_dirs}."
+                )
+            if all(
+                len(split_images) == 0
+                for split_images in split_definitions.values()
+            ):
+                raise ValueError(
+                    "No samples were parsed from the discovered split directories."
+                )
 
-        return self.dataset
+            original_splits: dict[str, Sequence[PathType]] = {
+                split_name: split_definitions.get(split_name, [])
+                for split_name in self.CANONICAL_SPLIT_NAMES
+            }
+
+            if split_ratios is None:
+                self.dataset.make_splits(original_splits)
+            elif is_counts:
+                sampled = self._apply_counts_to_splits(
+                    original_splits,
+                    split_ratios,  # type: ignore[arg-type]
+                )
+                self.dataset.make_splits(sampled)
+                self._remove_unsplit_records()
+            else:
+                logger.warning(
+                    "Using percentage-based split ratios will redistribute "
+                    "and shuffle all samples across splits. Original split "
+                    "boundaries will not be preserved."
+                )
+                self.dataset.make_splits(split_ratios)
+
+            return self.dataset
+        finally:
+            self._log_skipped_annotation_summary()
 
     def _parse_available_splits(
         self, dataset_dir: Path, **kwargs
@@ -479,6 +498,7 @@ class BaseParser(ABC):
 
         self._seen_parser_issue_messages.add(message)
         self._parser_issue_messages.append(message)
+        self._skipped_annotation_counts_by_reason[reason] += 1
 
         details = []
         if annotation_id is not None:
@@ -489,7 +509,36 @@ class BaseParser(ABC):
             details.append(f"image={image}")
 
         suffix = f" ({', '.join(details)})" if details else ""
-        logger.warning(f"Skipping annotation: {reason}{suffix}")
+        if (
+            self.full_warnings
+            or self._logged_skipped_annotation_warnings
+            < self.SKIPPED_WARNING_LIMIT
+        ):
+            logger.warning(f"Skipping annotation: {reason}{suffix}")
+            self._logged_skipped_annotation_warnings += 1
+        else:
+            self._suppressed_skipped_annotation_warnings += 1
+
+    def _log_skipped_annotation_summary(self) -> None:
+        if (
+            self.full_warnings
+            or self._suppressed_skipped_annotation_warnings == 0
+        ):
+            return
+
+        logger.warning(
+            "Skipped logging "
+            f"{self._suppressed_skipped_annotation_warnings} additional warnings, "
+            "enable the --log-all-warnings flag to see the full list."
+        )
+        reason_summary = ", ".join(
+            f"{reason} ({count} records)"
+            for reason, count in sorted(
+                self._skipped_annotation_counts_by_reason.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        )
+        logger.warning(f"Skipped annotations by reason: {reason_summary}")
 
     @staticmethod
     def _compare_stem_files(

--- a/luxonis_ml/data/parsers/luxonis_parser.py
+++ b/luxonis_ml/data/parsers/luxonis_parser.py
@@ -75,6 +75,7 @@ class LuxonisParser(Generic[T]):
         dataset_plugin: T = None,
         dataset_type: DatasetType | None = None,
         task_name: str | dict[str, str] | None = None,
+        full_warnings: bool = False,
         **kwargs,
     ):
         """High-level abstraction over various parsers.
@@ -117,6 +118,9 @@ class LuxonisParser(Generic[T]):
             a dictionary with class names as keys and task names as values.
             In the latter case, the task name for a record with a given
             class name will be taken from the dictionary.
+        @type full_warnings: bool
+        @param full_warnings: Whether all skipped annotation warnings
+            should be logged without truncation.
         @type kwargs: Dict[str, Any]
         @param kwargs: Additional C{kwargs} to be passed to the
             constructor of specific L{BaseDataset} implementation.
@@ -165,7 +169,10 @@ class LuxonisParser(Generic[T]):
             **kwargs,
         )
         self.parser = self.parsers[self.dataset_type](
-            self.dataset, self.dataset_type, task_name
+            self.dataset,
+            self.dataset_type,
+            task_name,
+            full_warnings=full_warnings,
         )
 
     @staticmethod

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -1,10 +1,15 @@
 import json
+from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
+from loguru import logger
 
 from luxonis_ml.data import LuxonisLoader, LuxonisParser, ParserIssue
+from luxonis_ml.data.parsers.base_parser import BaseParser, ParserOutput
 from luxonis_ml.data.utils import get_task_type
+from luxonis_ml.enums import DatasetType
 from luxonis_ml.utils import environ
 
 from .utils import create_image
@@ -430,6 +435,109 @@ def test_ultralytics_ndjson_parser(
         "classification",
     }
     dataset.delete_dataset(delete_local=True)
+
+
+class _DummyDataset:
+    def add(self, _generator: Iterator[object]) -> None:
+        return None
+
+    def make_splits(self, _splits: object) -> None:
+        return None
+
+
+class _WarningParser(BaseParser):
+    def __init__(
+        self,
+        warning_count: int,
+        *,
+        reason: str = "dummy skipped annotation",
+        full_warnings: bool = False,
+    ):
+        super().__init__(
+            _DummyDataset(),
+            DatasetType.COCO,
+            None,
+            full_warnings=full_warnings,
+        )
+        self.warning_count = warning_count
+        self.reason = reason
+
+    @staticmethod
+    def validate_split(_split_path: Path) -> dict[str, Any]:
+        return {}
+
+    def from_dir(
+        self, dataset_dir: Path, **kwargs: Any
+    ) -> tuple[list[Path], list[Path], list[Path]]:
+        return [], [], []
+
+    def from_split(self, **kwargs: Any) -> ParserOutput:
+        for annotation_id in range(self.warning_count):
+            self._warn_skipped_annotation(
+                ParserIssue.NON_NUMERIC_ANNOTATION,
+                self.reason,
+                annotation_id=annotation_id,
+            )
+        return iter(()), {}, []
+
+
+def test_skipped_annotation_warnings_are_capped():
+    parser = _WarningParser(BaseParser.SKIPPED_WARNING_LIMIT + 5)
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(str(message).strip()),
+        format="{message}",
+        level="WARNING",
+    )
+
+    try:
+        parser.parse_split()
+    finally:
+        logger.remove(sink_id)
+
+    assert len(parser.get_parser_issue_messages()) == (
+        BaseParser.SKIPPED_WARNING_LIMIT + 5
+    )
+    assert (
+        sum(message.startswith("Skipping annotation:") for message in messages)
+        == BaseParser.SKIPPED_WARNING_LIMIT
+    )
+    assert (
+        "Skipped logging 5 additional warnings, enable the "
+        "--log-all-warnings flag to see the full list."
+    ) in messages
+    assert (
+        "Skipped annotations by reason: dummy skipped annotation (55 records)"
+        in messages
+    )
+
+
+def test_full_warnings_logs_all_skipped_annotation_warnings():
+    parser = _WarningParser(
+        BaseParser.SKIPPED_WARNING_LIMIT + 5, full_warnings=True
+    )
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(str(message).strip()),
+        format="{message}",
+        level="WARNING",
+    )
+
+    try:
+        parser.parse_split()
+    finally:
+        logger.remove(sink_id)
+
+    assert len(parser.get_parser_issue_messages()) == (
+        BaseParser.SKIPPED_WARNING_LIMIT + 5
+    )
+    assert (
+        sum(message.startswith("Skipping annotation:") for message in messages)
+        == BaseParser.SKIPPED_WARNING_LIMIT + 5
+    )
+    assert not any(
+        message.startswith("Skipped logging ") for message in messages
+    )
 
 
 def test_ultralytics_ndjson_parser_explicit_type(

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -508,11 +508,11 @@ def test_skipped_annotation_warnings_are_capped():
         == BaseParser.SKIPPED_WARNING_LIMIT
     )
     assert (
-        "Skipped logging 5 additional warnings, enable the "
-        "--log-all-warnings flag to see the full list."
+        "Skipped logging 5 additional warnings. Enable the "
+        "`--log-all-warnings` flag to see the full list."
     ) in messages
     assert (
-        "Skipped annotations by reason: dummy skipped annotation (55 records)"
+        "Skipped annotations: dummy skipped annotation (55 records)"
         in messages
     )
 

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -1,12 +1,17 @@
 import json
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from loguru import logger
 
-from luxonis_ml.data import LuxonisLoader, LuxonisParser, ParserIssue
+from luxonis_ml.data import (
+    BaseDataset,
+    LuxonisLoader,
+    LuxonisParser,
+    ParserIssue,
+)
 from luxonis_ml.data.parsers.base_parser import BaseParser, ParserOutput
 from luxonis_ml.data.utils import get_task_type
 from luxonis_ml.enums import DatasetType
@@ -454,7 +459,7 @@ class _WarningParser(BaseParser):
         full_warnings: bool = False,
     ):
         super().__init__(
-            _DummyDataset(),
+            cast(BaseDataset, _DummyDataset()),
             DatasetType.COCO,
             None,
             full_warnings=full_warnings,


### PR DESCRIPTION
## Purpose
- Mainly because workflows tests are slowed down heavily by logging all warnings as pytest captures and buffers all the logged output.
- Also helpful for very large datasets.
- Skipped annotation warnings are capped at 50, and more skipped annotations logs a small report with the number of annotations skipped per reason.
- There is a new CLI flag `--log-all-warnings` that can be added to `luxonis_ml data parse ...` to disable this warning truncation

Example truncation:
<img width="895" height="229" alt="truncated_warnings" src="https://github.com/user-attachments/assets/993c25e9-7a1f-460e-8531-0ce32e8c4541" />

`--log-all-warnings` enabled to bypass the truncation:
<img width="896" height="177" alt="log_all_warnings_flag" src="https://github.com/user-attachments/assets/921949ba-4bb5-44fe-9e08-87c2266d2bca" />

 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--log-all-warnings` CLI option to the parse command to control skipped-annotation warning verbosity.

* **Improvements**
  * Skipped-annotation warnings are now capped by default and include a summary of how many additional warnings were suppressed.
  * When `--log-all-warnings` is enabled, skipped-annotation warnings are no longer capped and suppression summaries are omitted.

* **Tests**
  * Added/updated tests to verify both capped and uncapped warning output behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->