### PR TITLE
Hotfix: Revert bugfix for filtering class names when `filter_task_names` is set

### DIFF
--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -181,16 +181,10 @@ class LuxonisLoader(BaseLoader):
             self._df = self._df.filter(
                 pl.col("task_name").is_in(self._filter_task_names)
             )
-            self._classes = {
-                task_name: self._classes[task_name]
-                for task_name in self._filter_task_names
-                if task_name in self._classes
-            }
 
         self._df_col_indices = {
             column: i for i, column in enumerate(self._df.columns)
         }
-
         self._instances: list[str] = []
         splits_path = self.dataset._metadata_path / "splits.json"
         if not splits_path.exists():
@@ -204,7 +198,6 @@ class LuxonisLoader(BaseLoader):
         for v in self._view:
             self._instances.extend(splits[v])
 
-        self.idx_to_df_row: list[list[int]] = []
         group_id_list = self._df["group_id"].to_list()
         group_id_set = set(group_id_list)
         self._instances = [


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Before #426 there was a bug in `LuxonisLoader` where `LuxonisLoader.classes` were first filtered based on the filtered task names just to be immediately replaced by the original classes dictionary [here](https://github.com/luxonis/luxonis-ml/blob/8d457878f9471773031eff3939bcb264fb89ed2f/luxonis_ml/data/loaders/luxonis_loader.py#L186). 

Changing this causes the TAL assigner to fail in some cases in `luxonis-train`, I haven't yet found out the specific issue but reverting to the previous behavior fixes this for now. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loader behavior when filtering by task name so class mappings remain consistent after filtering.
  * Fixed internal indexing setup to avoid an unnecessary initialization step, helping keep data loading stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->