### PR TITLE
Fix codecov report update

### DIFF
--- a/.github/workflows/update-cov-report.yaml
+++ b/.github/workflows/update-cov-report.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   update-base-report:
     runs-on: ubuntu-latest
@@ -17,12 +21,30 @@ jobs:
       - name: Download artifacts
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151
         with:
-          name: coverage
-          path: coverage.xml
+          name: coverage-ubuntu-latest-.*
+          name_is_regexp: true
+          path: coverage
           workflow: ci.yaml
+          merge_multiple: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Collect coverage files
+        id: coverage-files
+        shell: bash
+        run: |
+          files=$(find coverage -type f -name 'coverage-ubuntu-latest-*.xml' | sort | paste -sd, -)
+          if [[ -z "$files" ]]; then
+            echo "No coverage files found" >&2
+            exit 1
+          fi
+          echo "files=$files" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          files: ${{ steps.coverage-files.outputs.files }}
+          flags: pytest-ubuntu-latest
+          name: pytest-ubuntu-latest
+          disable_search: true


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes the action to upload codecov reports after changes in #431

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved coverage report automation to better handle multiple coverage files.
  * Coverage uploads now use all matching generated reports instead of a single fixed file.
  * Added stricter workflow permissions for safer execution.
  * The workflow now fails clearly if no coverage reports are found, helping surface reporting issues sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->