### PR TITLE
Improve docs for `sample_metadata`

### DIFF
--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -53,7 +53,8 @@ Most data pipelines follow the same sequence:
      - Convert a supported external dataset layout into LDF.
      - `luxonis_ml.data.parsers`
    * - `LuxonisLoader`
-     - Iterate image-like inputs and labels from one or more dataset splits.
+     - Iterate image-like inputs, labels, and sample metadata from one or
+       more dataset splits.
      - `luxonis_ml.data.loaders`
    * - `AlbumentationsEngine`
      - Apply runtime image and label augmentation while loading samples.
@@ -69,8 +70,10 @@ Example:
         dataset = LuxonisDataset("parking_lot")
         loader = LuxonisLoader(dataset, view="train")
 
-        for inputs, labels in loader:
-            ...
+        for sample in loader:
+            images = sample.images
+            labels = sample.labels
+            metadata = sample.metadata
 
 Note:
     Importing from `luxonis_ml.data` is the recommended public API for common

--- a/luxonis_ml/data/datasets/__init__.py
+++ b/luxonis_ml/data/datasets/__init__.py
@@ -117,11 +117,43 @@ multiple synchronized sources.
      - Mapping from source names to synchronized media paths.
    * - ``task_name``
      - Optional group name used by loaders and metadata.
+   * - ``sample_metadata``
+     - Optional **record-level metadata** preserved with the sample and
+       returned by `LuxonisLoader` as `LoaderOutput.metadata`.
    * - ``annotation``
      - Optional annotation payload validated by `Detection`.
 
 Multi-source records preserve source names for `LuxonisLoader`, allowing
 training code to receive dictionaries such as ``{"rgb": ..., "depth": ...}``.
+Record-level metadata is separate from annotation metadata: ``sample_metadata``
+describes the sample, while ``annotation["metadata"]`` creates metadata label
+tasks.
+
+.. code-block:: json
+
+    {
+      "file": "images/frame_001.jpg",
+      "task_name": "detection",
+
+      "sample_metadata": {
+        "record_id": 123,
+        "camera": "left",
+        "tags": ["night", "warehouse"]
+      },
+
+      "annotation": {
+        "class": "person",
+        "boundingbox": {
+          "x": 0.1,
+          "y": 0.2,
+          "w": 0.3,
+          "h": 0.4
+        }
+      }
+    }
+
+**Frontend note:** ``sample_metadata`` is sample data, not an annotation
+target.
 
 See:
     `DatasetRecord` for record validation, `Detection` for payload grouping,
