### PR TITLE
Fix filter task names functionality

### DIFF
--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -191,7 +191,6 @@ class LuxonisLoader(BaseLoader):
             column: i for i, column in enumerate(self._df.columns)
         }
 
-        self._classes = self.dataset.get_classes()
         self._instances: list[str] = []
         splits_path = self.dataset._metadata_path / "splits.json"
         if not splits_path.exists():

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -159,11 +159,10 @@ class LuxonisLoader(BaseLoader):
                 self._source_names, color_space or "RGB"
             )
 
-        if self._filter_task_names is None:
-            self._df = self.dataset._load_df_offline(raise_when_empty=True)
-            self._classes = self.dataset.get_classes()
+        self._df = self.dataset._load_df_offline(raise_when_empty=True)
+        self._classes = self.dataset.get_classes()
 
-        else:
+        if self._filter_task_names is not None:
             if self.dataset.metadata.tasks:
                 df_task_names = set(self.dataset.metadata.tasks)
             else:
@@ -181,7 +180,7 @@ class LuxonisLoader(BaseLoader):
                 for task_name in self._filter_task_names
                 if task_name in self._classes
             }
-        self.classes = self.dataset.get_classes()
+        self.classes = self._classes
         self._instances: list[str] = []
         splits_path = self.dataset._metadata_path / "splits.json"
         if not splits_path.exists():

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
+import pytest
 
 from luxonis_ml.data import (
     BucketStorage,
@@ -192,6 +193,82 @@ def create_loader(
         seed=42,
         **kwargs,
     )
+
+
+def _create_filter_task_names_dataset(
+    dataset_name: str, tempdir: Path
+) -> LuxonisDataset:
+    def generator() -> DatasetIterator:
+        img = create_image(0, tempdir)
+        yield {
+            "file": img,
+            "task_name": "animals",
+            "annotation": {"class": "cat"},
+        }
+        yield {
+            "file": img,
+            "task_name": "vehicles",
+            "annotation": {
+                "class": "car",
+                "boundingbox": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.3},
+            },
+        }
+
+        img = create_image(1, tempdir)
+        yield {
+            "file": img,
+            "task_name": "animals",
+            "annotation": {
+                "class": "dog",
+                "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+            },
+        }
+        yield {
+            "file": img,
+            "task_name": "vehicles",
+            "annotation": {
+                "class": "truck",
+                "boundingbox": {"x": 0.4, "y": 0.4, "w": 0.2, "h": 0.2},
+            },
+        }
+
+    return create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+
+def test_filter_task_names(randint: int, tempdir: Path):
+    dataset = _create_filter_task_names_dataset(
+        f"test_filter_task_names_{randint}", tempdir
+    )
+
+    loader = LuxonisLoader(dataset, filter_task_names=["animals"])
+
+    assert len(loader) == 2
+    assert loader.classes == {"animals": {"cat": 0, "dog": 1}}
+
+    labels_by_sample = [labels for _, labels in loader]
+    for labels in labels_by_sample:
+        assert set(labels) == {
+            "animals/classification",
+            "animals/boundingbox",
+        }
+
+    assert any(
+        labels["animals/boundingbox"].shape == (0, 5)
+        for labels in labels_by_sample
+    )
+    assert sorted(
+        labels["animals/classification"].tolist()
+        for labels in labels_by_sample
+    ) == [[0.0, 1.0], [1.0, 0.0]]
+
+
+def test_filter_task_names_rejects_unknown_task(randint: int, tempdir: Path):
+    dataset = _create_filter_task_names_dataset(
+        f"test_filter_task_names_rejects_unknown_task_{randint}", tempdir
+    )
+
+    with pytest.raises(ValueError, match="not in the dataset"):
+        LuxonisLoader(dataset, filter_task_names=["missing"])
 
 
 def test_loader_passes_is_validation_pipeline_to_legacy_engines(

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -243,7 +243,7 @@ def test_filter_task_names(randint: int, tempdir: Path):
     loader = LuxonisLoader(dataset, filter_task_names=["animals"])
 
     assert len(loader) == 2
-    assert loader.classes == {"animals": {"cat": 0, "dog": 1}}
+    assert loader._classes == {"animals": {"cat": 0, "dog": 1}}
 
     labels_by_sample = [labels for _, labels in loader]
     for labels in labels_by_sample:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Adds tests for `filter_task_names` functionality. 
## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loader initialization now consistently loads dataset information and available classes up front.
  * Class listings now correctly reflect any applied task filtering instead of always showing the full set.
  * Invalid task filters now return a clear error, helping catch configuration issues sooner.

* **Tests**
  * Added coverage for task-based filtering behavior, including mixed annotation outputs and invalid task names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->