@@ -143,8 +175,8 @@ LUXONISML_TEAM_ID / datasets / dataset_name``. The default base path is
      - Contents
    * - ``annotations/*.parquet``
      - Parquet shards containing media paths, source names, task names, class
-       names, instance IDs, task types, serialized annotation payloads, and
-       UUIDs.
+       names, instance IDs, task types, serialized annotation payloads,
+       serialized ``sample_metadata`` JSON, and UUIDs.
    * - ``media/``
      - Local copies of remote media. Local-only datasets may keep this
        directory empty and continue referencing the original files.

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -20,32 +20,67 @@ validated by `Detection`.
 
 Single-source records use ``"file"``:
 
-.. python::
+.. code-block:: json
 
     {
-        "file": "path/to/image.jpg",
-        "task_name": "detection",
-        "annotation": {
-            "class": "car",
-            "boundingbox": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
-        },
+      "file": "path/to/image.jpg",
+      "task_name": "detection",
+
+      "sample_metadata": {
+        "record_id": 123,
+        "camera": "left",
+        "tags": ["night", "warehouse"]
+      },
+
+      "annotation": {
+        "class": "car",
+        "boundingbox": {
+          "x": 0.1,
+          "y": 0.2,
+          "w": 0.3,
+          "h": 0.4
+        }
+      }
     }
 
 Multi-source records use ``"files"``:
 
-.. python::
+.. code-block:: json
 
     {
-        "files": {
-            "rgb": "path/to/rgb.png",
-            "depth": "path/to/depth.png",
-        },
-        "task_name": "detection",
-        "annotation": {
-            "class": "person",
-            "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.3, "h": 0.4},
-        },
+      "files": {
+        "rgb": "path/to/rgb.png",
+        "depth": "path/to/depth.png"
+      },
+      "task_name": "detection",
+
+      "sample_metadata": {
+        "sequence": "loading_dock_07",
+        "frame": 42
+      },
+
+      "annotation": {
+        "class": "person",
+        "boundingbox": {
+          "x": 0.1,
+          "y": 0.1,
+          "w": 0.3,
+          "h": 0.4
+        }
+      }
     }
+
+**Record-level metadata** lives in ``sample_metadata``. It describes the whole
+sample: capture IDs, UI tags, source-system identifiers, camera names, frame
+numbers, timestamps, or other values that should travel with the sample.
+`LuxonisLoader` exposes it through `LoaderOutput.metadata`.
+
+**Annotation metadata** lives in `Detection.metadata`. It is converted into
+label tasks such as ``"detection/metadata/weather"`` and is meant to be
+consumed by training code as annotation labels.
+
+**Frontend note:** ``sample_metadata`` is sample data, not an annotation
+target.
 
 Task names group annotations that should be consumed together. If no
 ``task_name`` is provided, the empty string ``""`` is used. Loader label keys
@@ -1179,10 +1214,46 @@ class ArrayAnnotation(Annotation):
 class DatasetRecord(BaseModelExtraForbid):
     """Dataset record containing file paths and an optional annotation.
 
+    A record is the unit of ingestion for `LuxonisDataset.add`. It may point
+    to one media source through ``file`` or to multiple synchronized sources
+    through ``files``.
+
+    ``sample_metadata`` stores **record-level metadata**. It is preserved by
+    native import/export and returned by `LuxonisLoader` as
+    `LoaderOutput.metadata`. It is intentionally separate from
+    `Detection.metadata`, which creates annotation metadata label tasks.
+
     Attributes:
         files: File paths keyed by source name.
         annotation: Optional detection associated with the dataset record.
         task_name: The name of the task to which the record belongs.
+        sample_metadata: JSON-like metadata for the whole sample. Values
+            should be JSON-serializable. Missing metadata defaults to an empty
+            dictionary.
+
+    Example:
+        .. code-block:: json
+
+            {
+              "file": "images/frame_001.jpg",
+              "task_name": "detection",
+
+              "sample_metadata": {
+                "record_id": 123,
+                "camera": "left",
+                "tags": ["night", "warehouse"]
+              },
+
+              "annotation": {
+                "class": "person",
+                "boundingbox": {
+                  "x": 0.1,
+                  "y": 0.2,
+                  "w": 0.3,
+                  "h": 0.4
+                }
+              }
+            }
 
     """
 
@@ -1325,6 +1396,17 @@ class DatasetRecord(BaseModelExtraForbid):
 
     @staticmethod
     def decode_metadata(value: Any) -> Params:
+        """Decode serialized record metadata into a dictionary.
+
+        Args:
+            value: A metadata dictionary, serialized JSON object, empty string,
+                or ``None``.
+
+        Returns:
+            Decoded metadata when the value is a dictionary-like JSON object;
+            otherwise an empty dictionary.
+
+        """
         if value in (None, ""):
             return {}
         if isinstance(value, str):

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -1262,7 +1262,9 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                 ``DatasetRecord`` objects or actual ``DatasetRecord``
                 instances. Each record must contain at least a
                 file path and can optionally include an annotation
-                and a task name.
+                and a task name. Use ``sample_metadata`` for values
+                attached to the whole sample rather than to one
+                annotation.
 
                 For example:
 
@@ -1270,29 +1272,41 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
 
                     def record_generator():
                         yield {
-                            "file": f"/path/to/image.jpg",
+                            "file": "/path/to/image.jpg",
                             "task_name": "animals",
+
+                            "sample_metadata": {
+                                "record_id": 123,
+                                "camera": "left",
+                                "tags": ["night", "warehouse"],
+                            },
+
                             "annotation": {
                                 "instance_id": 1,
-                                "class_name": "cat",
+                                "class": "cat",
                                 "boundingbox": {
-                                    "x": 10,
-                                    "y": 20,
-                                    "w": 100,
-                                    "h": 150,
-                                }
+                                    "x": 0.10,
+                                    "y": 0.20,
+                                    "w": 0.30,
+                                    "h": 0.40,
+                                },
                                 "keypoints": {
                                     "keypoints": [
-                                        (15, 25, 1),
-                                        (50, 60, 1),
-                                        (70, 80, 0),
+                                        (0.15, 0.25, 1),
+                                        (0.50, 0.60, 1),
+                                        (0.70, 0.80, 0),
                                     ],
                                 },
                                 "instance_segmentation": {
                                     "mask": "/path/to/mask.png",
-                                }
+                                },
                             },
                         }
+
+                `LuxonisLoader` returns ``sample_metadata`` through
+                `LoaderOutput.metadata`. Annotation metadata under
+                ``annotation["metadata"]`` is different: it becomes a
+                metadata label task.
 
             batch_size: The number of records to process in a batch before writing
                 to storage. Larger batch sizes may be more efficient but will

--- a/luxonis_ml/data/exporters/__init__.py
+++ b/luxonis_ml/data/exporters/__init__.py
@@ -32,6 +32,9 @@ metadata, and media paths used by concrete exporters.
      - Semantic segmentation masks stored as image files.
    * - `NativeExporter`, `UltralyticsNDJSONExporter`
      - Native LDF and Ultralytics NDJSON interchange formats.
+
+`NativeExporter` preserves **record-level metadata** by writing
+``sample_metadata`` objects into native LDF ``annotations.json`` files.
 """
 
 from .base_exporter import BaseExporter

--- a/luxonis_ml/data/exporters/native_exporter.py
+++ b/luxonis_ml/data/exporters/native_exporter.py
@@ -19,7 +19,41 @@ from luxonis_ml.utils.path import path_to_posix
 
 
 class NativeExporter(BaseExporter):
-    """Exporter for LDF format."""
+    """Exporter for native LDF directory format.
+
+    Native export writes split directories with copied media and an
+    ``annotations.json`` file. Each annotation entry follows the same
+    record-level shape accepted by `NativeParser` and `LuxonisDataset.add`.
+
+    ``sample_metadata`` is exported as a JSON object next to ``file`` or
+    ``files``. It is **record-level metadata**, not an annotation label.
+
+    Example:
+        .. code-block:: json
+
+            {
+              "file": "images/0.jpg",
+              "task_name": "detection",
+
+              "sample_metadata": {
+                "record_id": 123,
+                "camera": "left",
+                "tags": ["night", "warehouse"]
+              },
+
+              "annotation": {
+                "instance_id": 0,
+                "class": "person",
+                "boundingbox": {
+                  "x": 0.1,
+                  "y": 0.2,
+                  "w": 0.3,
+                  "h": 0.4
+                }
+              }
+            }
+
+    """
 
     @staticmethod
     def get_split_names() -> dict[str, str]:

--- a/luxonis_ml/data/loaders/__init__.py
+++ b/luxonis_ml/data/loaders/__init__.py
@@ -19,14 +19,31 @@ Basic Usage
     dataset = LuxonisDataset("parking_lot")
     loader = LuxonisLoader(dataset, view="train")
 
-    inputs, labels = loader[0]
+    sample = loader[0]
+
+    images = sample.images
+    labels = sample.labels
+    metadata = sample.metadata
 
 `LuxonisLoader` implements indexed access and iteration. The returned value is
-always ``(inputs, labels)``.
+always `LoaderOutput`.
 
-For single-source datasets, ``inputs`` is a single image-like array. For
-multi-source datasets, ``inputs`` is a dictionary mapping source names to
-arrays.
+`LoaderOutput.images` maps source names to arrays. Single-source datasets use
+the conventional ``"image"`` source name; multi-source datasets preserve the
+names from the record ``"files"`` mapping.
+
+`LoaderOutput.metadata` contains **record-level metadata** from
+``DatasetRecord.sample_metadata``. By default it also includes a
+``"filenames"`` mapping from source name to the loaded file basename.
+
+Legacy two-value unpacking still works when code only needs inputs and labels:
+
+.. python::
+
+    image_or_images, labels = loader[0]
+
+Metadata is not yielded by tuple unpacking. Access it through
+``loader[0].metadata``.
 
 
 Constructor Options
@@ -47,6 +64,8 @@ state. Common options include:
     - ``keep_categorical_as_strings`` to preserve categorical metadata values.
     - ``update_mode`` to control media synchronization for remote datasets.
     - ``filter_task_names`` to load only selected task groups.
+    - ``autopopulate_metadata`` to include automatic metadata such as source
+      filenames in `LoaderOutput.metadata`.
 
 When a remote dataset is loaded, annotations and metadata are refreshed. Media
 files are downloaded according to `UpdateMode`: ``ALL`` overwrites local media
@@ -70,6 +89,20 @@ Example:
 
 Metadata labels use ``"task_name/metadata/key"`` so each metadata field can be
 consumed independently.
+
+Sample metadata does not use label keys. It is returned separately through
+`LoaderOutput.metadata`:
+
+.. python::
+
+    sample = loader[0]
+    print(sample.metadata)
+
+    # {
+    #     "filenames": {"image": "frame_001.jpg"},
+    #     "record_id": 123,
+    #     "camera": "left",
+    # }
 
 
 Output Layouts
@@ -103,6 +136,55 @@ Output Layouts
 See:
     `luxonis_ml.data.datasets.annotation` for the ingestion schemas that are
     converted into these loader outputs.
+
+
+Sample Metadata
+===============
+
+**Record-level metadata** comes from ``DatasetRecord.sample_metadata`` and is
+available as `LoaderOutput.metadata`.
+
+.. python::
+
+    sample = loader[0]
+
+    sample.metadata
+    # {
+    #     "filenames": {"image": "frame_001.jpg"},
+    #     "record_id": 123,
+    #     "camera": "left",
+    # }
+
+Pass ``autopopulate_metadata=False`` to return only stored metadata:
+
+.. python::
+
+    loader = LuxonisLoader(dataset, autopopulate_metadata=False)
+    metadata = loader[0].metadata
+
+When batch augmentations combine several samples, metadata from the input
+samples is preserved in ``"batch_augmentation_metadata"``:
+
+.. python::
+
+    {
+        "record_id": 123,
+
+        "batch_augmentation_metadata": [
+            {
+                "input_index": 0,
+                "sample_metadata": {"record_id": 123},
+            },
+            {
+                "input_index": 1,
+                "sample_metadata": {"record_id": 456},
+            },
+        ],
+    }
+
+**Annotation metadata is different:** values under
+``annotation["metadata"]`` are converted into label tasks such as
+``"detection/metadata/weather"``.
 
 
 Runtime Options

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -56,6 +56,21 @@ class LuxonisLoader(BaseLoader):
     multi-source dataset it yields ``(images, labels)``, where ``images``
     maps source names to arrays.
 
+    Prefer attribute access for new code:
+
+    .. python::
+
+        sample = loader[0]
+
+        images = sample.images
+        labels = sample.labels
+        metadata = sample.metadata
+
+    ``sample.metadata`` contains **record-level metadata** from
+    `DatasetRecord.sample_metadata`. When ``autopopulate_metadata`` is enabled,
+    the loader also adds a ``"filenames"`` mapping from source name to file
+    basename.
+
     Label keys use ``"task_name/task_type"``. If a dataset was created
     without a task name, the default task name is empty and keys look like
     ``"/boundingbox"`` or ``"/segmentation"``.
@@ -77,6 +92,8 @@ class LuxonisLoader(BaseLoader):
         keep_categorical_as_strings: Whether categorical metadata remains
             as strings.
         filter_task_names: Optional task-name allowlist.
+        autopopulate_metadata: Whether automatic metadata such as source
+            filenames is added to `LoaderOutput.metadata`.
         tasks_without_background: Segmentation tasks where unassigned
             pixels are mapped to background class :math:`0`.
 
@@ -140,7 +157,10 @@ class LuxonisLoader(BaseLoader):
             filter_task_names: Optional task names to include. If omitted,
                 all tasks are included.
             autopopulate_metadata: Whether to add automatic sample metadata
-                such as source filenames.
+                such as source filenames. When enabled, returned metadata
+                includes a ``"filenames"`` dictionary keyed by source name.
+                Set to ``False`` to return only metadata stored in
+                `DatasetRecord.sample_metadata`.
 
         Raises:
             ValueError: If `color_space` is neither a string nor a
@@ -320,7 +340,19 @@ class LuxonisLoader(BaseLoader):
             idx: Index of the sample to retrieve.
 
         Returns:
-            Image data and annotation labels.
+            `LoaderOutput` with image arrays, annotation labels, and
+            record-level metadata.
+
+        Example:
+            .. python::
+
+                sample = loader[0]
+
+                images = sample.images
+                labels = sample.labels
+                metadata = sample.metadata
+
+                image_or_images, labels = sample  # Legacy compatibility.
 
         Raises:
             ValueError: If the selected views contain no records or a
@@ -562,6 +594,32 @@ class LuxonisLoader(BaseLoader):
 
     @staticmethod
     def _merge_sample_metadata(metadata_batch: list[Params]) -> Params:
+        """Merge metadata from samples used by a batch augmentation.
+
+        The first sample's metadata remains at the top level. Metadata from
+        every input sample is also preserved in
+        ``"batch_augmentation_metadata"`` so consumers can inspect which
+        records contributed to the augmented output.
+
+        Example:
+            .. python::
+
+                {
+                    "record_id": 123,
+
+                    "batch_augmentation_metadata": [
+                        {
+                            "input_index": 0,
+                            "sample_metadata": {"record_id": 123},
+                        },
+                        {
+                            "input_index": 1,
+                            "sample_metadata": {"record_id": 456},
+                        },
+                    ],
+                }
+
+        """
         if not metadata_batch:
             return {}
 

--- a/luxonis_ml/data/parsers/__init__.py
+++ b/luxonis_ml/data/parsers/__init__.py
@@ -137,7 +137,7 @@ Supported Formats
    * - Native LDF
      - ``DatasetType.NATIVE``
      - ``NativeParser``
-     - Existing Luxonis native exports.
+     - Existing Luxonis native exports, including ``sample_metadata`` records.
 
 See:
     `luxonis_ml.data.datasets.annotation` for the LDF annotation schemas

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -11,7 +11,6 @@ from .base_parser import BaseParser, ParserOutput
 
 
 class NativeParser(BaseParser):
-    _SPLIT_NAMES: tuple[str, ...] = ("train", "val", "test")
     """Parse a directory with native LDF annotations.
 
     Expected format::
@@ -23,10 +22,41 @@ class NativeParser(BaseParser):
         └── test/
 
     The annotations are stored in a single JSON file as a list of dictionaries
-    in the same format as the output of the generator function used
-    by ``BaseDataset.add``.
+    in the same format as the output of the generator function used by
+    `BaseDataset.add`.
+
+    ``sample_metadata`` is read as **record-level metadata** and preserved on
+    the resulting `DatasetRecord`. It is distinct from
+    ``annotation["metadata"]``, which creates metadata label tasks.
+
+    Example ``annotations.json`` entry:
+
+        .. code-block:: json
+
+            {
+              "file": "images/0.jpg",
+              "task_name": "detection",
+
+              "sample_metadata": {
+                "record_id": 123,
+                "camera": "left",
+                "tags": ["night", "warehouse"]
+              },
+
+              "annotation": {
+                "class": "person",
+                "boundingbox": {
+                  "x": 0.1,
+                  "y": 0.2,
+                  "w": 0.3,
+                  "h": 0.4
+                }
+              }
+            }
 
     """
+
+    _SPLIT_NAMES: tuple[str, ...] = ("train", "val", "test")
 
     @staticmethod
     def validate_split(split_path: Path) -> dict[str, Any] | None:

--- a/luxonis_ml/data/utils/parquet.py
+++ b/luxonis_ml/data/utils/parquet.py
@@ -1,3 +1,11 @@
+"""Parquet row helpers for Luxonis Data Format annotations.
+
+Most users should interact with `DatasetRecord.sample_metadata` and
+`LoaderOutput.metadata`. This module documents the lower-level storage shape:
+``sample_metadata`` is stored in parquet as serialized JSON text and decoded
+back to a dictionary when records are loaded or exported.
+"""
+
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -7,6 +15,7 @@ from typing_extensions import Self
 from luxonis_ml.typing import PathType
 
 DEFAULT_METADATA = "{}"
+"""Serialized empty metadata object used for old or missing metadata rows."""
 
 
 class ParquetRecord(TypedDict):
@@ -20,7 +29,22 @@ class ParquetRecord(TypedDict):
         instance_id: Optional instance identifier.
         task_type: Optional task type.
         annotation: Optional serialized annotation JSON.
-        sample_metadata: Optional serialized metadata JSON for the entire sample.
+        sample_metadata: Serialized JSON object for **record-level metadata**.
+            Empty metadata is stored as ``"{}"``.
+
+    Example:
+        .. python::
+
+            {
+                "file": "/data/images/frame_001.jpg",
+                "source_name": "image",
+                "task_name": "detection",
+                "class_name": "person",
+                "instance_id": 0,
+                "task_type": "boundingbox",
+                "annotation": '{"x":0.1,"y":0.2,"w":0.3,"h":0.4}',
+                "sample_metadata": '{"record_id":123,"camera":"left"}',
+            }
 
     """
 
@@ -40,6 +64,10 @@ class ParquetFileManager:
     Rows are buffered in memory and flushed to the current parquet file.
     A new file is selected every ``num_rows`` writes. Filenames are
     zero-padded numeric counters such as ``0000000000.parquet``.
+
+    Existing parquet shards that do not have ``sample_metadata`` are read as
+    if every row contained ``"{}"``. This keeps older LDF datasets compatible
+    with record-level metadata.
 
     Attributes:
         dir: Directory containing parquet files.
@@ -70,6 +98,7 @@ class ParquetFileManager:
             ...     "instance_id": 0,
             ...     "task_type": "boundingbox",
             ...     "annotation": "{}",
+            ...     "sample_metadata": "{}",
             ... }
             >>> manager = ParquetFileManager("/tmp/ldf-parquet-example", num_rows=2)
             >>> manager.num_rows

--- a/luxonis_ml/typing.py
+++ b/luxonis_ml/typing.py
@@ -77,15 +77,55 @@ class LoaderOutput(
     if TYPE_CHECKING
     else object
 ):
+    """Images, labels, and record metadata returned by dataset loaders.
+
+    Prefer attribute access for new code. The object also supports the legacy
+    two-value tuple protocol so existing code can continue to unpack
+    ``image_or_images, labels = loader[0]``.
+
+    Attributes:
+        images: Image arrays keyed by source name. Single-source datasets use
+            the conventional ``"image"`` key.
+        labels: Label arrays keyed by ``"task_name/task_type"``.
+        metadata: **Record-level metadata** from
+            `DatasetRecord.sample_metadata`, plus any automatic loader
+            metadata such as ``"filenames"`` when enabled.
+
+    Example:
+        .. python::
+
+            sample = loader[0]
+
+            images = sample.images
+            labels = sample.labels
+            metadata = sample.metadata
+
+    """
+
     images: dict[str, "np.ndarray"]
     labels: dict[str, "np.ndarray"]
     metadata: Params
 
     def __iter__(self) -> Iterator["np.ndarray | dict[str, np.ndarray]"]:
+        """Yield the legacy ``(image_or_images, labels)`` tuple shape.
+
+        Single-source samples yield the first image array. Multi-source samples
+        yield the full ``images`` mapping. Metadata is intentionally available
+        only through the `metadata` attribute.
+        """
         yield self.images if len(self.images) > 1 else self.image
         yield self.labels
 
     def __getitem__(self, index: int) -> "np.ndarray | dict[str, np.ndarray]":
+        """Return legacy tuple-style values by index.
+
+        Args:
+            index: ``0`` for image data and ``1`` for labels.
+
+        Raises:
+            IndexError: If ``index`` is not ``0`` or ``1``.
+
+        """
         if index == 0:
             return self.images if len(self.images) > 1 else self.image
         if index == 1:


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Improved documentation for the new `sample_metadata` field. 

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that loader samples include images, labels, and record-level metadata.
  * Documented access through `sample.images`, `sample.labels`, and `sample.metadata`.
  * Added guidance for preserving and exporting sample metadata across native and parquet formats.
  * Clarified automatic filename metadata, batch augmentation metadata, and compatibility with legacy tuple unpacking.
  * Expanded dataset record, annotation, parser, and storage format examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->