### PR TITLE
Fix bbox ordering with multiple batch augmentations

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -39,6 +39,12 @@ TargetType: TypeAlias = Literal[
     "metadata",
 ]
 
+# Target types describing individual instances, and so kept in step with the
+# bounding boxes of their task group as those are filtered.
+ASSOCIATED_TARGET_TYPES = frozenset(
+    {"instance_mask", "keypoints", "array", "metadata"}
+)
+
 
 class AlbumentationConfigItem(ConfigItem):
     """Configuration item for `AlbumentationsEngine`.
@@ -578,38 +584,38 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 "seed": seed,
             }
 
-        # Warning issued when "bbox_params" or "keypoint_params"
-        # are provided to a compose with transformations that
-        # do not use them. We don't care about these warnings.
         bbox_targets_by_group = {}
-        for bbox_target, bbox_type in self._targets.items():
-            if bbox_type != "bboxes":
+        for target_name, target_type in self._targets.items():
+            if target_type != "bboxes":
                 continue
-            task_group = self._target_names_to_task_groups[bbox_target]
+            task_group = self._target_names_to_task_groups[target_name]
             if task_group in bbox_targets_by_group:
                 raise ValueError(
                     "Multiple bounding-box targets belong to task group "
                     f"'{task_group}'."
                 )
-            bbox_targets_by_group[task_group] = bbox_target
+            bbox_targets_by_group[task_group] = target_name
 
         self._bbox_task_groups = set(bbox_targets_by_group)
-        bbox_associations = {}
-        for task_group, bbox_target in bbox_targets_by_group.items():
-            bbox_associations[bbox_target] = {
+        bbox_associations = {
+            bbox_target: {
                 target_name: target_type
                 for target_name, target_type in self._targets.items()
-                if target_type
-                in {"instance_mask", "keypoints", "array", "metadata"}
+                if target_type in ASSOCIATED_TARGET_TYPES
                 and self._target_names_to_task_groups[target_name]
                 == task_group
             }
+            for task_group, bbox_target in bbox_targets_by_group.items()
+        }
         self._bbox_associated_targets = {
             target_name
             for associations in bbox_associations.values()
             for target_name in associations
         }
 
+        # Warning issued when "bbox_params" or "keypoint_params"
+        # are provided to a compose with transformations that
+        # do not use them. We don't care about these warnings.
         with warnings.catch_warnings(record=True):
             self._batch_transform = BatchCompose(
                 batch_transforms,
@@ -653,9 +659,9 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         )
 
         # Albumentations chokes on zero-size targets, so they are dropped
-        # before the remaining stages. Labels that a batch transform emptied
-        # are remembered so postprocessing can still report them as empty
-        # instead of silently omitting the task.
+        # here. Ones a batch transform emptied are remembered so that
+        # postprocessing can still report them as empty rather than omit
+        # the task entirely.
         emptied_targets = set()
         for target_name in list(data.keys()):
             value = data[target_name]
@@ -878,8 +884,6 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 out_labels[task] = array
 
         for target_name in emptied_targets:
-            # These were dropped before the remaining stages ran, so none of
-            # the loops above can have produced a label for them.
             task = self._target_names_to_tasks[target_name]
             if self._targets[target_name] == "instance_mask":
                 # The recorded shape is the pre-augmentation one.
@@ -978,12 +982,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
     @staticmethod
     def _get_task_group(task: str) -> str:
-        """Return the complete task path without its task-type suffix."""
-        task_type = get_task_type(task)
-        suffix = f"/{task_type}"
-        if task.endswith(suffix):
-            return task[: -len(suffix)]
-        return ""
+        """Return the complete task path without its task-type suffix.
+
+        Unlike `get_task_name`, this keeps every level of a nested task
+        name, so ``"a/b/keypoints"`` groups under ``"a/b"``.
+        """
+        return task.removesuffix(get_task_type(task)).removesuffix("/")
 
     @staticmethod
     def _task_to_target_name(task: str) -> str:

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -610,7 +610,9 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             }
             for task_group, bbox_target in bbox_targets_by_group.items()
         }
-        self._bbox_associated_targets = {
+        # Targets tied to a bbox target, the boxes themselves included. Only
+        # these are reported as empty when a transform clears them out.
+        self._grouped_targets = set(bbox_targets_by_group.values()) | {
             target_name
             for associations in bbox_associations.values()
             for target_name in associations
@@ -668,10 +670,6 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             for target_name, spec in label_specs[index].items():
                 contributed.setdefault(target_name, spec)
 
-        reportable = self._bbox_associated_targets | set(
-            self._bbox_targets_by_group.values()
-        )
-
         # Albumentations chokes on zero-size targets, so they are dropped
         # here. Ones a batch transform emptied are remembered so that
         # postprocessing can still report them as empty rather than omit
@@ -681,7 +679,10 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             value = data[target_name]
             if isinstance(value, np.ndarray) and value.size == 0:
                 del data[target_name]
-                if target_name in contributed and target_name in reportable:
+                if (
+                    target_name in contributed
+                    and target_name in self._grouped_targets
+                ):
                     emptied_targets[target_name] = contributed[target_name]
 
         data = self._spatial_transform(**data)
@@ -1015,12 +1016,10 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         """Return the complete task path without its task-type suffix.
 
         Unlike `get_task_name`, this keeps every level of a nested task
-        name, so ``"a/b/keypoints"`` groups under ``"a/b"``.
-
-        A leading ``"/"`` marks LDF's default task, whose name is empty on
-        purpose: ``"/boundingbox"`` and ``"/keypoints"`` describe the same
-        annotations and share the group ``""``. A task with no separator at
-        all has no name to group by, so it is only grouped with itself.
+        name, so ``"a/b/keypoints"`` groups under ``"a/b"``. The leading
+        ``"/"`` of LDF's default task marks a name that is empty on purpose,
+        while a task with no separator at all has no name to group by and is
+        only ever grouped with itself.
         """
         group = task.removesuffix(get_task_type(task)).removesuffix("/")
         if group:

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -11,7 +11,7 @@ from loguru import logger
 from pydantic import Field
 from typing_extensions import override
 
-from luxonis_ml.data.utils.task_utils import get_task_name, task_is_metadata
+from luxonis_ml.data.utils.task_utils import get_task_type, task_is_metadata
 from luxonis_ml.typing import ConfigItem, LoaderMultiOutput, Params
 from luxonis_ml.utils import deprecated
 
@@ -369,14 +369,16 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
         Raises:
             ValueError: If a target task type is unsupported, more than
-                one transform is marked for resizing, or a configured
-                transform is not an Albumentations transform.
+                one bounding-box target belongs to the same task group,
+                more than one transform is marked for resizing, or a
+                configured transform is not an Albumentations transform.
             TypeError: If a resizing transform has a non-numeric
                 probability ``p``.
 
         """
         self._targets: dict[str, TargetType] = {}
         self._target_names_to_tasks = {}
+        self._target_names_to_task_groups = {}
         self._n_classes = n_classes
         self._image_size = (height, width)
         self._source_names = source_names
@@ -439,6 +441,9 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
             self._targets[target_name] = target_type
             self._target_names_to_tasks[target_name] = task
+            self._target_names_to_task_groups[target_name] = (
+                self._get_task_group(task)
+            )
 
         for source_name in source_names:
             self._targets[source_name] = "image"
@@ -577,9 +582,35 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         # Warning issued when "bbox_params" or "keypoint_params"
         # are provided to a compose with transformations that
         # do not use them. We don't care about these warnings.
+        bbox_targets_by_group = {}
+        for bbox_target, bbox_type in self._targets.items():
+            if bbox_type != "bboxes":
+                continue
+            task_group = self._target_names_to_task_groups[bbox_target]
+            if task_group in bbox_targets_by_group:
+                raise ValueError(
+                    "Multiple bounding-box targets belong to task group "
+                    f"'{task_group}'."
+                )
+            bbox_targets_by_group[task_group] = bbox_target
+
+        self._bbox_task_groups = set(bbox_targets_by_group)
+        bbox_associations = {}
+        for task_group, bbox_target in bbox_targets_by_group.items():
+            bbox_associations[bbox_target] = {
+                target_name: target_type
+                for target_name, target_type in self._targets.items()
+                if target_type
+                in {"instance_mask", "keypoints", "array", "metadata"}
+                and self._target_names_to_task_groups[target_name]
+                == task_group
+            }
+
         with warnings.catch_warnings(record=True):
             self._batch_transform = BatchCompose(
-                batch_transforms, **_get_params(is_custom=True)
+                batch_transforms,
+                bbox_associations=bbox_associations,
+                **_get_params(is_custom=True),
             )
             self._spatial_transform = self._wrap_transform(
                 A.Compose(wrapped_spatial_ops, **_get_params())
@@ -756,13 +787,13 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 continue
 
             task = self._target_names_to_tasks[target_name]
-            task_name = get_task_name(task)
+            task_group = self._target_names_to_task_groups[target_name]
 
             if target_type == "bboxes":
                 out_labels[task], index = postprocess_bboxes(
                     array, self._bbox_area_threshold
                 )
-                bboxes_indices[task_name] = index
+                bboxes_indices[task_group] = index
 
         for target_name, target_type in self._targets.items():
             if target_name not in data:
@@ -773,10 +804,10 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 continue
 
             task = self._target_names_to_tasks[target_name]
-            task_name = get_task_name(task)
+            task_group = self._target_names_to_task_groups[target_name]
 
-            if task_name not in bboxes_indices:
-                if "bboxes" in self._targets.values():
+            if task_group not in bboxes_indices:
+                if task_group in self._bbox_task_groups:
                     bbox_ordering = np.array([], dtype=int)
                 elif target_type == "keypoints":
                     bbox_ordering = np.arange(
@@ -785,7 +816,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 else:
                     bbox_ordering = np.arange(array.shape[0])
             else:
-                bbox_ordering = bboxes_indices[task_name]
+                bbox_ordering = bboxes_indices[task_group]
 
             if target_type == "mask":
                 out_labels[task] = postprocess_mask(array)
@@ -895,6 +926,15 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         if hasattr(A, config.name):
             return getattr(A, config.name)(**params)
         return TRANSFORMATIONS.get(config.name)(**params)  # type: ignore
+
+    @staticmethod
+    def _get_task_group(task: str) -> str:
+        """Return the complete task path without its task-type suffix."""
+        task_type = get_task_type(task)
+        suffix = f"/{task_type}"
+        if task.endswith(suffix):
+            return task[: -len(suffix)]
+        return ""
 
     @staticmethod
     def _task_to_target_name(task: str) -> str:

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -832,13 +832,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             if target_type != "bboxes" or target_name not in data:
                 continue
 
-            array = data[target_name]
-            if array.size == 0:
-                continue
-
+            # An emptied bbox target is kept rather than skipped: its
+            # associated labels are still reported as empty, so dropping the
+            # task would leave them without the boxes they belong to.
             task = self._target_names_to_tasks[target_name]
             out_labels[task], index = postprocess_bboxes(
-                array, self._bbox_area_threshold
+                data[target_name], self._bbox_area_threshold
             )
             bboxes_indices[self._target_names_to_task_groups[target_name]] = (
                 index
@@ -1016,12 +1015,17 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         """Return the complete task path without its task-type suffix.
 
         Unlike `get_task_name`, this keeps every level of a nested task
-        name, so ``"a/b/keypoints"`` groups under ``"a/b"``. A task with no
-        name at all is its own group, so that unnamed tasks of different
-        types are not lumped together.
+        name, so ``"a/b/keypoints"`` groups under ``"a/b"``.
+
+        A leading ``"/"`` marks LDF's default task, whose name is empty on
+        purpose: ``"/boundingbox"`` and ``"/keypoints"`` describe the same
+        annotations and share the group ``""``. A task with no separator at
+        all has no name to group by, so it is only grouped with itself.
         """
         group = task.removesuffix(get_task_type(task)).removesuffix("/")
-        return group or task
+        if group:
+            return group
+        return "" if task.startswith("/") else task
 
     @staticmethod
     def _task_to_target_name(task: str) -> str:

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -19,6 +19,7 @@ from .batch_compose import BatchCompose
 from .batch_transform import BatchTransform
 from .custom import TRANSFORMATIONS, LetterboxResize
 from .utils import (
+    instance_count,
     postprocess_bboxes,
     postprocess_keypoints,
     postprocess_mask,
@@ -28,6 +29,8 @@ from .utils import (
 )
 
 Data: TypeAlias = dict[str, np.ndarray]
+# LDF layout of a single annotation: its trailing shape and its dtype.
+LabelSpec: TypeAlias = tuple[tuple[int, ...], np.dtype]
 TargetType: TypeAlias = Literal[
     "image",
     "array",
@@ -596,7 +599,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 )
             bbox_targets_by_group[task_group] = target_name
 
-        self._bbox_task_groups = set(bbox_targets_by_group)
+        self._bbox_targets_by_group = bbox_targets_by_group
         bbox_associations = {
             bbox_target: {
                 target_name: target_type
@@ -650,7 +653,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
     @override
     def apply(self, input_batch: list[LoaderMultiOutput]) -> LoaderMultiOutput:
-        data_batch, n_keypoints, label_shapes = self._preprocess_batch(
+        data_batch, n_keypoints, label_specs = self._preprocess_batch(
             input_batch
         )
 
@@ -658,20 +661,28 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             data_batch, keypoints_per_instance=n_keypoints
         )
 
+        # A batch transform discards the members it did not merge, and a task
+        # only those members carried is not part of this sample at all.
+        contributed = {}
+        for index in self.batch_augmentation_indices:
+            for target_name, spec in label_specs[index].items():
+                contributed.setdefault(target_name, spec)
+
+        reportable = self._bbox_associated_targets | set(
+            self._bbox_targets_by_group.values()
+        )
+
         # Albumentations chokes on zero-size targets, so they are dropped
         # here. Ones a batch transform emptied are remembered so that
         # postprocessing can still report them as empty rather than omit
         # the task entirely.
-        emptied_targets = set()
+        emptied_targets = {}
         for target_name in list(data.keys()):
             value = data[target_name]
             if isinstance(value, np.ndarray) and value.size == 0:
                 del data[target_name]
-                if (
-                    target_name in label_shapes
-                    and target_name in self._bbox_associated_targets
-                ):
-                    emptied_targets.add(target_name)
+                if target_name in contributed and target_name in reportable:
+                    emptied_targets[target_name] = contributed[target_name]
 
         data = self._spatial_transform(**data)
         data = self._custom_transform(**data)
@@ -691,30 +702,29 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         else:
             data = self._pixel_transform(**data)
 
-        return self._postprocess(
-            data, n_keypoints, emptied_targets, label_shapes
-        )
+        return self._postprocess(data, n_keypoints, emptied_targets)
 
     def _preprocess_batch(
         self, labels_batch: list[LoaderMultiOutput]
-    ) -> tuple[list[Data], dict[str, int], dict[str, tuple[int, ...]]]:
+    ) -> tuple[list[Data], dict[str, int], list[dict[str, LabelSpec]]]:
         """Preprocess a batch of labels.
 
         Args:
             labels_batch: Loader outputs to preprocess.
 
         Returns:
-            Preprocessed data, keypoint counts for each task, and the
-            per-annotation LDF shape of every target the batch actually
-            provided labels for.
+            Preprocessed data, keypoint counts for each task, and, for every
+            member of the batch, the LDF layout of each target it provided
+            labels for.
 
         """
         data_batch = []
         n_keypoints = {}
-        label_shapes: dict[str, tuple[int, ...]] = {}
+        label_specs: list[dict[str, LabelSpec]] = []
 
         for image_dict, labels in labels_batch:
             data = {}
+            specs: dict[str, LabelSpec] = {}
 
             key = next(iter(image_dict))
             data["_original_image_key"] = key
@@ -755,7 +765,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                     continue
 
                 array = labels[task]
-                label_shapes.setdefault(target_name, array.shape[1:])
+                specs[target_name] = (array.shape[1:], array.dtype)
 
                 if target_type in {"mask", "instance_mask"}:
                     data[target_name] = preprocess_mask(array)
@@ -772,15 +782,15 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                     data[target_name] = array
 
             data_batch.append(data)
+            label_specs.append(specs)
 
-        return data_batch, n_keypoints, label_shapes
+        return data_batch, n_keypoints, label_specs
 
     def _postprocess(
         self,
         data: Data,
         n_keypoints: dict[str, int],
-        emptied_targets: set[str],
-        label_shapes: dict[str, tuple[int, ...]],
+        emptied_targets: dict[str, LabelSpec],
     ) -> LoaderMultiOutput:
         """Postprocess the augmented data back to LDF format.
 
@@ -790,11 +800,10 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         Args:
             data: Augmented data keyed by target name.
             n_keypoints: Mapping from task names to keypoint counts.
-            emptied_targets: Targets a batch transform emptied because all
-                the bounding boxes they belong to were filtered out. They
-                are reported as empty labels rather than omitted.
-            label_shapes: Per-annotation LDF shape of every target the input
-                batch provided labels for.
+            emptied_targets: LDF layout of the targets a batch transform
+                emptied because all the bounding boxes they belong to were
+                filtered out. They are reported as empty labels rather than
+                omitted.
 
         Returns:
             Augmented images and labels.
@@ -820,7 +829,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         bboxes_indices = {}
 
         for target_name, target_type in self._targets.items():
-            if target_name not in data:
+            if target_type != "bboxes" or target_name not in data:
                 continue
 
             array = data[target_name]
@@ -828,16 +837,15 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 continue
 
             task = self._target_names_to_tasks[target_name]
-            task_group = self._target_names_to_task_groups[target_name]
-
-            if target_type == "bboxes":
-                out_labels[task], index = postprocess_bboxes(
-                    array, self._bbox_area_threshold
-                )
-                bboxes_indices[task_group] = index
+            out_labels[task], index = postprocess_bboxes(
+                array, self._bbox_area_threshold
+            )
+            bboxes_indices[self._target_names_to_task_groups[target_name]] = (
+                index
+            )
 
         for target_name, target_type in self._targets.items():
-            if target_name not in data:
+            if target_type == "bboxes" or target_name not in data:
                 continue
 
             array = data[target_name]
@@ -845,29 +853,27 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 continue
 
             task = self._target_names_to_tasks[target_name]
-            task_group = self._target_names_to_task_groups[target_name]
-
-            if task_group in bboxes_indices:
-                bbox_ordering = bboxes_indices[task_group]
-            elif task_group in self._bbox_task_groups:
-                bbox_ordering = np.array([], dtype=int)
-            elif target_type == "keypoints":
-                bbox_ordering = np.arange(
-                    array.shape[0] // n_keypoints[target_name]
-                )
-            elif target_type == "instance_mask":
-                # Instance masks are (H, W, N) here, so the instance count
-                # is the last axis, not the first.
-                bbox_ordering = np.arange(array.shape[-1])
-            else:
-                bbox_ordering = np.arange(array.shape[0])
 
             if target_type == "mask":
                 out_labels[task] = postprocess_mask(array)
+                continue
 
-            elif target_type == "instance_mask":
-                masks = postprocess_mask(array)
-                out_labels[task] = masks[bbox_ordering]
+            if target_type == "classification":
+                out_labels[task] = array
+                continue
+
+            available = instance_count(
+                array, target_type, n_keypoints.get(target_name, 0)
+            )
+            bbox_ordering = self._resolve_ordering(
+                self._target_names_to_task_groups[target_name],
+                bboxes_indices,
+                available,
+                task,
+            )
+
+            if target_type == "instance_mask":
+                out_labels[task] = postprocess_mask(array)[bbox_ordering]
 
             elif target_type == "keypoints":
                 out_labels[task] = postprocess_keypoints(
@@ -877,22 +883,47 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                     image_width,
                     n_keypoints[target_name],
                 )
-            elif target_type in {"array", "metadata"}:
+            else:
                 out_labels[task] = array[bbox_ordering]
 
-            elif target_type == "classification":
-                out_labels[task] = array
-
-        for target_name in emptied_targets:
+        for target_name, (trailing, dtype) in emptied_targets.items():
             task = self._target_names_to_tasks[target_name]
             if self._targets[target_name] == "instance_mask":
                 # The recorded shape is the pre-augmentation one.
                 trailing = (image_height, image_width)
-            else:
-                trailing = label_shapes[target_name]
-            out_labels[task] = np.zeros((0, *trailing))
+            out_labels[task] = np.zeros((0, *trailing), dtype=dtype)
 
         return out_image_dict, out_labels
+
+    def _resolve_ordering(
+        self,
+        task_group: str,
+        bboxes_indices: dict[str, np.ndarray],
+        available: int,
+        task: str,
+    ) -> np.ndarray:
+        """Instances of a task to keep, in the order its boxes survived.
+
+        Instances a bounding box no longer accounts for are dropped. An
+        ordering reaching past the labels that are actually there means the
+        annotation carried a different number of instances than boxes, which
+        `BatchCompose` has already refused to guess at; the excess is dropped
+        so that the sample still loads.
+        """
+        if task_group not in bboxes_indices:
+            if task_group in self._bbox_targets_by_group:
+                return np.array([], dtype=int)
+            return np.arange(available)
+
+        ordering = bboxes_indices[task_group]
+        if ordering.size and ordering.max() >= available:
+            logger.warning(
+                f"Task '{task}' has {available} instances for "
+                f"{ordering.max() + 1} bounding boxes; the instances without "
+                f"a box are dropped and the rest may be misaligned."
+            )
+            ordering = ordering[ordering < available]
+        return ordering
 
     @staticmethod
     def _resolve_pipeline_stage(
@@ -985,9 +1016,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         """Return the complete task path without its task-type suffix.
 
         Unlike `get_task_name`, this keeps every level of a nested task
-        name, so ``"a/b/keypoints"`` groups under ``"a/b"``.
+        name, so ``"a/b/keypoints"`` groups under ``"a/b"``. A task with no
+        name at all is its own group, so that unnamed tasks of different
+        types are not lumped together.
         """
-        return task.removesuffix(get_task_type(task)).removesuffix("/")
+        group = task.removesuffix(get_task_type(task)).removesuffix("/")
+        return group or task
 
     @staticmethod
     def _task_to_target_name(task: str) -> str:

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -1,5 +1,4 @@
 import warnings
-from collections import defaultdict
 from collections.abc import Callable, Iterable
 from math import prod
 from typing import Any, Literal, TypeAlias, cast
@@ -605,6 +604,11 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 and self._target_names_to_task_groups[target_name]
                 == task_group
             }
+        self._bbox_associated_targets = {
+            target_name
+            for associations in bbox_associations.values()
+            for target_name in associations
+        }
 
         with warnings.catch_warnings(record=True):
             self._batch_transform = BatchCompose(
@@ -634,14 +638,28 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
     @override
     def apply(self, input_batch: list[LoaderMultiOutput]) -> LoaderMultiOutput:
-        data_batch, n_keypoints = self._preprocess_batch(input_batch)
+        data_batch, n_keypoints, label_shapes = self._preprocess_batch(
+            input_batch
+        )
 
-        data = self._batch_transform(data_batch)
+        data = self._batch_transform(
+            data_batch, keypoints_per_instance=n_keypoints
+        )
 
+        # Albumentations chokes on zero-size targets, so they are dropped
+        # before the remaining stages. Labels that a batch transform emptied
+        # are remembered so postprocessing can still report them as empty
+        # instead of silently omitting the task.
+        emptied_targets = set()
         for target_name in list(data.keys()):
             value = data[target_name]
             if isinstance(value, np.ndarray) and value.size == 0:
                 del data[target_name]
+                if (
+                    target_name in label_shapes
+                    and target_name in self._bbox_associated_targets
+                ):
+                    emptied_targets.add(target_name)
 
         data = self._spatial_transform(**data)
         data = self._custom_transform(**data)
@@ -661,23 +679,27 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         else:
             data = self._pixel_transform(**data)
 
-        return self._postprocess(data, n_keypoints)
+        return self._postprocess(
+            data, n_keypoints, emptied_targets, label_shapes
+        )
 
     def _preprocess_batch(
         self, labels_batch: list[LoaderMultiOutput]
-    ) -> tuple[list[Data], dict[str, int]]:
+    ) -> tuple[list[Data], dict[str, int], dict[str, tuple[int, ...]]]:
         """Preprocess a batch of labels.
 
         Args:
             labels_batch: Loader outputs to preprocess.
 
         Returns:
-            Preprocessed data and keypoint counts for each task.
+            Preprocessed data, keypoint counts for each task, and the
+            per-annotation LDF shape of every target the batch actually
+            provided labels for.
 
         """
         data_batch = []
-        bbox_counters = defaultdict(int)
         n_keypoints = {}
+        label_shapes: dict[str, tuple[int, ...]] = {}
 
         for image_dict, labels in labels_batch:
             data = {}
@@ -721,15 +743,13 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                     continue
 
                 array = labels[task]
+                label_shapes.setdefault(target_name, array.shape[1:])
 
                 if target_type in {"mask", "instance_mask"}:
                     data[target_name] = preprocess_mask(array)
 
                 elif target_type == "bboxes":
-                    data[target_name] = preprocess_bboxes(
-                        array, bbox_counters[target_name]
-                    )
-                    bbox_counters[target_name] += data[target_name].shape[0]
+                    data[target_name] = preprocess_bboxes(array)
 
                 elif target_type == "keypoints":
                     n_keypoints[target_name] = array.shape[1] // 3
@@ -741,10 +761,14 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
             data_batch.append(data)
 
-        return data_batch, n_keypoints
+        return data_batch, n_keypoints, label_shapes
 
     def _postprocess(
-        self, data: Data, n_keypoints: dict[str, int]
+        self,
+        data: Data,
+        n_keypoints: dict[str, int],
+        emptied_targets: set[str],
+        label_shapes: dict[str, tuple[int, ...]],
     ) -> LoaderMultiOutput:
         """Postprocess the augmented data back to LDF format.
 
@@ -754,6 +778,11 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         Args:
             data: Augmented data keyed by target name.
             n_keypoints: Mapping from task names to keypoint counts.
+            emptied_targets: Targets a batch transform emptied because all
+                the bounding boxes they belong to were filtered out. They
+                are reported as empty labels rather than omitted.
+            label_shapes: Per-annotation LDF shape of every target the input
+                batch provided labels for.
 
         Returns:
             Augmented images and labels.
@@ -806,17 +835,20 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
             task = self._target_names_to_tasks[target_name]
             task_group = self._target_names_to_task_groups[target_name]
 
-            if task_group not in bboxes_indices:
-                if task_group in self._bbox_task_groups:
-                    bbox_ordering = np.array([], dtype=int)
-                elif target_type == "keypoints":
-                    bbox_ordering = np.arange(
-                        array.shape[0] // n_keypoints[target_name]
-                    )
-                else:
-                    bbox_ordering = np.arange(array.shape[0])
-            else:
+            if task_group in bboxes_indices:
                 bbox_ordering = bboxes_indices[task_group]
+            elif task_group in self._bbox_task_groups:
+                bbox_ordering = np.array([], dtype=int)
+            elif target_type == "keypoints":
+                bbox_ordering = np.arange(
+                    array.shape[0] // n_keypoints[target_name]
+                )
+            elif target_type == "instance_mask":
+                # Instance masks are (H, W, N) here, so the instance count
+                # is the last axis, not the first.
+                bbox_ordering = np.arange(array.shape[-1])
+            else:
+                bbox_ordering = np.arange(array.shape[0])
 
             if target_type == "mask":
                 out_labels[task] = postprocess_mask(array)
@@ -838,6 +870,17 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
             elif target_type == "classification":
                 out_labels[task] = array
+
+        for target_name in emptied_targets:
+            # These were dropped before the remaining stages ran, so none of
+            # the loops above can have produced a label for them.
+            task = self._target_names_to_tasks[target_name]
+            if self._targets[target_name] == "instance_mask":
+                # The recorded shape is the pre-augmentation one.
+                trailing = (image_height, image_width)
+            else:
+                trailing = label_shapes[target_name]
+            out_labels[task] = np.zeros((0, *trailing))
 
         return out_image_dict, out_labels
 

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -34,12 +34,10 @@ class BatchCompose(A.Compose):
         Args:
             transforms: Transformations to compose.
             bbox_associations: Bbox fields mapped to their associated target
-                fields and target types. Keyword-only so it cannot be
-                mistaken for `A.Compose`_'s positional ``bbox_params``.
-                Bbox fields listed here are expected to carry a dedicated
+                fields and target types. Fields listed here must carry the
                 index column appended by
                 `luxonis_ml.data.augmentations.utils.preprocess_bboxes`;
-                fields not listed here are left untouched.
+                any other bbox field is left untouched.
             **kwargs: Additional arguments passed to `A.Compose`_.
 
         .. _A.Compose:
@@ -71,9 +69,9 @@ class BatchCompose(A.Compose):
             data_batch: Batch of Albumentations data dictionaries. Its
                 length must equal ``batch_size``.
             keypoints_per_instance: Number of keypoints each instance of a
-                keypoint field carries. Needed to regroup keypoint rows by
-                instance when compacting bbox-associated labels; keypoint
-                fields missing from this mapping are left untouched.
+                keypoint field carries, used to regroup keypoint rows by
+                instance. Fields missing from this mapping are left
+                untouched.
 
         Returns:
             Single transformed data dictionary.
@@ -147,13 +145,10 @@ class BatchCompose(A.Compose):
     def _reindex_bboxes(self, data: dict[str, np.ndarray]) -> dict[str, int]:
         """Give each bbox field contiguous indices and return its size.
 
-        Only fields declared in ``bbox_associations`` are touched. Those carry
-        an index column appended by the engine; for any other bbox field the
-        last column is the class label and must be left alone.
-
-        The indices are local positions into bbox-associated labels. They are
-        assigned before bbox filtering so the surviving indices can be used to
-        compact those labels in lockstep.
+        Only fields declared in ``bbox_associations`` are touched; for any
+        other bbox field the last column is the class label. The indices are
+        positions into the bbox-associated labels, stamped before filtering so
+        that the survivors can be used to compact those labels in lockstep.
         """
         bbox_counts = {}
         bbox_processor = self.processors.get("bboxes")
@@ -173,8 +168,7 @@ class BatchCompose(A.Compose):
                 raise ValueError(
                     f"Bbox field '{field_name}' must be a 2D array."
                 )
-            # A copy rather than an in-place write: the caller's array may
-            # be read-only, and it is not this composition's to modify.
+            # The caller's array may be read-only, and is not ours to modify.
             bboxes = bboxes.copy()
             bboxes[:, -1] = np.arange(len(bboxes), dtype=bboxes.dtype)
             data[field_name] = bboxes
@@ -188,23 +182,21 @@ class BatchCompose(A.Compose):
     ) -> None:
         """Drop labels associated with bboxes filtered from the current stage.
 
-        A field whose length disagrees with the bbox count cannot be matched
-        up instance by instance, so it is left untouched rather than dropped
-        or regrouped on a guess.
+        A field whose instance count disagrees with the bbox count cannot be
+        matched up instance by instance, so it is left untouched rather than
+        dropped or regrouped on a guess.
         """
         for bbox_field, associations in self._bbox_associations.items():
-            # A field is in `bbox_counts` only if `_reindex_bboxes` saw it in
-            # this same dict, and it validated the layout there too.
             if bbox_field not in bbox_counts:
                 continue
-            bboxes = data[bbox_field]
 
             bbox_count = bbox_counts[bbox_field]
-            if bboxes.size == 0:
-                indices = np.array([], dtype=int)
-            else:
-                indices = bboxes[:, -1].astype(int)
-
+            bboxes = data[bbox_field]
+            indices = (
+                bboxes[:, -1].astype(int)
+                if bboxes.size
+                else np.array([], dtype=int)
+            )
             if bbox_count and np.array_equal(indices, np.arange(bbox_count)):
                 continue
 
@@ -223,57 +215,64 @@ class BatchCompose(A.Compose):
                 if value.size == 0:
                     continue
 
-                if target_type == "instance_mask":
-                    if value.shape[-1] != bbox_count:
-                        self._warn_unmatched(
-                            field_name,
-                            f"{value.shape[-1]} instances",
-                            bbox_count,
-                            bbox_field,
-                        )
-                        continue
-                    data[field_name] = value[..., indices]
-                elif target_type == "keypoints":
-                    n_keypoints = keypoints_per_instance.get(field_name)
-                    if (
-                        n_keypoints is None
-                        or value.shape[0] != bbox_count * n_keypoints
-                    ):
-                        self._warn_unmatched(
-                            field_name,
-                            f"{value.shape[0]} keypoint rows",
-                            bbox_count,
-                            bbox_field,
-                        )
-                        continue
-                    grouped = value.reshape(
-                        bbox_count, n_keypoints, *value.shape[1:]
-                    )
-                    data[field_name] = grouped[indices].reshape(
-                        -1, *value.shape[1:]
+                compacted = self._select_instances(
+                    value,
+                    target_type,
+                    indices,
+                    bbox_count,
+                    keypoints_per_instance.get(field_name, 0),
+                )
+                if compacted is None:
+                    self._warn_unmatched(
+                        field_name, value, bbox_count, bbox_field
                     )
                 else:
-                    if len(value) != bbox_count:
-                        self._warn_unmatched(
-                            field_name,
-                            f"{len(value)} values",
-                            bbox_count,
-                            bbox_field,
-                        )
-                        continue
-                    data[field_name] = value[indices]
+                    data[field_name] = compacted
+
+    @staticmethod
+    def _select_instances(
+        value: np.ndarray,
+        target_type: str,
+        indices: np.ndarray,
+        bbox_count: int,
+        n_keypoints: int,
+    ) -> np.ndarray | None:
+        """Keep only the instances at ``indices``, in that order.
+
+        Returns ``None`` if the field does not hold exactly ``bbox_count``
+        instances, in which case it cannot be matched up with the boxes.
+        """
+        if target_type == "instance_mask":
+            # Instance masks are (H, W, N) at this point.
+            if value.shape[-1] != bbox_count:
+                return None
+            return value[..., indices]
+
+        if target_type == "keypoints":
+            if not n_keypoints or value.shape[0] != bbox_count * n_keypoints:
+                return None
+            grouped = value.reshape(bbox_count, n_keypoints, *value.shape[1:])
+            return grouped[indices].reshape(-1, *value.shape[1:])
+
+        if len(value) != bbox_count:
+            return None
+        return value[indices]
 
     def _warn_unmatched(
-        self, field_name: str, found: str, bbox_count: int, bbox_field: str
+        self,
+        field_name: str,
+        value: np.ndarray,
+        bbox_count: int,
+        bbox_field: str,
     ) -> None:
         if field_name in self._mismatched_fields:
             return
         self._mismatched_fields.add(field_name)
         logger.warning(
-            f"Field '{field_name}' has {found} for {bbox_count} bounding "
-            f"boxes in '{bbox_field}', so the two cannot be matched up. "
-            f"Leaving it as is; it may end up misaligned with the bounding "
-            f"boxes that survive augmentation."
+            f"Field '{field_name}' with shape {value.shape} cannot be matched "
+            f"to the {bbox_count} bounding boxes in '{bbox_field}'; leaving "
+            f"it as is. It may end up misaligned with the boxes that survive "
+            f"augmentation."
         )
 
     @staticmethod

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -80,8 +80,8 @@ class BatchCompose(A.Compose):
                 if isinstance(next(iter(data.values())), list):
                     data = {key: value[0] for key, value in batch.items()}
 
-                data = self.check_data_post_transform(data)
                 self._reindex_bboxes(data)
+                data = self.check_data_post_transform(data)
                 new_batch.append(data)
             data_batch = new_batch
 
@@ -104,6 +104,18 @@ class BatchCompose(A.Compose):
         bbox indices assigned for its position in the original input batch.
         Instance masks and other bbox-associated labels are compacted with the
         output, so subsequent batch transforms require contiguous indices.
+
+        The last bbox column is the stable index that ``_postprocess`` uses to
+        pair each surviving box with its instance mask channel (and keypoints,
+        arrays, metadata). After a batch transform those labels are
+        concatenated in the same order as the boxes, so position ``i`` in the
+        box array lines up with channel ``i`` in the concatenated labels.
+        Assigning ``arange`` restores that alignment only while the two are
+        still in lockstep, so this must run on the *complete* set of boxes,
+        before ``check_data_post_transform`` drops any of them. Reindexing
+        after a drop would renumber the survivors ``0..M-1`` while the label
+        channels stay un-dropped, silently pairing boxes with the wrong
+        instances.
         """
         for field_name in self.processors["bboxes"].data_fields:
             bboxes = data.get(field_name)

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -21,11 +21,18 @@ class BatchCompose(A.Compose):
 
     transforms: list[BatchTransform]
 
-    def __init__(self, transforms: TransformsSeqType, **kwargs):
+    def __init__(
+        self,
+        transforms: TransformsSeqType,
+        bbox_associations: dict[str, dict[str, str]] | None = None,
+        **kwargs,
+    ):
         """Compose batch transforms.
 
         Args:
             transforms: Transformations to compose.
+            bbox_associations: Bbox fields mapped to their associated target
+                fields and target types.
             **kwargs: Additional arguments passed to `A.Compose`_.
 
         .. _A.Compose:
@@ -33,6 +40,7 @@ class BatchCompose(A.Compose):
 
         """
         super().__init__(transforms, is_check_shapes=False, **kwargs)
+        self._bbox_associations = bbox_associations or {}
 
         random.seed(self.seed)
         np.random.seed(self.seed)
@@ -80,8 +88,10 @@ class BatchCompose(A.Compose):
                 if isinstance(next(iter(data.values())), list):
                     data = {key: value[0] for key, value in batch.items()}
 
-                self._reindex_bboxes(data)
+                bbox_counts = self._reindex_bboxes(data)
                 data = self.check_data_post_transform(data)
+                self._compact_bbox_associated_labels(data, bbox_counts)
+                self._reindex_bboxes(data)
                 new_batch.append(data)
             data_batch = new_batch
 
@@ -96,32 +106,95 @@ class BatchCompose(A.Compose):
 
         return data
 
-    def _reindex_bboxes(self, data: dict[str, np.ndarray]) -> None:
-        """Reindex boxes to match their associated batched labels.
+    def _reindex_bboxes(self, data: dict[str, np.ndarray]) -> dict[str, int]:
+        """Give each bbox field contiguous indices and return its size.
 
-        Batch transforms can reduce several input samples to one output. In
-        particular, when a transform is skipped, the retained sample can keep
-        bbox indices assigned for its position in the original input batch.
-        Instance masks and other bbox-associated labels are compacted with the
-        output, so subsequent batch transforms require contiguous indices.
-
-        The last bbox column is the stable index that ``_postprocess`` uses to
-        pair each surviving box with its instance mask channel (and keypoints,
-        arrays, metadata). After a batch transform those labels are
-        concatenated in the same order as the boxes, so position ``i`` in the
-        box array lines up with channel ``i`` in the concatenated labels.
-        Assigning ``arange`` restores that alignment only while the two are
-        still in lockstep, so this must run on the *complete* set of boxes,
-        before ``check_data_post_transform`` drops any of them. Reindexing
-        after a drop would renumber the survivors ``0..M-1`` while the label
-        channels stay un-dropped, silently pairing boxes with the wrong
-        instances.
+        The indices are local positions into bbox-associated labels. They are
+        assigned before bbox filtering so the surviving indices can be used to
+        compact those labels in lockstep.
         """
-        for field_name in self.processors["bboxes"].data_fields:
+        bbox_counts = {}
+        bbox_processor = self.processors.get("bboxes")
+        if bbox_processor is None:
+            return bbox_counts
+
+        for field_name in bbox_processor.data_fields:
             bboxes = data.get(field_name)
-            if bboxes is None or bboxes.size == 0:
+            if bboxes is None:
                 continue
+            bbox_counts[field_name] = len(bboxes)
+            if bboxes.size == 0:
+                continue
+            if bboxes.ndim < 2:
+                raise ValueError(
+                    f"Bbox field '{field_name}' must be a 2D array."
+                )
             bboxes[:, -1] = np.arange(len(bboxes), dtype=bboxes.dtype)
+        return bbox_counts
+
+    def _compact_bbox_associated_labels(
+        self, data: dict[str, np.ndarray], bbox_counts: dict[str, int]
+    ) -> None:
+        """Drop labels associated with bboxes filtered from the current stage."""
+        for bbox_field, associations in self._bbox_associations.items():
+            bboxes = data.get(bbox_field)
+            if bboxes is None:
+                continue
+
+            bbox_count = bbox_counts.get(bbox_field, 0)
+            if bboxes.size == 0:
+                indices = np.array([], dtype=int)
+            elif bboxes.ndim < 2:
+                raise ValueError(
+                    f"Bbox field '{bbox_field}' must be a 2D array."
+                )
+            else:
+                indices = bboxes[:, -1].astype(int)
+
+            for field_name, target_type in associations.items():
+                value = data.get(field_name)
+                if value is None:
+                    continue
+
+                if bbox_count == 0:
+                    if target_type == "instance_mask" and value.ndim > 1:
+                        data[field_name] = value[..., :0]
+                    else:
+                        data[field_name] = value[:0]
+                    continue
+
+                if value.size == 0:
+                    continue
+
+                if target_type == "instance_mask":
+                    if value.shape[-1] != bbox_count:
+                        raise ValueError(
+                            f"Instance-mask field '{field_name}' has "
+                            f"{value.shape[-1]} instances for {bbox_count} "
+                            f"bboxes in '{bbox_field}'."
+                        )
+                    data[field_name] = value[..., indices]
+                elif target_type == "keypoints":
+                    if value.shape[0] % bbox_count:
+                        raise ValueError(
+                            f"Keypoint field '{field_name}' has "
+                            f"{value.shape[0]} rows, which cannot be grouped "
+                            f"across {bbox_count} bboxes in '{bbox_field}'."
+                        )
+                    keypoints_per_bbox = value.shape[0] // bbox_count
+                    grouped = value.reshape(
+                        bbox_count, keypoints_per_bbox, *value.shape[1:]
+                    )
+                    data[field_name] = grouped[indices].reshape(
+                        -1, *value.shape[1:]
+                    )
+                else:
+                    if len(value) != bbox_count:
+                        raise ValueError(
+                            f"Field '{field_name}' has {len(value)} values for "
+                            f"{bbox_count} bboxes in '{bbox_field}'."
+                        )
+                    data[field_name] = value[indices]
 
     @staticmethod
     def _make_contiguous(data: dict[str, np.ndarray]) -> dict[str, np.ndarray]:

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -81,6 +81,7 @@ class BatchCompose(A.Compose):
                     data = {key: value[0] for key, value in batch.items()}
 
                 data = self.check_data_post_transform(data)
+                self._reindex_bboxes(data)
                 new_batch.append(data)
             data_batch = new_batch
 
@@ -94,6 +95,21 @@ class BatchCompose(A.Compose):
         data["_original_image_key"] = original_image_key
 
         return data
+
+    def _reindex_bboxes(self, data: dict[str, np.ndarray]) -> None:
+        """Reindex boxes to match their associated batched labels.
+
+        Batch transforms can reduce several input samples to one output. In
+        particular, when a transform is skipped, the retained sample can keep
+        bbox indices assigned for its position in the original input batch.
+        Instance masks and other bbox-associated labels are compacted with the
+        output, so subsequent batch transforms require contiguous indices.
+        """
+        for field_name in self.processors["bboxes"].data_fields:
+            bboxes = data.get(field_name)
+            if bboxes is None or bboxes.size == 0:
+                continue
+            bboxes[:, -1] = np.arange(len(bboxes), dtype=bboxes.dtype)
 
     @staticmethod
     def _make_contiguous(data: dict[str, np.ndarray]) -> dict[str, np.ndarray]:

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -3,6 +3,7 @@ import random
 import albumentations as A
 import numpy as np
 from albumentations.core.composition import TransformsSeqType
+from loguru import logger
 from typing_extensions import override
 
 from .batch_transform import BatchTransform
@@ -24,6 +25,7 @@ class BatchCompose(A.Compose):
     def __init__(
         self,
         transforms: TransformsSeqType,
+        *,
         bbox_associations: dict[str, dict[str, str]] | None = None,
         **kwargs,
     ):
@@ -32,7 +34,12 @@ class BatchCompose(A.Compose):
         Args:
             transforms: Transformations to compose.
             bbox_associations: Bbox fields mapped to their associated target
-                fields and target types.
+                fields and target types. Keyword-only so it cannot be
+                mistaken for `A.Compose`_'s positional ``bbox_params``.
+                Bbox fields listed here are expected to carry a dedicated
+                index column appended by
+                `luxonis_ml.data.augmentations.utils.preprocess_bboxes`;
+                fields not listed here are left untouched.
             **kwargs: Additional arguments passed to `A.Compose`_.
 
         .. _A.Compose:
@@ -41,6 +48,7 @@ class BatchCompose(A.Compose):
         """
         super().__init__(transforms, is_check_shapes=False, **kwargs)
         self._bbox_associations = bbox_associations or {}
+        self._mismatched_fields: set[str] = set()
 
         random.seed(self.seed)
         np.random.seed(self.seed)
@@ -51,13 +59,20 @@ class BatchCompose(A.Compose):
 
     @override
     def __call__(
-        self, data_batch: list[dict[str, np.ndarray]]
+        self,
+        data_batch: list[dict[str, np.ndarray]],
+        *,
+        keypoints_per_instance: dict[str, int] | None = None,
     ) -> dict[str, np.ndarray]:
         """Apply the composed transforms to a batch.
 
         Args:
             data_batch: Batch of Albumentations data dictionaries. Its
                 length must equal ``batch_size``.
+            keypoints_per_instance: Number of keypoints each instance of a
+                keypoint field carries. Needed to regroup keypoint rows by
+                instance when compacting bbox-associated labels; keypoint
+                fields missing from this mapping are left untouched.
 
         Returns:
             Single transformed data dictionary.
@@ -90,7 +105,11 @@ class BatchCompose(A.Compose):
 
                 bbox_counts = self._reindex_bboxes(data)
                 data = self.check_data_post_transform(data)
-                self._compact_bbox_associated_labels(data, bbox_counts)
+                self._compact_bbox_associated_labels(
+                    data, bbox_counts, keypoints_per_instance or {}
+                )
+                # Filtering left gaps in the index column; close them so the
+                # next transform starts from contiguous indices again.
                 self._reindex_bboxes(data)
                 new_batch.append(data)
             data_batch = new_batch
@@ -109,6 +128,10 @@ class BatchCompose(A.Compose):
     def _reindex_bboxes(self, data: dict[str, np.ndarray]) -> dict[str, int]:
         """Give each bbox field contiguous indices and return its size.
 
+        Only fields declared in ``bbox_associations`` are touched. Those carry
+        an index column appended by the engine; for any other bbox field the
+        last column is the class label and must be left alone.
+
         The indices are local positions into bbox-associated labels. They are
         assigned before bbox filtering so the surviving indices can be used to
         compact those labels in lockstep.
@@ -119,6 +142,8 @@ class BatchCompose(A.Compose):
             return bbox_counts
 
         for field_name in bbox_processor.data_fields:
+            if field_name not in self._bbox_associations:
+                continue
             bboxes = data.get(field_name)
             if bboxes is None:
                 continue
@@ -129,27 +154,40 @@ class BatchCompose(A.Compose):
                 raise ValueError(
                     f"Bbox field '{field_name}' must be a 2D array."
                 )
+            # A copy rather than an in-place write: the caller's array may
+            # be read-only, and it is not this composition's to modify.
+            bboxes = bboxes.copy()
             bboxes[:, -1] = np.arange(len(bboxes), dtype=bboxes.dtype)
+            data[field_name] = bboxes
         return bbox_counts
 
     def _compact_bbox_associated_labels(
-        self, data: dict[str, np.ndarray], bbox_counts: dict[str, int]
+        self,
+        data: dict[str, np.ndarray],
+        bbox_counts: dict[str, int],
+        keypoints_per_instance: dict[str, int],
     ) -> None:
-        """Drop labels associated with bboxes filtered from the current stage."""
-        for bbox_field, associations in self._bbox_associations.items():
-            bboxes = data.get(bbox_field)
-            if bboxes is None:
-                continue
+        """Drop labels associated with bboxes filtered from the current stage.
 
-            bbox_count = bbox_counts.get(bbox_field, 0)
+        A field whose length disagrees with the bbox count cannot be matched
+        up instance by instance, so it is left untouched rather than dropped
+        or regrouped on a guess.
+        """
+        for bbox_field, associations in self._bbox_associations.items():
+            # A field is in `bbox_counts` only if `_reindex_bboxes` saw it in
+            # this same dict, and it validated the layout there too.
+            if bbox_field not in bbox_counts:
+                continue
+            bboxes = data[bbox_field]
+
+            bbox_count = bbox_counts[bbox_field]
             if bboxes.size == 0:
                 indices = np.array([], dtype=int)
-            elif bboxes.ndim < 2:
-                raise ValueError(
-                    f"Bbox field '{bbox_field}' must be a 2D array."
-                )
             else:
                 indices = bboxes[:, -1].astype(int)
+
+            if bbox_count and np.array_equal(indices, np.arange(bbox_count)):
+                continue
 
             for field_name, target_type in associations.items():
                 value = data.get(field_name)
@@ -168,33 +206,56 @@ class BatchCompose(A.Compose):
 
                 if target_type == "instance_mask":
                     if value.shape[-1] != bbox_count:
-                        raise ValueError(
-                            f"Instance-mask field '{field_name}' has "
-                            f"{value.shape[-1]} instances for {bbox_count} "
-                            f"bboxes in '{bbox_field}'."
+                        self._warn_unmatched(
+                            field_name,
+                            f"{value.shape[-1]} instances",
+                            bbox_count,
+                            bbox_field,
                         )
+                        continue
                     data[field_name] = value[..., indices]
                 elif target_type == "keypoints":
-                    if value.shape[0] % bbox_count:
-                        raise ValueError(
-                            f"Keypoint field '{field_name}' has "
-                            f"{value.shape[0]} rows, which cannot be grouped "
-                            f"across {bbox_count} bboxes in '{bbox_field}'."
+                    n_keypoints = keypoints_per_instance.get(field_name)
+                    if (
+                        n_keypoints is None
+                        or value.shape[0] != bbox_count * n_keypoints
+                    ):
+                        self._warn_unmatched(
+                            field_name,
+                            f"{value.shape[0]} keypoint rows",
+                            bbox_count,
+                            bbox_field,
                         )
-                    keypoints_per_bbox = value.shape[0] // bbox_count
+                        continue
                     grouped = value.reshape(
-                        bbox_count, keypoints_per_bbox, *value.shape[1:]
+                        bbox_count, n_keypoints, *value.shape[1:]
                     )
                     data[field_name] = grouped[indices].reshape(
                         -1, *value.shape[1:]
                     )
                 else:
                     if len(value) != bbox_count:
-                        raise ValueError(
-                            f"Field '{field_name}' has {len(value)} values for "
-                            f"{bbox_count} bboxes in '{bbox_field}'."
+                        self._warn_unmatched(
+                            field_name,
+                            f"{len(value)} values",
+                            bbox_count,
+                            bbox_field,
                         )
+                        continue
                     data[field_name] = value[indices]
+
+    def _warn_unmatched(
+        self, field_name: str, found: str, bbox_count: int, bbox_field: str
+    ) -> None:
+        if field_name in self._mismatched_fields:
+            return
+        self._mismatched_fields.add(field_name)
+        logger.warning(
+            f"Field '{field_name}' has {found} for {bbox_count} bounding "
+            f"boxes in '{bbox_field}', so the two cannot be matched up. "
+            f"Leaving it as is; it may end up misaligned with the bounding "
+            f"boxes that survive augmentation."
+        )
 
     @staticmethod
     def _make_contiguous(data: dict[str, np.ndarray]) -> dict[str, np.ndarray]:

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -301,9 +301,13 @@ class BatchCompose(A.Compose):
                 if value.size == 0:
                     continue
 
+                # Keypoint rows can only be counted by instance once it is
+                # known how many keypoints each instance carries.
                 n_keypoints = keypoints_per_instance.get(field_name, 0)
-                if (
-                    self._count_instances(value, target_type, n_keypoints)
+                countable = target_type != "keypoints" or n_keypoints > 0
+
+                if not countable or (
+                    instance_count(value, target_type, n_keypoints)
                     != bbox_count
                 ):
                     self._warn_unmatched(
@@ -313,15 +317,6 @@ class BatchCompose(A.Compose):
                     data[field_name] = self._select_instances(
                         value, target_type, indices, bbox_count, n_keypoints
                     )
-
-    @staticmethod
-    def _count_instances(
-        value: np.ndarray, target_type: str, n_keypoints: int
-    ) -> int | None:
-        """Instances in ``value``, or ``None`` if they cannot be counted."""
-        if target_type == "keypoints" and n_keypoints < 1:
-            return None
-        return instance_count(value, target_type, n_keypoints)
 
     @staticmethod
     def _select_instances(

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -7,7 +7,7 @@ from loguru import logger
 from typing_extensions import override
 
 from .batch_transform import BatchTransform
-from .utils import yield_batches
+from .utils import instance_count, yield_batches
 
 
 class BatchCompose(A.Compose):
@@ -47,6 +47,7 @@ class BatchCompose(A.Compose):
         super().__init__(transforms, is_check_shapes=False, **kwargs)
         self._bbox_associations = bbox_associations or {}
         self._mismatched_fields: set[str] = set()
+        self._index_column = self._locate_index_column()
 
         random.seed(self.seed)
         np.random.seed(self.seed)
@@ -87,6 +88,9 @@ class BatchCompose(A.Compose):
                 f"but got {len(data_batch)}."
             )
 
+        keypoints_per_instance = keypoints_per_instance or {}
+        self._mismatched_fields = set()
+
         input_indices = [[i] for i in range(len(data_batch))]
         if not self.transforms:
             return data_batch[0]
@@ -101,13 +105,18 @@ class BatchCompose(A.Compose):
             for i, batch in enumerate(
                 yield_batches(data_batch, transform.batch_size)
             ):
+                # Captured before padding so that a transform which does not
+                # fire returns the first sample exactly as it came in.
+                first_sample = {key: value[0] for key, value in batch.items()}
+                self._pad_absent_instances(batch, keypoints_per_instance)
+
                 data = transform(**batch)  # type: ignore
                 batch_indices = input_indices[
                     i * transform.batch_size : (i + 1) * transform.batch_size
                 ]
 
                 if not transform.params:
-                    data = {key: value[0] for key, value in batch.items()}
+                    data = first_sample
                     new_indices.append(batch_indices[0])
                 else:
                     new_indices.append(
@@ -121,7 +130,7 @@ class BatchCompose(A.Compose):
                 bbox_counts = self._reindex_bboxes(data)
                 data = self.check_data_post_transform(data)
                 self._compact_bbox_associated_labels(
-                    data, bbox_counts, keypoints_per_instance or {}
+                    data, bbox_counts, keypoints_per_instance
                 )
                 # Filtering left gaps in the index column; close them so the
                 # next transform starts from contiguous indices again.
@@ -142,6 +151,83 @@ class BatchCompose(A.Compose):
 
         return data
 
+    def _locate_index_column(self) -> int:
+        """Position of the instance-index column, counted from the right.
+
+        `luxonis_ml.data.augmentations.utils.preprocess_bboxes` appends the
+        index as the last column, but the wrapped bbox processor appends one
+        more column for every configured label field, pushing the index left.
+        """
+        processor = self.processors.get("bboxes")
+        if processor is None:
+            return -1
+        return -1 - len(processor.params.label_fields or [])
+
+    def _pad_absent_instances(
+        self,
+        batch: dict[str, list[np.ndarray]],
+        keypoints_per_instance: dict[str, int],
+    ) -> None:
+        """Give samples missing an associated label one empty instance per box.
+
+        Batch transforms concatenate only the samples that carry a field, so
+        in a partially annotated batch the merged labels would come back
+        shorter than the merged boxes with no way to tell which boxes they
+        belong to. Filling the gaps keeps the two one-to-one.
+        """
+        image_shapes = [image.shape[:2] for image in batch.get("image", [])]
+
+        for bbox_field, associations in self._bbox_associations.items():
+            if bbox_field not in batch:
+                continue
+
+            bbox_counts = [len(bboxes) for bboxes in batch[bbox_field]]
+
+            for field_name, target_type in associations.items():
+                if field_name not in batch:
+                    continue
+                self._fill_empty_entries(
+                    batch[field_name],
+                    target_type,
+                    bbox_counts,
+                    image_shapes,
+                    keypoints_per_instance.get(field_name, 0),
+                )
+
+    @staticmethod
+    def _fill_empty_entries(
+        values: list[np.ndarray],
+        target_type: str,
+        bbox_counts: list[int],
+        image_shapes: list[tuple[int, ...]],
+        n_keypoints: int,
+    ) -> None:
+        """Replace each empty entry with zeroed instances, one per box.
+
+        The layout is copied from a populated entry, so a field no sample in
+        the batch carries is left empty rather than invented.
+        """
+        template = next((value for value in values if value.size), None)
+        if template is None:
+            return
+        if target_type == "keypoints" and n_keypoints < 1:
+            return
+
+        for i, value in enumerate(values):
+            if value.size or not bbox_counts[i]:
+                continue
+
+            if target_type == "instance_mask":
+                if i >= len(image_shapes):
+                    continue
+                shape = (*image_shapes[i], bbox_counts[i])
+            elif target_type == "keypoints":
+                shape = (bbox_counts[i] * n_keypoints, *template.shape[1:])
+            else:
+                shape = (bbox_counts[i], *template.shape[1:])
+
+            values[i] = np.zeros(shape, dtype=template.dtype)
+
     def _reindex_bboxes(self, data: dict[str, np.ndarray]) -> dict[str, int]:
         """Give each bbox field contiguous indices and return its size.
 
@@ -151,13 +237,8 @@ class BatchCompose(A.Compose):
         that the survivors can be used to compact those labels in lockstep.
         """
         bbox_counts = {}
-        bbox_processor = self.processors.get("bboxes")
-        if bbox_processor is None:
-            return bbox_counts
 
-        for field_name in bbox_processor.data_fields:
-            if field_name not in self._bbox_associations:
-                continue
+        for field_name in self._bbox_associations:
             bboxes = data.get(field_name)
             if bboxes is None:
                 continue
@@ -170,7 +251,9 @@ class BatchCompose(A.Compose):
                 )
             # The caller's array may be read-only, and is not ours to modify.
             bboxes = bboxes.copy()
-            bboxes[:, -1] = np.arange(len(bboxes), dtype=bboxes.dtype)
+            bboxes[:, self._index_column] = np.arange(
+                len(bboxes), dtype=bboxes.dtype
+            )
             data[field_name] = bboxes
         return bbox_counts
 
@@ -184,7 +267,9 @@ class BatchCompose(A.Compose):
 
         A field whose instance count disagrees with the bbox count cannot be
         matched up instance by instance, so it is left untouched rather than
-        dropped or regrouped on a guess.
+        dropped or regrouped on a guess. The counts are compared even when
+        nothing was filtered, because a transform that drops boxes itself
+        leaves the surviving indices looking untouched.
         """
         for bbox_field, associations in self._bbox_associations.items():
             if bbox_field not in bbox_counts:
@@ -193,12 +278,13 @@ class BatchCompose(A.Compose):
             bbox_count = bbox_counts[bbox_field]
             bboxes = data[bbox_field]
             indices = (
-                bboxes[:, -1].astype(int)
+                bboxes[:, self._index_column].astype(int)
                 if bboxes.size
                 else np.array([], dtype=int)
             )
-            if bbox_count and np.array_equal(indices, np.arange(bbox_count)):
-                continue
+            unfiltered = bool(
+                bbox_count and np.array_equal(indices, np.arange(bbox_count))
+            )
 
             for field_name, target_type in associations.items():
                 value = data.get(field_name)
@@ -215,19 +301,27 @@ class BatchCompose(A.Compose):
                 if value.size == 0:
                     continue
 
-                compacted = self._select_instances(
-                    value,
-                    target_type,
-                    indices,
-                    bbox_count,
-                    keypoints_per_instance.get(field_name, 0),
-                )
-                if compacted is None:
+                n_keypoints = keypoints_per_instance.get(field_name, 0)
+                if (
+                    self._count_instances(value, target_type, n_keypoints)
+                    != bbox_count
+                ):
                     self._warn_unmatched(
                         field_name, value, bbox_count, bbox_field
                     )
-                else:
-                    data[field_name] = compacted
+                elif not unfiltered:
+                    data[field_name] = self._select_instances(
+                        value, target_type, indices, bbox_count, n_keypoints
+                    )
+
+    @staticmethod
+    def _count_instances(
+        value: np.ndarray, target_type: str, n_keypoints: int
+    ) -> int | None:
+        """Instances in ``value``, or ``None`` if they cannot be counted."""
+        if target_type == "keypoints" and n_keypoints < 1:
+            return None
+        return instance_count(value, target_type, n_keypoints)
 
     @staticmethod
     def _select_instances(
@@ -236,26 +330,16 @@ class BatchCompose(A.Compose):
         indices: np.ndarray,
         bbox_count: int,
         n_keypoints: int,
-    ) -> np.ndarray | None:
-        """Keep only the instances at ``indices``, in that order.
-
-        Returns ``None`` if the field does not hold exactly ``bbox_count``
-        instances, in which case it cannot be matched up with the boxes.
-        """
+    ) -> np.ndarray:
+        """Keep only the instances at ``indices``, in that order."""
         if target_type == "instance_mask":
             # Instance masks are (H, W, N) at this point.
-            if value.shape[-1] != bbox_count:
-                return None
             return value[..., indices]
 
         if target_type == "keypoints":
-            if not n_keypoints or value.shape[0] != bbox_count * n_keypoints:
-                return None
             grouped = value.reshape(bbox_count, n_keypoints, *value.shape[1:])
             return grouped[indices].reshape(-1, *value.shape[1:])
 
-        if len(value) != bbox_count:
-            return None
         return value[indices]
 
     def _warn_unmatched(
@@ -265,6 +349,7 @@ class BatchCompose(A.Compose):
         bbox_count: int,
         bbox_field: str,
     ) -> None:
+        """Warn once per field per sample that a field could not be matched."""
         if field_name in self._mismatched_fields:
             return
         self._mismatched_fields.add(field_name)

--- a/luxonis_ml/data/augmentations/custom/mixup.py
+++ b/luxonis_ml/data/augmentations/custom/mixup.py
@@ -10,6 +10,19 @@ from luxonis_ml.data.augmentations.batch_transform import BatchTransform
 from luxonis_ml.data.augmentations.custom import LetterboxResize
 
 
+def _column_count(batch: list[np.ndarray], default: int) -> int:
+    """Column count to give empty entries so concatenation lines up.
+
+    Albumentations sizes these rows differently depending on which optional
+    fields a pipeline uses, so the width is taken from a populated entry
+    rather than assumed.
+    """
+    for array in batch:
+        if array.size > 0 and array.ndim == 2:
+            return array.shape[1]
+    return default
+
+
 class MixUp(BatchTransform):
     r"""Batch-based augmentation that blends two images together.
 
@@ -187,10 +200,11 @@ class MixUp(BatchTransform):
             Transformed bounding boxes.
 
         """
+        n_columns = _column_count(bboxes_batch, default=6)
         for i in range(len(bboxes_batch)):
             bbox = bboxes_batch[i]
-            if bbox.size == 0:  # pragma: no cover
-                bboxes_batch[i] = np.zeros((0, 6), dtype=bbox.dtype)
+            if bbox.size == 0:
+                bboxes_batch[i] = np.zeros((0, n_columns), dtype=bbox.dtype)
 
         bboxes_batch[1] = self._resize(
             bboxes_batch[1],
@@ -219,10 +233,11 @@ class MixUp(BatchTransform):
             Transformed keypoints.
 
         """
+        n_columns = _column_count(keypoints_batch, default=6)
         for i in range(len(keypoints_batch)):
-            if keypoints_batch[i].size == 0:  # pragma: no cover
+            if keypoints_batch[i].size == 0:
                 keypoints_batch[i] = np.zeros(
-                    (0, 5), dtype=keypoints_batch[i].dtype
+                    (0, n_columns), dtype=keypoints_batch[i].dtype
                 )
 
         keypoints_batch[1] = self._resize(
@@ -282,7 +297,6 @@ class MixUp(BatchTransform):
             return self._resize_transform.apply_to_bboxes(
                 data, *padding, **kwargs
             )
-        if target_type == "keypoints":
-            return self._resize_transform.apply_to_keypoints(
-                data, *padding, **kwargs
-            )
+        return self._resize_transform.apply_to_keypoints(
+            data, *padding, **kwargs
+        )

--- a/luxonis_ml/data/augmentations/custom/mixup.py
+++ b/luxonis_ml/data/augmentations/custom/mixup.py
@@ -14,8 +14,7 @@ def _column_count(batch: list[np.ndarray], default: int) -> int:
     """Column count to give empty entries so concatenation lines up.
 
     Albumentations sizes these rows differently depending on which optional
-    fields a pipeline uses, so the width is taken from a populated entry
-    rather than assumed.
+    fields a pipeline uses, so the width is read off a populated entry.
     """
     for array in batch:
         if array.size > 0 and array.ndim == 2:

--- a/luxonis_ml/data/augmentations/custom/mixup.py
+++ b/luxonis_ml/data/augmentations/custom/mixup.py
@@ -8,18 +8,11 @@ from typing_extensions import override
 
 from luxonis_ml.data.augmentations.batch_transform import BatchTransform
 from luxonis_ml.data.augmentations.custom import LetterboxResize
-
-
-def _column_count(batch: list[np.ndarray], default: int) -> int:
-    """Column count to give empty entries so concatenation lines up.
-
-    Albumentations sizes these rows differently depending on which optional
-    fields a pipeline uses, so the width is read off a populated entry.
-    """
-    for array in batch:
-        if array.size > 0 and array.ndim == 2:
-            return array.shape[1]
-    return default
+from luxonis_ml.data.augmentations.utils import (
+    BBOX_COLUMNS,
+    KEYPOINT_COLUMNS,
+    pad_empty_entries,
+)
 
 
 class MixUp(BatchTransform):
@@ -199,11 +192,7 @@ class MixUp(BatchTransform):
             Transformed bounding boxes.
 
         """
-        n_columns = _column_count(bboxes_batch, default=6)
-        for i in range(len(bboxes_batch)):
-            bbox = bboxes_batch[i]
-            if bbox.size == 0:
-                bboxes_batch[i] = np.zeros((0, n_columns), dtype=bbox.dtype)
+        bboxes_batch = pad_empty_entries(bboxes_batch, default=BBOX_COLUMNS)
 
         bboxes_batch[1] = self._resize(
             bboxes_batch[1],
@@ -232,12 +221,9 @@ class MixUp(BatchTransform):
             Transformed keypoints.
 
         """
-        n_columns = _column_count(keypoints_batch, default=6)
-        for i in range(len(keypoints_batch)):
-            if keypoints_batch[i].size == 0:
-                keypoints_batch[i] = np.zeros(
-                    (0, n_columns), dtype=keypoints_batch[i].dtype
-                )
+        keypoints_batch = pad_empty_entries(
+            keypoints_batch, default=KEYPOINT_COLUMNS
+        )
 
         keypoints_batch[1] = self._resize(
             keypoints_batch[1],

--- a/luxonis_ml/data/augmentations/custom/mixup.py
+++ b/luxonis_ml/data/augmentations/custom/mixup.py
@@ -8,11 +8,7 @@ from typing_extensions import override
 
 from luxonis_ml.data.augmentations.batch_transform import BatchTransform
 from luxonis_ml.data.augmentations.custom import LetterboxResize
-from luxonis_ml.data.augmentations.utils import (
-    BBOX_COLUMNS,
-    KEYPOINT_COLUMNS,
-    pad_empty_entries,
-)
+from luxonis_ml.data.augmentations.utils import pad_empty_entries
 
 
 class MixUp(BatchTransform):
@@ -192,7 +188,7 @@ class MixUp(BatchTransform):
             Transformed bounding boxes.
 
         """
-        bboxes_batch = pad_empty_entries(bboxes_batch, default=BBOX_COLUMNS)
+        bboxes_batch = pad_empty_entries(bboxes_batch)
 
         bboxes_batch[1] = self._resize(
             bboxes_batch[1],
@@ -221,9 +217,7 @@ class MixUp(BatchTransform):
             Transformed keypoints.
 
         """
-        keypoints_batch = pad_empty_entries(
-            keypoints_batch, default=KEYPOINT_COLUMNS
-        )
+        keypoints_batch = pad_empty_entries(keypoints_batch)
 
         keypoints_batch[1] = self._resize(
             keypoints_batch[1],

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -8,6 +8,11 @@ from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from typing_extensions import override
 
 from luxonis_ml.data.augmentations.batch_transform import BatchTransform
+from luxonis_ml.data.augmentations.utils import (
+    BBOX_COLUMNS,
+    KEYPOINT_COLUMNS,
+    pad_empty_entries,
+)
 from luxonis_ml.utils.logging import deprecated
 
 
@@ -268,12 +273,10 @@ class Mosaic4(BatchTransform):
 
         """
         new_bboxes = []
+        bboxes_batch = pad_empty_entries(bboxes_batch, default=BBOX_COLUMNS)
         for i, (bboxes, (orig_height, orig_width)) in enumerate(
             zip(bboxes_batch, image_shapes, strict=True)
         ):
-            if bboxes.size == 0:  # pragma: no cover
-                bboxes = np.zeros((0, 6), dtype=bboxes.dtype)
-
             bbox = self._apply_mosaic4_to_bboxes(
                 bboxes,
                 orig_height,
@@ -310,12 +313,12 @@ class Mosaic4(BatchTransform):
 
         """
         new_keypoints = []
+        keypoints_batch = pad_empty_entries(
+            keypoints_batch, default=KEYPOINT_COLUMNS
+        )
         for i, (keypoints, (orig_height, orig_width)) in enumerate(
             zip(keypoints_batch, image_shapes, strict=True)
         ):
-            if keypoints.size == 0:
-                keypoints = np.zeros((0, 6), dtype=keypoints.dtype)
-
             new_keypoint = self._apply_mosaic4_to_keypoints(
                 keypoints,
                 orig_height,

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -8,11 +8,7 @@ from albumentations.core.bbox_utils import denormalize_bboxes, normalize_bboxes
 from typing_extensions import override
 
 from luxonis_ml.data.augmentations.batch_transform import BatchTransform
-from luxonis_ml.data.augmentations.utils import (
-    BBOX_COLUMNS,
-    KEYPOINT_COLUMNS,
-    pad_empty_entries,
-)
+from luxonis_ml.data.augmentations.utils import pad_empty_entries
 from luxonis_ml.utils.logging import deprecated
 
 
@@ -273,7 +269,7 @@ class Mosaic4(BatchTransform):
 
         """
         new_bboxes = []
-        bboxes_batch = pad_empty_entries(bboxes_batch, default=BBOX_COLUMNS)
+        bboxes_batch = pad_empty_entries(bboxes_batch)
         for i, (bboxes, (orig_height, orig_width)) in enumerate(
             zip(bboxes_batch, image_shapes, strict=True)
         ):
@@ -313,9 +309,7 @@ class Mosaic4(BatchTransform):
 
         """
         new_keypoints = []
-        keypoints_batch = pad_empty_entries(
-            keypoints_batch, default=KEYPOINT_COLUMNS
-        )
+        keypoints_batch = pad_empty_entries(keypoints_batch)
         for i, (keypoints, (orig_height, orig_width)) in enumerate(
             zip(keypoints_batch, image_shapes, strict=True)
         ):

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -454,8 +454,6 @@ class Mosaic4(BatchTransform):
                 ]
                 out_masks.append(combined_mask)
 
-        # Any mask with a nonzero size has at least one instance, so the
-        # guard above is the only way to end up with nothing to stack.
         return np.stack(out_masks, axis=-1)
 
     @staticmethod

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -454,9 +454,8 @@ class Mosaic4(BatchTransform):
                 ]
                 out_masks.append(combined_mask)
 
-        if not out_masks:
-            return np.zeros((out_height, out_width, 0), dtype=np.uint8)
-
+        # Any mask with a nonzero size has at least one instance, so the
+        # guard above is the only way to end up with nothing to stack.
         return np.stack(out_masks, axis=-1)
 
     @staticmethod
@@ -542,7 +541,7 @@ class Mosaic4(BatchTransform):
         elif position_index == 2:
             shift_x = out_width - in_width
             shift_y = out_height
-        elif position_index == 3:
+        else:
             shift_x = out_width
             shift_y = out_height
 

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -312,7 +312,10 @@ def postprocess_bboxes(
 
     """
     if bboxes.size == 0:
-        return np.zeros((0, 5)), np.zeros((0,), dtype=np.uint8)
+        return (
+            np.zeros((0, 5), dtype=bboxes.dtype),
+            np.zeros((0,), dtype=np.uint8),
+        )
     ordering = bboxes[:, -1]
     raw_bboxes = bboxes[:, :-1]
     raw_bboxes[:, 2] -= raw_bboxes[:, 0]

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -312,10 +312,7 @@ def postprocess_bboxes(
 
     """
     if bboxes.size == 0:
-        return (
-            np.zeros((0, 5), dtype=bboxes.dtype),
-            np.zeros((0,), dtype=np.uint8),
-        )
+        return np.zeros((0, 5)), np.zeros((0,), dtype=np.uint8)
     ordering = bboxes[:, -1]
     raw_bboxes = bboxes[:, :-1]
     raw_bboxes[:, 2] -= raw_bboxes[:, 0]

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -34,6 +34,103 @@ from typing import TypeVar
 import numpy as np
 
 
+def instance_count(
+    array: np.ndarray, target_type: str, n_keypoints: int = 0
+) -> int:
+    r"""Count the instances an Albumentations-layout target describes.
+
+    Each per-instance target type stores its instances on a different axis,
+    so the count cannot be read off ``len(array)`` alone.
+
+    Args:
+        array: Target in the Albumentations layout.
+        target_type: Target type the array holds, such as
+            ``"instance_mask"`` or ``"keypoints"``.
+        n_keypoints: Number of keypoints :math:`K` per instance. Only used
+            for keypoint targets, which store :math:`K` rows per instance.
+
+    Returns:
+        Number of instances in ``array``.
+
+    Raises:
+        ValueError: If ``target_type`` is ``"keypoints"`` and
+            ``n_keypoints`` is not positive.
+
+    Examples:
+        >>> instance_count(np.zeros((8, 8, 3)), "instance_mask")
+        3
+        >>> instance_count(np.zeros((6, 3)), "keypoints", n_keypoints=2)
+        3
+        >>> instance_count(np.zeros((4, 5)), "metadata")
+        4
+
+    """
+    if target_type == "instance_mask":
+        return array.shape[-1]
+
+    if target_type == "keypoints":
+        if n_keypoints < 1:
+            raise ValueError(
+                "Keypoint instances cannot be counted without knowing how "
+                "many keypoints each instance has."
+            )
+        return array.shape[0] // n_keypoints
+
+    return len(array)
+
+
+# Albumentations bbox rows are [x_min, y_min, x_max, y_max, class, index]
+# and keypoint rows are [x, y, z, angle, scale, visibility]. Both come to
+# six columns, for unrelated reasons.
+BBOX_COLUMNS = 6
+KEYPOINT_COLUMNS = 6
+
+
+def pad_empty_entries(
+    batch: list[np.ndarray], default: int
+) -> list[np.ndarray]:
+    r"""Shape every empty entry so the batch can be concatenated.
+
+    A sample carrying no boxes or keypoints comes back in whatever shape the
+    transform left it in, including a one-dimensional ``np.array([])`` that
+    will not concatenate with the populated samples. Those entries are
+    replaced by correctly shaped empty rows.
+
+    The width is read off a populated entry, since a pipeline's optional
+    fields decide how wide these rows are. An entry that is empty but still
+    two-dimensional carries the same width and is used when no entry is
+    populated; ``default`` is a last resort.
+
+    Args:
+        batch: Per-sample arrays, some of which may be empty.
+        default: Width to use when no entry carries one.
+
+    Returns:
+        The batch, with every empty entry shaped :math:`\left(0, n\right)`.
+
+    Examples:
+        >>> batch = [np.array([]), np.zeros((2, 7))]
+        >>> [array.shape for array in pad_empty_entries(batch, default=6)]
+        [(0, 7), (2, 7)]
+        >>> [a.shape for a in pad_empty_entries([np.array([])], default=6)]
+        [(0, 6)]
+
+    """
+    n_columns = default
+    for array in batch:
+        if array.ndim == 2:
+            n_columns = array.shape[1]
+            if array.size > 0:
+                break
+
+    return [
+        np.zeros((0, n_columns), dtype=array.dtype)
+        if array.size == 0
+        else array
+        for array in batch
+    ]
+
+
 def preprocess_mask(seg: np.ndarray) -> np.ndarray:
     r"""Convert an LDF mask to the Albumentations mask layout.
 

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -79,15 +79,8 @@ def instance_count(
     return len(array)
 
 
-# Albumentations bbox rows are [x_min, y_min, x_max, y_max, class, index]
-# and keypoint rows are [x, y, z, angle, scale, visibility]. Both come to
-# six columns, for unrelated reasons.
-BBOX_COLUMNS = 6
-KEYPOINT_COLUMNS = 6
-
-
 def pad_empty_entries(
-    batch: list[np.ndarray], default: int
+    batch: list[np.ndarray], n_columns: int = 6
 ) -> list[np.ndarray]:
     r"""Shape every empty entry so the batch can be concatenated.
 
@@ -99,24 +92,25 @@ def pad_empty_entries(
     The width is read off a populated entry, since a pipeline's optional
     fields decide how wide these rows are. An entry that is empty but still
     two-dimensional carries the same width and is used when no entry is
-    populated; ``default`` is a last resort.
+    populated.
 
     Args:
         batch: Per-sample arrays, some of which may be empty.
-        default: Width to use when no entry carries one.
+        n_columns: Width to fall back on when no entry carries one. Both
+            bbox rows :math:`\left[x_{\min}, y_{\min}, x_{\max}, y_{\max},
+            c, i\right]` and keypoint rows are six columns wide.
 
     Returns:
         The batch, with every empty entry shaped :math:`\left(0, n\right)`.
 
     Examples:
         >>> batch = [np.array([]), np.zeros((2, 7))]
-        >>> [array.shape for array in pad_empty_entries(batch, default=6)]
+        >>> [array.shape for array in pad_empty_entries(batch)]
         [(0, 7), (2, 7)]
-        >>> [a.shape for a in pad_empty_entries([np.array([])], default=6)]
+        >>> [array.shape for array in pad_empty_entries([np.array([])])]
         [(0, 6)]
 
     """
-    n_columns = default
     for array in batch:
         if array.ndim == 2:
             n_columns = array.shape[1]

--- a/luxonis_ml/data/augmentations/utils.py
+++ b/luxonis_ml/data/augmentations/utils.py
@@ -21,9 +21,11 @@ centralized.
      - :math:`\left(N, 3K\right)` normalized rows
      - :math:`\left(NK, 3\right)` pixel-space rows
 
-The appended bbox index :math:`i` is used during postprocessing to keep
-bbox-associated labels, such as instance masks and keypoints, aligned with the
-bounding boxes that survive augmentation and filtering.
+The appended bbox index :math:`i` is a position into the bbox-associated
+labels, such as instance masks and keypoints, and is used to keep them aligned
+with the bounding boxes that survive augmentation and filtering. It is local to
+whichever stage last wrote it: `BatchCompose` restamps it after every batch
+transform, so it is not stable across the whole pipeline.
 """
 
 from collections.abc import Iterator
@@ -60,7 +62,7 @@ def preprocess_mask(seg: np.ndarray) -> np.ndarray:
     return seg.transpose(1, 2, 0)
 
 
-def preprocess_bboxes(bboxes: np.ndarray, bbox_counter: int) -> np.ndarray:
+def preprocess_bboxes(bboxes: np.ndarray) -> np.ndarray:
     r"""Convert LDF bounding boxes to Albumentations format.
 
     LDF stores bounding boxes as normalized
@@ -68,29 +70,26 @@ def preprocess_bboxes(bboxes: np.ndarray, bbox_counter: int) -> np.ndarray:
     class ID and :math:`x` and :math:`y` are the top-left corner.
     Albumentations expects normalized
     :math:`\left[x_{\min}, y_{\min}, x_{\max}, y_{\max}, c\right]`
-    rows. This function also appends a stable per-box index used after
+    rows. This function also appends a per-box index used after
     augmentation to keep bbox-associated labels aligned with boxes that
     survived filtering.
 
     Args:
         bboxes: Bounding boxes of shape :math:`\left(N, 5\right)` in
             :math:`\left[c, x, y, w, h\right]` format.
-        bbox_counter: Offset used to create the appended bbox indices.
-            The first output row receives this value, the next receives
-            ``bbox_counter + 1``, and so on.
 
     Returns:
         Bounding boxes of shape :math:`\left(N, 6\right)` in
         :math:`\left[x_{\min}, y_{\min}, x_{\max}, y_{\max}, c, i\right]`
-        format, where :math:`i` is the stable bbox index.
+        format, where :math:`i` is the bbox index.
 
     Examples:
         >>> bboxes = np.array([[2, 0.1, 0.2, 0.3, 0.4]])
-        >>> out = preprocess_bboxes(bboxes, bbox_counter=5)
+        >>> out = preprocess_bboxes(bboxes)
         >>> np.round(out[:, :4], 4).tolist()
         [[0.1, 0.2, 0.4, 0.6]]
         >>> out[:, 4:].astype(int).tolist()
-        [[2, 5]]
+        [[2, 0]]
 
     """
     bboxes = bboxes[:, [1, 2, 3, 4, 0]]
@@ -101,9 +100,7 @@ def preprocess_bboxes(bboxes: np.ndarray, bbox_counter: int) -> np.ndarray:
 
     # Used later to filter out instance tasks associated
     # with bboxes that were removed during augmentations.
-    indices = np.arange(
-        bbox_counter, bboxes.shape[0] + bbox_counter, dtype=bboxes.dtype
-    )[:, None]
+    indices = np.arange(bboxes.shape[0], dtype=bboxes.dtype)[:, None]
     return np.concatenate((bboxes, indices), axis=1)
 
 
@@ -190,7 +187,7 @@ def postprocess_bboxes(
             :math:`\left(N, 6\right)` in
             :math:`\left[x_{\min}, y_{\min}, x_{\max}, y_{\max}, c,
             i\right]` format, where :math:`c` is the class ID and
-            :math:`i` is the stable bbox index.
+            :math:`i` is the bbox index.
         area_threshold: Minimum normalized box area
             :math:`w \cdot h` required for a box to remain valid.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ doctest_optionflags = [
   "NUMBER",
 ]
 testpaths = ["tests", "luxonis_ml"]
-addopts = ["--warnings", "--doctest-modules"]
+addopts = ["--disable-warnings", "--doctest-modules"]
 
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,7 +194,7 @@ doctest_optionflags = [
   "NUMBER",
 ]
 testpaths = ["tests", "luxonis_ml"]
-addopts = ["--disable-warnings", "--doctest-modules"]
+addopts = ["--warnings", "--doctest-modules"]
 
 
 [tool.coverage.run]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ pytest-split~=0.11
 pytest-subtests~=0.15
 pytest-xdist~=3.8
 pytest-clarity~=1.0
+hypothesis~=6.161
 onnx~=1.22
 pre-commit<4.0.0
 pydoctor~=25.10

--- a/tests/test_data/test_augmentations/conftest.py
+++ b/tests/test_data/test_augmentations/conftest.py
@@ -1,0 +1,20 @@
+import random
+from collections.abc import Iterator
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def restore_global_rngs() -> Iterator[None]:
+    """Undo the process-global reseeding `BatchCompose` does on construction.
+
+    Building an engine seeds `random` and `numpy.random` for the whole
+    process, so without this every test scheduled after one of these on the
+    same xdist worker would inherit a fixed RNG stream.
+    """
+    random_state = random.getstate()
+    numpy_state = np.random.get_state()
+    yield
+    random.setstate(random_state)
+    np.random.set_state(numpy_state)

--- a/tests/test_data/test_augmentations/helpers.py
+++ b/tests/test_data/test_augmentations/helpers.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from luxonis_ml.data.augmentations import BatchTransform
+
+
+class KeepFirstSample(BatchTransform):
+    """Passes the first sample's targets through untouched.
+
+    Lets a test see exactly what `BatchCompose` did to the data, without a
+    real transform rewriting the targets on the way through.
+    """
+
+    def __init__(self):
+        super().__init__(batch_size=2, p=1.0)
+
+    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
+        return image_batch[0]
+
+    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_instance_mask(
+        self, masks_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_bboxes(
+        self, bboxes_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return bboxes_batch[0]
+
+    def apply_to_keypoints(
+        self, keypoints_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return keypoints_batch[0]
+
+    def apply_to_metadata(
+        self, metadata_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return metadata_batch[0]
+
+    def apply_to_array(self, array_batch: list[np.ndarray], **_) -> np.ndarray:
+        return array_batch[0]

--- a/tests/test_data/test_augmentations/label_strategies.py
+++ b/tests/test_data/test_augmentations/label_strategies.py
@@ -152,8 +152,11 @@ def build_labels(group: TaskGroupSpec, height: int, width: int) -> Labels:
 
 
 task_types = st.lists(
-    st.sampled_from(ALL_TASK_TYPES), min_size=1, max_size=len(ALL_TASK_TYPES)
-).map(lambda drawn: sorted(set(drawn)))
+    st.sampled_from(ALL_TASK_TYPES),
+    min_size=1,
+    max_size=len(ALL_TASK_TYPES),
+    unique=True,
+).map(sorted)
 
 
 @st.composite

--- a/tests/test_data/test_augmentations/label_strategies.py
+++ b/tests/test_data/test_augmentations/label_strategies.py
@@ -1,0 +1,213 @@
+"""Hypothesis strategies for the label types the engine advertises.
+
+`AlbumentationsEngine` documents support for seven label types, spread over
+any number of task groups and image sources. The strategies here build
+*self-consistent* samples for arbitrary combinations of them: within one task
+group every per-instance label describes the same instances, so a generated
+sample is something `LuxonisLoader` could plausibly hand over.
+"""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+from hypothesis import strategies as st
+
+from luxonis_ml.typing import Labels
+
+# Every task type `AlbumentationsEngine` claims to handle. "metadata" is
+# spelled as a task-type suffix here and expanded to "metadata/<field>" when
+# the task string is built.
+PER_INSTANCE_TASK_TYPES = [
+    "boundingbox",
+    "keypoints",
+    "instance_segmentation",
+    "array",
+    "metadata",
+]
+WHOLE_IMAGE_TASK_TYPES = ["segmentation", "classification"]
+ALL_TASK_TYPES = PER_INSTANCE_TASK_TYPES + WHOLE_IMAGE_TASK_TYPES
+
+
+@dataclass
+class TaskGroupSpec:
+    """One task group: a set of task types over a shared instance count."""
+
+    name: str
+    task_types: list[str]
+    n_instances: int
+    n_classes: int
+    n_keypoints: int
+
+    def task(self, task_type: str) -> str:
+        suffix = "metadata/id" if task_type == "metadata" else task_type
+        return f"{self.name}/{suffix}"
+
+    @property
+    def tasks(self) -> dict[str, str]:
+        return {
+            self.task(task_type): (
+                "metadata/id" if task_type == "metadata" else task_type
+            )
+            for task_type in self.task_types
+        }
+
+
+@dataclass
+class SampleSpec:
+    """A full engine configuration plus the batch to feed it."""
+
+    groups: list[TaskGroupSpec]
+    source_channels: dict[str, int]
+    height: int
+    width: int
+    image_height: int
+    image_width: int
+    config: list[dict] = field(default_factory=list)
+
+    @property
+    def source_names(self) -> list[str]:
+        return list(self.source_channels)
+
+    @property
+    def targets(self) -> dict[str, str]:
+        targets = {}
+        for group in self.groups:
+            targets.update(group.tasks)
+        return targets
+
+    @property
+    def n_classes(self) -> dict[str, int]:
+        return {
+            task: group.n_classes
+            for group in self.groups
+            for task in group.tasks
+        }
+
+    def images(self) -> dict[str, np.ndarray]:
+        return {
+            name: np.full(
+                (self.image_height, self.image_width, channels),
+                fill_value=(i + 1) * 20,
+                dtype=np.uint8,
+            )
+            for i, (name, channels) in enumerate(self.source_channels.items())
+        }
+
+
+def _instance_boxes(n_instances: int) -> np.ndarray:
+    """Non-overlapping boxes laid out on a diagonal, well inside the image."""
+    boxes = []
+    for i in range(n_instances):
+        offset = 0.05 + i * 0.18
+        boxes.append([0.0, offset, offset, 0.12, 0.12])
+    return np.array(boxes, dtype=np.float64).reshape(n_instances, 5)
+
+
+def build_labels(group: TaskGroupSpec, height: int, width: int) -> Labels:
+    """Build one group's labels, consistent across every task type in it."""
+    labels: Labels = {}
+    n = group.n_instances
+    boxes = _instance_boxes(n)
+
+    for task_type in group.task_types:
+        task = group.task(task_type)
+
+        if task_type == "boundingbox":
+            labels[task] = boxes.copy()
+
+        elif task_type == "keypoints":
+            keypoints = np.zeros((n, group.n_keypoints * 3))
+            for i in range(n):
+                for k in range(group.n_keypoints):
+                    keypoints[i, k * 3] = boxes[i, 1] + 0.06
+                    keypoints[i, k * 3 + 1] = boxes[i, 2] + 0.06
+                    keypoints[i, k * 3 + 2] = 2.0
+            labels[task] = keypoints
+
+        elif task_type == "instance_segmentation":
+            masks = np.zeros((n, height, width), dtype=np.uint8)
+            for i in range(n):
+                r0 = int(boxes[i, 2] * height)
+                c0 = int(boxes[i, 1] * width)
+                r1 = max(r0 + 1, int((boxes[i, 2] + boxes[i, 4]) * height))
+                c1 = max(c0 + 1, int((boxes[i, 1] + boxes[i, 3]) * width))
+                masks[i, r0:r1, c0:c1] = i + 1
+            labels[task] = masks
+
+        elif task_type == "array":
+            labels[task] = np.arange(n * 2, dtype=np.float64).reshape(n, 2)
+
+        elif task_type == "metadata":
+            labels[task] = np.arange(n, dtype=np.float64)
+
+        elif task_type == "segmentation":
+            masks = np.zeros((group.n_classes, height, width), dtype=np.uint8)
+            masks[0, : height // 2, : width // 2] = 1
+            labels[task] = masks
+
+        elif task_type == "classification":
+            classes = np.zeros(group.n_classes)
+            classes[0] = 1.0
+            labels[task] = classes
+
+    return labels
+
+
+task_types = st.lists(
+    st.sampled_from(ALL_TASK_TYPES), min_size=1, max_size=len(ALL_TASK_TYPES)
+).map(lambda drawn: sorted(set(drawn)))
+
+
+@st.composite
+def task_groups(draw: st.DrawFn, name: str) -> TaskGroupSpec:
+    return TaskGroupSpec(
+        name=name,
+        task_types=draw(task_types),
+        n_instances=draw(st.integers(min_value=0, max_value=3)),
+        n_classes=draw(st.integers(min_value=1, max_value=3)),
+        n_keypoints=draw(st.integers(min_value=1, max_value=3)),
+    )
+
+
+BATCH_CONFIGS = [
+    [],
+    [{"name": "HorizontalFlip", "params": {"p": 1.0}}],
+    [{"name": "RandomBrightnessContrast", "params": {"p": 1.0}}],
+    [{"name": "Affine", "params": {"p": 1.0, "rotate": 15}}],
+    [{"name": "MixUp", "params": {"p": 1.0}}],
+    [{"name": "Mosaic4", "params": {"p": 1.0, "height": 64, "width": 64}}],
+    [
+        {"name": "Mosaic4", "params": {"p": 1.0, "height": 64, "width": 64}},
+        {"name": "MixUp", "params": {"p": 1.0}},
+    ],
+    [
+        {"name": "MixUp", "params": {"p": 1.0}},
+        {"name": "HorizontalFlip", "params": {"p": 1.0}},
+        {"name": "RandomBrightnessContrast", "params": {"p": 1.0}},
+    ],
+]
+
+
+@st.composite
+def sample_specs(draw: st.DrawFn, max_groups: int = 2) -> SampleSpec:
+    n_groups = draw(st.integers(min_value=1, max_value=max_groups))
+    groups = [draw(task_groups(f"group{i}")) for i in range(n_groups)]
+
+    n_sources = draw(st.integers(min_value=1, max_value=3))
+    channels = draw(
+        st.lists(
+            st.sampled_from([1, 3]), min_size=n_sources, max_size=n_sources
+        )
+    )
+    source_channels = {f"source{i}": channels[i] for i in range(n_sources)}
+
+    size = draw(st.sampled_from([32, 64]))
+    return SampleSpec(
+        groups=groups,
+        source_channels=source_channels,
+        height=size,
+        width=size,
+        image_height=draw(st.sampled_from([48, 64])),
+        image_width=draw(st.sampled_from([48, 64])),
+        config=draw(st.sampled_from(BATCH_CONFIGS)),
+    )

--- a/tests/test_data/test_augmentations/label_strategies.py
+++ b/tests/test_data/test_augmentations/label_strategies.py
@@ -1,22 +1,19 @@
 """Hypothesis strategies for the label types the engine advertises.
 
-`AlbumentationsEngine` documents support for seven label types, spread over
-any number of task groups and image sources. The strategies here build
-*self-consistent* samples for arbitrary combinations of them: within one task
-group every per-instance label describes the same instances, so a generated
-sample is something `LuxonisLoader` could plausibly hand over.
+Samples are built *self-consistent*: within one task group every per-instance
+label describes the same instances, so a generated sample is something
+`LuxonisLoader` could plausibly hand over.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import numpy as np
 from hypothesis import strategies as st
 
 from luxonis_ml.typing import Labels
 
-# Every task type `AlbumentationsEngine` claims to handle. "metadata" is
-# spelled as a task-type suffix here and expanded to "metadata/<field>" when
-# the task string is built.
+# "metadata" is spelled as a bare task type here and expanded to
+# "metadata/<field>" when the task string is built.
 PER_INSTANCE_TASK_TYPES = [
     "boundingbox",
     "keypoints",
@@ -38,16 +35,17 @@ class TaskGroupSpec:
     n_classes: int
     n_keypoints: int
 
+    @staticmethod
+    def _suffix(task_type: str) -> str:
+        return "metadata/id" if task_type == "metadata" else task_type
+
     def task(self, task_type: str) -> str:
-        suffix = "metadata/id" if task_type == "metadata" else task_type
-        return f"{self.name}/{suffix}"
+        return f"{self.name}/{self._suffix(task_type)}"
 
     @property
     def tasks(self) -> dict[str, str]:
         return {
-            self.task(task_type): (
-                "metadata/id" if task_type == "metadata" else task_type
-            )
+            self.task(task_type): self._suffix(task_type)
             for task_type in self.task_types
         }
 
@@ -62,7 +60,7 @@ class SampleSpec:
     width: int
     image_height: int
     image_width: int
-    config: list[dict] = field(default_factory=list)
+    config: list[dict]
 
     @property
     def source_names(self) -> list[str]:
@@ -189,8 +187,10 @@ BATCH_CONFIGS = [
 
 
 @st.composite
-def sample_specs(draw: st.DrawFn, max_groups: int = 2) -> SampleSpec:
-    n_groups = draw(st.integers(min_value=1, max_value=max_groups))
+def sample_specs(
+    draw: st.DrawFn, min_groups: int = 1, max_groups: int = 2
+) -> SampleSpec:
+    n_groups = draw(st.integers(min_value=min_groups, max_value=max_groups))
     groups = [draw(task_groups(f"group{i}")) for i in range(n_groups)]
 
     n_sources = draw(st.integers(min_value=1, max_value=3))

--- a/tests/test_data/test_augmentations/test_batch_compose_internals.py
+++ b/tests/test_data/test_augmentations/test_batch_compose_internals.py
@@ -336,5 +336,7 @@ def test_labels_emptied_by_a_spatial_transform_are_reported_empty() -> None:
         [({"image": np.zeros((16, 16, 3), dtype=np.uint8)}, labels)]
     )
 
-    assert "task/boundingbox" not in out_labels
+    # The boxes are reported empty rather than dropped, so the metadata is
+    # not left referring to a task that is not in the output.
+    assert out_labels["task/boundingbox"].shape == (0, 5)
     assert out_labels["task/metadata/id"].shape[0] == 0

--- a/tests/test_data/test_augmentations/test_batch_compose_internals.py
+++ b/tests/test_data/test_augmentations/test_batch_compose_internals.py
@@ -340,3 +340,8 @@ def test_labels_emptied_by_a_spatial_transform_are_reported_empty() -> None:
     # not left referring to a task that is not in the output.
     assert out_labels["task/boundingbox"].shape == (0, 5)
     assert out_labels["task/metadata/id"].shape[0] == 0
+
+    # Albumentations hands back its own empty arrays as float32; taking the
+    # dtype from those would make an emptied task disagree with the very
+    # same pipeline's populated output.
+    assert out_labels["task/boundingbox"].dtype == np.float64

--- a/tests/test_data/test_augmentations/test_batch_compose_internals.py
+++ b/tests/test_data/test_augmentations/test_batch_compose_internals.py
@@ -6,7 +6,7 @@ import pytest
 from loguru import logger
 
 from luxonis_ml.data import AlbumentationsEngine
-from luxonis_ml.data.augmentations import BatchCompose, BatchTransform
+from luxonis_ml.data.augmentations import BatchCompose, BatchTransform, MixUp
 from luxonis_ml.typing import Labels
 
 from .helpers import KeepFirstSample
@@ -41,6 +41,19 @@ class PushFirstBoxOutOfFrame(KeepFirstSample):
 class ReturnsFlatBoxes(KeepFirstSample):
     def apply_to_bboxes(self, _batch: list[np.ndarray], **_) -> np.ndarray:
         return np.array([1.0, 2.0, 3.0])
+
+
+class DropsFirstBox(KeepFirstSample):
+    """Filters a box inside the transform, leaving the labels untouched.
+
+    The surviving boxes look untouched from the outside, so nothing but the
+    instance count gives the mismatch away.
+    """
+
+    def apply_to_bboxes(
+        self, bboxes_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return bboxes_batch[0][1:]
 
 
 def compose(
@@ -167,7 +180,12 @@ def test_keypoints_without_a_known_count_are_left_alone(
     assert "cannot be matched" in "".join(warnings_log)
 
 
-def test_the_same_field_only_warns_once(warnings_log: list[str]) -> None:
+def test_every_affected_sample_warns(warnings_log: list[str]) -> None:
+    """A warning per sample, so the scale of the problem is visible.
+
+    Suppressing repeats for the lifetime of the composition would report a
+    dataset-wide misalignment exactly once per training run.
+    """
     composition = compose(
         {"bboxes": {"label": "metadata"}}, {"label": "metadata"}
     )
@@ -175,7 +193,108 @@ def test_the_same_field_only_warns_once(warnings_log: list[str]) -> None:
     composition(batch(bboxes=boxes(2), label=np.ones(5)))
     composition(batch(bboxes=boxes(2), label=np.ones(5)))
 
-    assert "".join(warnings_log).count("cannot be matched") == 1
+    assert "".join(warnings_log).count("cannot be matched") == 2
+
+
+def test_boxes_dropped_inside_a_transform_are_reported(
+    warnings_log: list[str],
+) -> None:
+    """A transform that filters boxes itself must not pass unnoticed.
+
+    Its output indices come back contiguous, so only the instance count
+    reveals that the labels no longer describe the surviving boxes.
+    """
+    composition = compose(
+        {"bboxes": {"label": "metadata"}},
+        {"label": "metadata"},
+        transform=DropsFirstBox(),
+    )
+
+    composition(batch(bboxes=boxes(3), label=np.arange(3.0)))
+
+    assert "cannot be matched" in "".join(warnings_log)
+
+
+def test_label_fields_are_not_overwritten_by_the_index_column() -> None:
+    """Albumentations appends label columns to the right of the index one.
+
+    Writing the instance index to the last column would replace every box's
+    class label with its row number.
+    """
+    composition = BatchCompose(
+        [KeepFirstSample()],
+        bbox_params=A.BboxParams(
+            format="albumentations", label_fields=["class_labels"]
+        ),
+        bbox_associations={"bboxes": {"metadata": "metadata"}},
+    )
+    indexed = np.array(
+        [
+            [0.1 * i, 0.1 * i, 0.1 * i + 0.2, 0.1 * i + 0.2, float(i)]
+            for i in range(3)
+        ]
+    )
+
+    output = composition(
+        [
+            {
+                "image": IMAGE,
+                "bboxes": indexed.copy(),
+                "class_labels": np.array([7, 8, 9]),
+                "metadata": np.arange(3.0),
+            }
+            for _ in range(2)
+        ]
+    )
+
+    assert output["class_labels"].tolist() == [7, 8, 9]
+
+
+def test_samples_without_a_label_get_one_empty_instance_per_box() -> None:
+    """A batch transform concatenates only the samples that carry a field.
+
+    Without a placeholder for the samples that do not, the merged labels
+    come back shorter than the merged boxes and nothing can say which boxes
+    they belong to.
+    """
+    composition = BatchCompose(
+        [MixUp(p=1.0)],
+        bbox_params=A.BboxParams(format="albumentations"),
+        additional_targets={"label": "metadata"},
+        bbox_associations={"bboxes": {"label": "metadata"}},
+    )
+
+    output = composition(
+        [
+            {"image": IMAGE, "bboxes": boxes(2), "label": np.arange(2.0)},
+            {"image": IMAGE, "bboxes": boxes(3), "label": np.array([])},
+        ]
+    )
+
+    assert len(output["label"]) == len(output["bboxes"]) == 5
+    assert output["label"][:2].tolist() == [0.0, 1.0]
+
+
+def test_indices_are_restamped_without_a_bbox_processor() -> None:
+    """Nothing filters the boxes, but they still need distinct indices.
+
+    Each sample is numbered from zero on the way in, so leaving the merged
+    boxes as they are points several of them at the same label.
+    """
+    composition = BatchCompose(
+        [MixUp(p=1.0)],
+        bbox_associations={"bboxes": {"metadata": "metadata"}},
+    )
+    box = np.array([[0.1, 0.1, 0.3, 0.3, 0.0, 0.0]])
+
+    output = composition(
+        [
+            {"image": IMAGE, "bboxes": box.copy(), "metadata": np.array([7])}
+            for _ in range(2)
+        ]
+    )
+
+    assert output["bboxes"][:, -1].tolist() == [0.0, 1.0]
 
 
 def test_make_contiguous_leaves_non_arrays_alone() -> None:

--- a/tests/test_data/test_augmentations/test_batch_compose_internals.py
+++ b/tests/test_data/test_augmentations/test_batch_compose_internals.py
@@ -5,9 +5,7 @@ import numpy as np
 import pytest
 from loguru import logger
 
-from luxonis_ml.data import AlbumentationsEngine
 from luxonis_ml.data.augmentations import BatchCompose, BatchTransform, MixUp
-from luxonis_ml.typing import Labels
 
 from .helpers import KeepFirstSample
 
@@ -134,7 +132,6 @@ def test_already_empty_associated_fields_are_left_alone() -> None:
 def test_unmatched_fields_warn_once_and_are_left_alone(
     target_type: str, value: np.ndarray, warnings_log: list[str]
 ) -> None:
-    """Counts that cannot be matched to boxes must not be regrouped."""
     composition = compose(
         {"bboxes": {"label": target_type}}, {"label": target_type}
     )
@@ -169,7 +166,6 @@ def test_unmatched_keypoints_warn_and_are_left_alone(
 def test_keypoints_without_a_known_count_are_left_alone(
     warnings_log: list[str],
 ) -> None:
-    """Without the per-instance count there is no safe way to regroup."""
     composition = compose(
         {"bboxes": {"label": "keypoints"}}, {"label": "keypoints"}
     )
@@ -304,44 +300,3 @@ def test_make_contiguous_leaves_non_arrays_alone() -> None:
 
     assert out["image"].flags["C_CONTIGUOUS"]
     assert out["note"] == "kept as is"
-
-
-def test_labels_emptied_by_a_spatial_transform_are_reported_empty() -> None:
-    """A crop can remove every box after the batch stage has finished."""
-    engine = AlbumentationsEngine(
-        16,
-        16,
-        {"task/boundingbox": "boundingbox", "task/metadata/id": "metadata"},
-        {"task/boundingbox": 1, "task/metadata/id": 1},
-        ["image"],
-        [
-            {
-                "name": "Crop",
-                "params": {
-                    "x_min": 0,
-                    "y_min": 0,
-                    "x_max": 4,
-                    "y_max": 4,
-                    "p": 1.0,
-                },
-            }
-        ],
-    )
-    labels: Labels = {
-        "task/boundingbox": np.array([[0.0, 0.7, 0.7, 0.2, 0.2]]),
-        "task/metadata/id": np.array([9.0]),
-    }
-
-    _, out_labels = engine.apply(
-        [({"image": np.zeros((16, 16, 3), dtype=np.uint8)}, labels)]
-    )
-
-    # The boxes are reported empty rather than dropped, so the metadata is
-    # not left referring to a task that is not in the output.
-    assert out_labels["task/boundingbox"].shape == (0, 5)
-    assert out_labels["task/metadata/id"].shape[0] == 0
-
-    # Albumentations hands back its own empty arrays as float32; taking the
-    # dtype from those would make an emptied task disagree with the very
-    # same pipeline's populated output.
-    assert out_labels["task/boundingbox"].dtype == np.float64

--- a/tests/test_data/test_augmentations/test_batch_compose_internals.py
+++ b/tests/test_data/test_augmentations/test_batch_compose_internals.py
@@ -1,0 +1,276 @@
+"""Behaviour of `BatchCompose` on inputs the engine does not normally send.
+
+`BatchCompose` is exported, so it can be driven directly with bbox
+associations that do not line up with the data. These tests pin down what it
+does then: warn once and leave the data alone, rather than raise or silently
+regroup it.
+"""
+
+from collections.abc import Iterator
+
+import albumentations as A
+import numpy as np
+import pytest
+from loguru import logger
+
+from luxonis_ml.data import AlbumentationsEngine
+from luxonis_ml.data.augmentations import BatchCompose, BatchTransform
+from luxonis_ml.typing import Labels
+
+IMAGE = np.zeros((16, 16, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def warnings_log() -> Iterator[list[str]]:
+    """Collect loguru warnings, which pytest's caplog does not see."""
+    messages: list[str] = []
+    handler = logger.add(messages.append, level="WARNING", format="{message}")
+    yield messages
+    logger.remove(handler)
+
+
+class KeepFirstSample(BatchTransform):
+    """Keeps the first sample's targets exactly as they arrived.
+
+    Every target is passed through untouched so a test can see precisely what
+    `BatchCompose` itself did to the data.
+    """
+
+    def __init__(self):
+        super().__init__(batch_size=2, p=1.0)
+
+    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
+        return image_batch[0]
+
+    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_instance_mask(
+        self, masks_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_bboxes(
+        self, bboxes_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return bboxes_batch[0]
+
+    def apply_to_keypoints(
+        self, keypoints_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return keypoints_batch[0]
+
+    def apply_to_metadata(
+        self, metadata_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return metadata_batch[0]
+
+    def apply_to_array(self, array_batch: list[np.ndarray], **_) -> np.ndarray:
+        return array_batch[0]
+
+
+class PushFirstBoxOutOfFrame(KeepFirstSample):
+    """Moves the first box outside the image so filtering drops it.
+
+    Indices are stamped before filtering, so the surviving boxes then carry
+    non-contiguous indices - the state compaction exists to handle.
+    """
+
+    def apply_to_bboxes(
+        self, bboxes_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        boxes = bboxes_batch[0].copy()
+        boxes[0, :4] = [1.2, 1.2, 1.5, 1.5]
+        return boxes
+
+
+class ReturnsFlatBoxes(KeepFirstSample):
+    """Hands back a one-dimensional bbox array, which is never valid."""
+
+    def apply_to_bboxes(self, _batch: list[np.ndarray], **_) -> np.ndarray:
+        return np.array([1.0, 2.0, 3.0])
+
+
+def compose(
+    associations: dict[str, dict[str, str]],
+    additional_targets: dict[str, str] | None = None,
+    transform: BatchTransform | None = None,
+) -> BatchCompose:
+    return BatchCompose(
+        [transform or PushFirstBoxOutOfFrame()],
+        bbox_params=A.BboxParams(format="albumentations", min_visibility=0.5),
+        keypoint_params=A.KeypointParams(format="xy", remove_invisible=False),
+        additional_targets=additional_targets or {},
+        bbox_associations=associations,
+    )
+
+
+def boxes(n: int) -> np.ndarray:
+    return np.array(
+        [
+            [0.1 * i, 0.1 * i, 0.1 * i + 0.2, 0.1 * i + 0.2, 0.0, float(i)]
+            for i in range(n)
+        ]
+    )
+
+
+def batch(**fields: np.ndarray) -> list[dict[str, np.ndarray]]:
+    return [
+        {"image": IMAGE, **{k: v.copy() for k, v in fields.items()}}
+        for _ in range(2)
+    ]
+
+
+def test_batch_size_must_match_the_composition() -> None:
+    composition = BatchCompose([KeepFirstSample()])
+
+    with pytest.raises(ValueError, match="Batch size must be equal to 2"):
+        composition([{"image": IMAGE}])
+
+
+def test_bbox_fields_absent_from_the_data_are_skipped() -> None:
+    """A declared association need not appear in every sample."""
+    composition = compose({"bboxes": {"metadata": "metadata"}})
+
+    output = composition(batch(metadata=np.array([1.0])))
+
+    assert output["metadata"].tolist() == [1.0]
+
+
+def test_one_dimensional_bboxes_are_rejected() -> None:
+    composition = compose({"bboxes": {}}, transform=ReturnsFlatBoxes())
+
+    with pytest.raises(ValueError, match="must be a 2D array"):
+        composition(batch(bboxes=boxes(2)))
+
+
+def test_associated_fields_absent_from_the_data_are_skipped() -> None:
+    composition = compose({"bboxes": {"metadata": "metadata"}})
+
+    output = composition(batch(bboxes=boxes(2)))
+
+    assert "metadata" not in output
+
+
+def test_already_empty_associated_fields_are_left_alone() -> None:
+    composition = compose({"bboxes": {"metadata": "metadata"}})
+
+    output = composition(batch(bboxes=boxes(2), metadata=np.array([])))
+
+    assert output["metadata"].size == 0
+
+
+@pytest.mark.parametrize(
+    ("target_type", "value", "expected_message"),
+    [
+        ("instance_mask", np.ones((16, 16, 5), dtype=np.uint8), "5 instances"),
+        ("metadata", np.ones(5), "5 values"),
+    ],
+)
+def test_unmatched_fields_warn_once_and_are_left_alone(
+    target_type: str,
+    value: np.ndarray,
+    expected_message: str,
+    warnings_log: list[str],
+) -> None:
+    """Counts that cannot be matched to boxes must not be regrouped."""
+    composition = compose(
+        {"bboxes": {"label": target_type}}, {"label": target_type}
+    )
+    original = value.copy()
+
+    output = composition(batch(bboxes=boxes(2), label=value))
+
+    assert np.array_equal(output["label"], original), (
+        "an unmatched field must be passed through untouched"
+    )
+    warned = "".join(warnings_log)
+    assert expected_message in warned
+    assert "cannot be matched up" in warned
+
+
+def test_unmatched_keypoints_warn_and_are_left_alone(
+    warnings_log: list[str],
+) -> None:
+    """Keypoint rows must be exactly ``bbox_count * n_keypoints``."""
+    composition = compose(
+        {"bboxes": {"label": "keypoints"}}, {"label": "keypoints"}
+    )
+    keypoints = np.array([[float(i), float(i), 2.0] for i in range(5)])
+
+    output = composition(
+        batch(bboxes=boxes(2), label=keypoints),
+        keypoints_per_instance={"label": 1},
+    )
+
+    assert output["label"].shape[0] == 5
+    assert "5 keypoint rows" in "".join(warnings_log)
+
+
+def test_keypoints_without_a_known_count_are_left_alone(
+    warnings_log: list[str],
+) -> None:
+    """Without the per-instance count there is no safe way to regroup."""
+    composition = compose(
+        {"bboxes": {"label": "keypoints"}}, {"label": "keypoints"}
+    )
+    keypoints = np.array([[float(i), float(i), 2.0] for i in range(2)])
+
+    composition(batch(bboxes=boxes(2), label=keypoints))
+
+    assert "cannot be matched up" in "".join(warnings_log)
+
+
+def test_the_same_field_only_warns_once(warnings_log: list[str]) -> None:
+    composition = compose(
+        {"bboxes": {"label": "metadata"}}, {"label": "metadata"}
+    )
+
+    composition(batch(bboxes=boxes(2), label=np.ones(5)))
+    composition(batch(bboxes=boxes(2), label=np.ones(5)))
+
+    assert "".join(warnings_log).count("cannot be matched up") == 1
+
+
+def test_make_contiguous_leaves_non_arrays_alone() -> None:
+    """Not every value in the data dict is a numpy array."""
+    data = {"image": np.zeros((4, 4))[::2], "note": "kept as is"}
+
+    out = BatchCompose._make_contiguous(data)  # type: ignore[arg-type]
+
+    assert out["image"].flags["C_CONTIGUOUS"]
+    assert out["note"] == "kept as is"
+
+
+def test_labels_emptied_by_a_spatial_transform_are_reported_empty() -> None:
+    """A crop can remove every box after the batch stage has finished."""
+    engine = AlbumentationsEngine(
+        16,
+        16,
+        {"task/boundingbox": "boundingbox", "task/metadata/id": "metadata"},
+        {"task/boundingbox": 1, "task/metadata/id": 1},
+        ["image"],
+        [
+            {
+                "name": "Crop",
+                "params": {
+                    "x_min": 0,
+                    "y_min": 0,
+                    "x_max": 4,
+                    "y_max": 4,
+                    "p": 1.0,
+                },
+            }
+        ],
+    )
+    labels: Labels = {
+        "task/boundingbox": np.array([[0.0, 0.7, 0.7, 0.2, 0.2]]),
+        "task/metadata/id": np.array([9.0]),
+    }
+
+    _, out_labels = engine.apply(
+        [({"image": np.zeros((16, 16, 3), dtype=np.uint8)}, labels)]
+    )
+
+    assert out_labels.get("task/boundingbox", np.zeros((0, 5))).shape[0] == 0
+    assert out_labels.get("task/metadata/id", np.zeros(0)).shape[0] == 0

--- a/tests/test_data/test_augmentations/test_batch_compose_internals.py
+++ b/tests/test_data/test_augmentations/test_batch_compose_internals.py
@@ -1,11 +1,3 @@
-"""Behaviour of `BatchCompose` on inputs the engine does not normally send.
-
-`BatchCompose` is exported, so it can be driven directly with bbox
-associations that do not line up with the data. These tests pin down what it
-does then: warn once and leave the data alone, rather than raise or silently
-regroup it.
-"""
-
 from collections.abc import Iterator
 
 import albumentations as A
@@ -16,6 +8,8 @@ from loguru import logger
 from luxonis_ml.data import AlbumentationsEngine
 from luxonis_ml.data.augmentations import BatchCompose, BatchTransform
 from luxonis_ml.typing import Labels
+
+from .helpers import KeepFirstSample
 
 IMAGE = np.zeros((16, 16, 3), dtype=np.uint8)
 
@@ -29,51 +23,11 @@ def warnings_log() -> Iterator[list[str]]:
     logger.remove(handler)
 
 
-class KeepFirstSample(BatchTransform):
-    """Keeps the first sample's targets exactly as they arrived.
-
-    Every target is passed through untouched so a test can see precisely what
-    `BatchCompose` itself did to the data.
-    """
-
-    def __init__(self):
-        super().__init__(batch_size=2, p=1.0)
-
-    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
-        return image_batch[0]
-
-    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_instance_mask(
-        self, masks_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_bboxes(
-        self, bboxes_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return bboxes_batch[0]
-
-    def apply_to_keypoints(
-        self, keypoints_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return keypoints_batch[0]
-
-    def apply_to_metadata(
-        self, metadata_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return metadata_batch[0]
-
-    def apply_to_array(self, array_batch: list[np.ndarray], **_) -> np.ndarray:
-        return array_batch[0]
-
-
 class PushFirstBoxOutOfFrame(KeepFirstSample):
     """Moves the first box outside the image so filtering drops it.
 
     Indices are stamped before filtering, so the surviving boxes then carry
-    non-contiguous indices - the state compaction exists to handle.
+    the non-contiguous indices that compaction exists to handle.
     """
 
     def apply_to_bboxes(
@@ -85,8 +39,6 @@ class PushFirstBoxOutOfFrame(KeepFirstSample):
 
 
 class ReturnsFlatBoxes(KeepFirstSample):
-    """Hands back a one-dimensional bbox array, which is never valid."""
-
     def apply_to_bboxes(self, _batch: list[np.ndarray], **_) -> np.ndarray:
         return np.array([1.0, 2.0, 3.0])
 
@@ -129,7 +81,6 @@ def test_batch_size_must_match_the_composition() -> None:
 
 
 def test_bbox_fields_absent_from_the_data_are_skipped() -> None:
-    """A declared association need not appear in every sample."""
     composition = compose({"bboxes": {"metadata": "metadata"}})
 
     output = composition(batch(metadata=np.array([1.0])))
@@ -161,17 +112,14 @@ def test_already_empty_associated_fields_are_left_alone() -> None:
 
 
 @pytest.mark.parametrize(
-    ("target_type", "value", "expected_message"),
+    ("target_type", "value"),
     [
-        ("instance_mask", np.ones((16, 16, 5), dtype=np.uint8), "5 instances"),
-        ("metadata", np.ones(5), "5 values"),
+        ("instance_mask", np.ones((16, 16, 5), dtype=np.uint8)),
+        ("metadata", np.ones(5)),
     ],
 )
 def test_unmatched_fields_warn_once_and_are_left_alone(
-    target_type: str,
-    value: np.ndarray,
-    expected_message: str,
-    warnings_log: list[str],
+    target_type: str, value: np.ndarray, warnings_log: list[str]
 ) -> None:
     """Counts that cannot be matched to boxes must not be regrouped."""
     composition = compose(
@@ -181,18 +129,16 @@ def test_unmatched_fields_warn_once_and_are_left_alone(
 
     output = composition(batch(bboxes=boxes(2), label=value))
 
-    assert np.array_equal(output["label"], original), (
-        "an unmatched field must be passed through untouched"
-    )
+    assert np.array_equal(output["label"], original)
     warned = "".join(warnings_log)
-    assert expected_message in warned
-    assert "cannot be matched up" in warned
+    assert f"shape {value.shape}" in warned
+    assert "cannot be matched" in warned
 
 
 def test_unmatched_keypoints_warn_and_are_left_alone(
     warnings_log: list[str],
 ) -> None:
-    """Keypoint rows must be exactly ``bbox_count * n_keypoints``."""
+    """Keypoint rows must number exactly ``bbox_count * n_keypoints``."""
     composition = compose(
         {"bboxes": {"label": "keypoints"}}, {"label": "keypoints"}
     )
@@ -204,7 +150,7 @@ def test_unmatched_keypoints_warn_and_are_left_alone(
     )
 
     assert output["label"].shape[0] == 5
-    assert "5 keypoint rows" in "".join(warnings_log)
+    assert "cannot be matched" in "".join(warnings_log)
 
 
 def test_keypoints_without_a_known_count_are_left_alone(
@@ -218,7 +164,7 @@ def test_keypoints_without_a_known_count_are_left_alone(
 
     composition(batch(bboxes=boxes(2), label=keypoints))
 
-    assert "cannot be matched up" in "".join(warnings_log)
+    assert "cannot be matched" in "".join(warnings_log)
 
 
 def test_the_same_field_only_warns_once(warnings_log: list[str]) -> None:
@@ -229,11 +175,10 @@ def test_the_same_field_only_warns_once(warnings_log: list[str]) -> None:
     composition(batch(bboxes=boxes(2), label=np.ones(5)))
     composition(batch(bboxes=boxes(2), label=np.ones(5)))
 
-    assert "".join(warnings_log).count("cannot be matched up") == 1
+    assert "".join(warnings_log).count("cannot be matched") == 1
 
 
 def test_make_contiguous_leaves_non_arrays_alone() -> None:
-    """Not every value in the data dict is a numpy array."""
     data = {"image": np.zeros((4, 4))[::2], "note": "kept as is"}
 
     out = BatchCompose._make_contiguous(data)  # type: ignore[arg-type]
@@ -272,5 +217,5 @@ def test_labels_emptied_by_a_spatial_transform_are_reported_empty() -> None:
         [({"image": np.zeros((16, 16, 3), dtype=np.uint8)}, labels)]
     )
 
-    assert out_labels.get("task/boundingbox", np.zeros((0, 5))).shape[0] == 0
-    assert out_labels.get("task/metadata/id", np.zeros(0)).shape[0] == 0
+    assert "task/boundingbox" not in out_labels
+    assert out_labels["task/metadata/id"].shape[0] == 0

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
+from luxonis_ml.data.augmentations import BatchCompose, MixUp
 from luxonis_ml.typing import Labels
 
 
@@ -34,6 +35,27 @@ def assert_boxes_match_masks(
             f"instance {i}: mask centroid y={cy:.3f} outside box "
             f"[{y:.3f}, {y + h:.3f}] — box paired with the wrong mask"
         )
+
+
+def assert_boxes_match_keypoints(
+    boxes: np.ndarray, keypoints: np.ndarray, tol: float = 0.05
+) -> None:
+    """Assert visible keypoints remain paired with their bounding boxes."""
+    assert boxes.shape[0] == keypoints.shape[0]
+    visible = keypoints[:, 2] > 0
+    assert np.any(visible)
+    for box, keypoint in zip(boxes[visible], keypoints[visible], strict=True):
+        x, y, w, h = box[1:5]
+        px, py = keypoint[:2]
+        assert x - tol <= px <= x + w + tol
+        assert y - tol <= py <= y + h + tol
+
+
+def assert_masks_match_values(masks: np.ndarray, values: np.ndarray) -> None:
+    """Assert each mask channel carries its associated scalar value."""
+    assert masks.shape[0] == values.shape[0]
+    for mask, value in zip(masks, values, strict=True):
+        assert np.unique(mask[mask != 0]).tolist() == [value]
 
 
 @pytest.fixture(
@@ -188,7 +210,23 @@ def test_batched_p_0(
     augmentations.apply([(images_dict, deepcopy(labels)) for _ in range(8)])
 
 
-def test_skipped_mosaic_before_mixup_reindexes_instance_masks() -> None:
+def test_batch_compose_without_bbox_params() -> None:
+    """BatchCompose remains usable for image-only batch transformations."""
+    first = np.zeros((8, 8, 3), dtype=np.uint8)
+    second = np.ones((8, 8, 3), dtype=np.uint8)
+    compose = BatchCompose([MixUp(p=0)])
+
+    output = compose([{"image": first}, {"image": second}])
+
+    assert np.array_equal(output["image"], first)
+
+
+@pytest.mark.parametrize(
+    ("mixup_probability", "expected_instances"), [(0.0, 2), (1.0, 4)]
+)
+def test_skipped_mosaic_before_mixup_reindexes_instance_masks(
+    mixup_probability: float, expected_instances: int
+) -> None:
     image = np.zeros((320, 320, 3), dtype=np.uint8)
     # Two instances whose masks are centered inside their boxes, so a
     # box-to-mask mispairing is detectable geometrically.
@@ -196,24 +234,24 @@ def test_skipped_mosaic_before_mixup_reindexes_instance_masks() -> None:
     instance_mask[0, 48:112, 48:112] = 1  # box 0 spans [0.15, 0.35]
     instance_mask[1, 192:256, 192:256] = 1  # box 1 spans [0.60, 0.80]
     labels: Labels = {
-        "task/instance_segmentation/boundingbox": np.array(
+        "task/boundingbox": np.array(
             [
                 [0.0, 0.15, 0.15, 0.20, 0.20],
                 [0.0, 0.60, 0.60, 0.20, 0.20],
             ]
         ),
-        "task/instance_segmentation/segmentation": instance_mask,
+        "task/instance_segmentation": instance_mask,
     }
     targets = {
-        "task/instance_segmentation/boundingbox": "boundingbox",
-        "task/instance_segmentation/segmentation": "instance_segmentation",
+        "task/boundingbox": "boundingbox",
+        "task/instance_segmentation": "instance_segmentation",
     }
     config = [
         {
             "name": "Mosaic4",
             "params": {"p": 0, "out_width": 640, "out_height": 640},
         },
-        {"name": "MixUp", "params": {"p": 1}},
+        {"name": "MixUp", "params": {"p": mixup_probability}},
     ]
     augmentations = AlbumentationsEngine(
         256,
@@ -224,17 +262,35 @@ def test_skipped_mosaic_before_mixup_reindexes_instance_masks() -> None:
         config,
     )
 
+    other_instance_mask = np.zeros((2, 320, 320), dtype=np.uint8)
+    other_instance_mask[0, 48:112, 192:256] = 1
+    other_instance_mask[1, 192:256, 48:112] = 1
+    other_labels: Labels = {
+        "task/boundingbox": np.array(
+            [
+                [0.0, 0.60, 0.15, 0.20, 0.20],
+                [0.0, 0.15, 0.60, 0.20, 0.20],
+            ]
+        ),
+        "task/instance_segmentation": other_instance_mask,
+    }
     _, out_labels = augmentations.apply(
-        [({"image": image}, deepcopy(labels)) for _ in range(8)]
+        [
+            ({"image": image}, deepcopy(labels if i < 4 else other_labels))
+            for i in range(8)
+        ]
     )
 
-    boxes = out_labels["task/instance_segmentation/boundingbox"]
-    masks = out_labels["task/instance_segmentation/segmentation"]
-    assert boxes.shape[0] == masks.shape[0] == 4
+    boxes = out_labels["task/boundingbox"]
+    masks = out_labels["task/instance_segmentation"]
+    assert boxes.shape[0] == masks.shape[0] == expected_instances
     assert_boxes_match_masks(boxes, masks)
 
 
-def test_mosaic_drops_boxes_keeps_masks_aligned() -> None:
+@pytest.mark.parametrize("mixup_probability", [None, 0.0, 1.0])
+def test_mosaic_drops_boxes_keeps_masks_aligned(
+    mixup_probability: float | None,
+) -> None:
     """Boxes dropped by ``min_bbox_visibility`` must not scramble masks.
 
     When a batch transform (here Mosaic4) crops instances so some boxes fall
@@ -249,18 +305,26 @@ def test_mosaic_drops_boxes_keeps_masks_aligned() -> None:
     size = 0.15
     instance_mask = np.zeros((4, 320, 320), dtype=np.uint8)
     boxes_in = []
+    keypoints_in = []
     for i, (x, y) in enumerate(corners):
         r0, r1 = int(y * 320), int((y + size) * 320)
         c0, c1 = int(x * 320), int((x + size) * 320)
-        instance_mask[i, r0:r1, c0:c1] = 1
+        instance_mask[i, r0:r1, c0:c1] = i + 1
         boxes_in.append([0.0, x, y, size, size])
+        keypoints_in.append([x + size / 2, y + size / 2, 2.0])
     labels: Labels = {
-        "task/instance_segmentation/boundingbox": np.array(boxes_in),
-        "task/instance_segmentation/segmentation": instance_mask,
+        "task/boundingbox": np.array(boxes_in),
+        "task/instance_segmentation": instance_mask,
+        "task/keypoints": np.array(keypoints_in),
+        "task/array": np.arange(1, 5),
+        "task/metadata/id": np.arange(11, 15),
     }
     targets = {
-        "task/instance_segmentation/boundingbox": "boundingbox",
-        "task/instance_segmentation/segmentation": "instance_segmentation",
+        "task/boundingbox": "boundingbox",
+        "task/instance_segmentation": "instance_segmentation",
+        "task/keypoints": "keypoints",
+        "task/array": "array",
+        "task/metadata/id": "metadata",
     }
     config = [
         {
@@ -268,6 +332,11 @@ def test_mosaic_drops_boxes_keeps_masks_aligned() -> None:
             "params": {"p": 1.0, "out_width": 640, "out_height": 640},
         }
     ]
+    batch_size = 4
+    if mixup_probability is not None:
+        config.append({"name": "MixUp", "params": {"p": mixup_probability}})
+        batch_size *= 2
+
     augmentations = AlbumentationsEngine(
         256,
         256,
@@ -280,12 +349,190 @@ def test_mosaic_drops_boxes_keeps_masks_aligned() -> None:
     )
 
     _, out_labels = augmentations.apply(
-        [({"image": image}, deepcopy(labels)) for _ in range(4)]
+        [({"image": image}, deepcopy(labels)) for _ in range(batch_size)]
     )
 
-    boxes = out_labels["task/instance_segmentation/boundingbox"]
-    masks = out_labels["task/instance_segmentation/segmentation"]
-    # The mosaic crop must drop at least one of the 16 candidate instances,
-    # otherwise the non-contiguous-index path is never exercised.
-    assert 0 < boxes.shape[0] < 16
+    boxes = out_labels["task/boundingbox"]
+    masks = out_labels["task/instance_segmentation"]
+    keypoints = out_labels["task/keypoints"]
+    arrays = out_labels["task/array"]
+    metadata = out_labels["task/metadata/id"]
+    # Boxes occupy every corner of every quadrant, so every possible Mosaic
+    # crop keeps some candidates and drops others.
+    assert 0 < boxes.shape[0] < 4 * batch_size
     assert_boxes_match_masks(boxes, masks)
+    assert_boxes_match_keypoints(boxes, keypoints)
+    assert arrays.shape == metadata.shape == (boxes.shape[0],)
+    assert_masks_match_values(masks, arrays)
+    assert np.array_equal(metadata, arrays + 10)
+
+
+def test_batch_transforms_keep_nested_task_groups_independent() -> None:
+    """Associated labels from nested task groups must not be compacted together."""
+
+    def make_mask(
+        instances: list[tuple[int, float, float]], size: int = 64
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        boxes = []
+        masks = np.zeros((len(instances), size, size), dtype=np.uint8)
+        values = []
+        for i, (value, x, y) in enumerate(instances):
+            x0, y0 = int(x * size), int(y * size)
+            masks[i, y0 : y0 + 8, x0 : x0 + 8] = value
+            boxes.append([0.0, x, y, 0.125, 0.125])
+            values.append(value)
+        return np.array(boxes), masks, np.array(values)
+
+    def make_labels(
+        root_instances: list[tuple[int, float, float]],
+        nested_instances: list[tuple[int, float, float]],
+    ) -> Labels:
+        root_boxes, root_masks, root_values = make_mask(root_instances)
+        nested_boxes, nested_masks, nested_values = make_mask(nested_instances)
+        return {
+            "/boundingbox": root_boxes,
+            "/instance_segmentation": root_masks,
+            "/metadata/id": root_values,
+            "/nested/boundingbox": nested_boxes,
+            "/nested/instance_segmentation": nested_masks,
+            "/nested/metadata/id": nested_values,
+        }
+
+    targets = {
+        "/boundingbox": "boundingbox",
+        "/instance_segmentation": "instance_segmentation",
+        "/metadata/id": "metadata",
+        "/nested/boundingbox": "boundingbox",
+        "/nested/instance_segmentation": "instance_segmentation",
+        "/nested/metadata/id": "metadata",
+    }
+    augmentations = AlbumentationsEngine(
+        64,
+        64,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        [
+            {
+                "name": "Mosaic4",
+                "params": {"p": 0.0, "height": 64, "width": 64},
+            },
+            {"name": "MixUp", "params": {"p": 1.0}},
+        ],
+    )
+    first = make_labels(
+        [(1, 0.10, 0.10), (2, 0.70, 0.70)],
+        [(101, 0.40, 0.40)],
+    )
+    second = make_labels(
+        [(3, 0.70, 0.10), (4, 0.10, 0.70)],
+        [(102, 0.20, 0.40)],
+    )
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+
+    _, output = augmentations.apply(
+        [
+            ({"image": image}, deepcopy(first if i < 4 else second))
+            for i in range(8)
+        ]
+    )
+
+    for task_group, expected_values in [
+        ("", np.array([1, 2, 3, 4])),
+        ("/nested", np.array([101, 102])),
+    ]:
+        boxes = output[f"{task_group}/boundingbox"]
+        masks = output[f"{task_group}/instance_segmentation"]
+        values = output[f"{task_group}/metadata/id"]
+        assert np.array_equal(values, expected_values)
+        assert_boxes_match_masks(boxes, masks)
+        assert_masks_match_values(masks, values)
+
+
+def test_standalone_labels_survive_bboxes_from_another_task_group() -> None:
+    """A bbox task must not filter standalone labels from another task group."""
+    targets = {
+        "detection/boundingbox": "boundingbox",
+        "pose/keypoints": "keypoints",
+        "pose/array": "array",
+        "pose/metadata/id": "metadata",
+    }
+    augmentations = AlbumentationsEngine(
+        64,
+        64,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        [{"name": "MixUp", "params": {"p": 1.0}}],
+    )
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    batch = []
+    for i in range(2):
+        batch.append(
+            (
+                {"image": image},
+                {
+                    "detection/boundingbox": np.array(
+                        [[0.0, 0.1 + i * 0.5, 0.1, 0.2, 0.2]]
+                    ),
+                    "pose/keypoints": np.array([[0.2 + i * 0.5, 0.2, 2.0]]),
+                    "pose/array": np.array([[i, i + 1]]),
+                    "pose/metadata/id": np.array([10 + i]),
+                },
+            )
+        )
+
+    _, output = augmentations.apply(batch)
+
+    assert output["pose/keypoints"].shape == (2, 3)
+    assert np.array_equal(output["pose/array"], [[0, 1], [1, 2]])
+    assert np.array_equal(output["pose/metadata/id"], [10, 11])
+
+
+def test_compaction_handles_all_filtered_bboxes() -> None:
+    """All associated labels are emptied when no bbox survives filtering."""
+    compose = BatchCompose(
+        [],
+        bbox_associations={
+            "bboxes": {
+                "instances": "instance_mask",
+                "keypoints": "keypoints",
+                "array": "array",
+                "metadata": "metadata",
+            }
+        },
+    )
+    data = {
+        "bboxes": np.array([]),
+        "instances": np.ones((8, 8, 2), dtype=np.uint8),
+        "keypoints": np.ones((4, 3)),
+        "array": np.ones((2, 4)),
+        "metadata": np.ones(2),
+    }
+
+    compose._compact_bbox_associated_labels(data, {"bboxes": 2})
+
+    assert data["instances"].shape == (8, 8, 0)
+    assert data["keypoints"].shape == (0, 3)
+    assert data["array"].shape == (0, 4)
+    assert data["metadata"].shape == (0,)
+
+
+def test_multiple_bbox_targets_in_one_task_group_are_rejected() -> None:
+    targets = {
+        "task/first_boxes": "boundingbox",
+        "task/second_boxes": "boundingbox",
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="Multiple bounding-box targets belong to task group 'task'",
+    ):
+        AlbumentationsEngine(
+            32,
+            32,
+            targets,
+            dict.fromkeys(targets, 1),
+            ["image"],
+            [],
+        )

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -157,3 +157,48 @@ def test_batched_p_0(
         256, 256, targets, n_classes, source_names, config
     )
     augmentations.apply([(images_dict, deepcopy(labels)) for _ in range(8)])
+
+
+def test_skipped_mosaic_before_mixup_reindexes_instance_masks() -> None:
+    image = np.zeros((320, 320, 3), dtype=np.uint8)
+    instance_mask = np.zeros((2, 320, 320), dtype=np.uint8)
+    instance_mask[0, 10:100, 10:100] = 1
+    instance_mask[1, 150:250, 150:250] = 1
+    labels: Labels = {
+        "task/instance_segmentation/boundingbox": np.array(
+            [
+                [0.0, 0.17, 0.17, 0.28, 0.28],
+                [0.0, 0.63, 0.63, 0.31, 0.31],
+            ]
+        ),
+        "task/instance_segmentation/segmentation": instance_mask,
+    }
+    targets = {
+        "task/instance_segmentation/boundingbox": "boundingbox",
+        "task/instance_segmentation/segmentation": "instance_segmentation",
+    }
+    config = [
+        {
+            "name": "Mosaic4",
+            "params": {"p": 0, "out_width": 640, "out_height": 640},
+        },
+        {"name": "MixUp", "params": {"p": 1}},
+    ]
+    augmentations = AlbumentationsEngine(
+        256,
+        256,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        config,
+    )
+
+    _, out_labels = augmentations.apply(
+        [({"image": image}, deepcopy(labels)) for _ in range(8)]
+    )
+
+    assert (
+        out_labels["task/instance_segmentation/boundingbox"].shape[0]
+        == out_labels["task/instance_segmentation/segmentation"].shape[0]
+        == 4
+    )

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -495,6 +495,120 @@ def test_batch_transforms_keep_nested_task_groups_independent() -> None:
         assert_masks_match_values(masks, values)
 
 
+def test_spatial_transform_emptying_the_boxes_keeps_the_task() -> None:
+    """A crop can remove every box after the batch stage has run.
+
+    The associated labels are still reported as empty, so dropping the bbox
+    task would leave a consumer with instance labels and no boxes to index
+    them against.
+    """
+    targets = {
+        "det/boundingbox": "boundingbox",
+        "det/keypoints": "keypoints",
+        "det/instance_segmentation": "instance_segmentation",
+    }
+    engine = AlbumentationsEngine(
+        64,
+        64,
+        targets,
+        dict.fromkeys(targets, 2),
+        ["image"],
+        [
+            {
+                "name": "Crop",
+                "params": {
+                    "x_min": 48,
+                    "y_min": 48,
+                    "x_max": 64,
+                    "y_max": 64,
+                    "p": 1.0,
+                },
+            }
+        ],
+        seed=0,
+    )
+
+    _, output = engine.apply(
+        [
+            (
+                {"image": np.zeros((64, 64, 3), dtype=np.uint8)},
+                {
+                    "det/boundingbox": np.array(
+                        [[0, 0.05, 0.05, 0.2, 0.2]], dtype=np.float32
+                    ),
+                    "det/keypoints": np.array(
+                        [[0.1, 0.1, 2]], dtype=np.float32
+                    ),
+                    "det/instance_segmentation": np.zeros(
+                        (1, 64, 64), dtype=np.uint8
+                    ),
+                },
+            )
+        ]
+    )
+
+    assert set(output) == set(targets)
+    assert output["det/boundingbox"].shape == (0, 5)
+    assert output["det/keypoints"].shape[0] == 0
+    assert output["det/instance_segmentation"].shape[0] == 0
+
+
+def test_default_task_labels_are_filtered_with_their_boxes() -> None:
+    """LDF's default task keys start with ``"/"`` and share one group.
+
+    Giving each task type its own group leaves the keypoints and mask of a
+    filtered-out box in the output, so every later instance is silently
+    paired with the wrong box.
+    """
+    engine = AlbumentationsEngine(
+        height=64,
+        width=64,
+        targets={
+            "/boundingbox": "boundingbox",
+            "/keypoints": "keypoints",
+            "/instance_segmentation": "instance_segmentation",
+        },
+        n_classes={"": 2},
+        source_names=["image"],
+        config=[],
+        seed=0,
+    )
+    # The middle box is too small to survive `bbox_area_threshold`.
+    boxes = np.array(
+        [
+            [0, 0.1, 0.1, 0.3, 0.3],
+            [1, 0.5, 0.5, 0.005, 0.005],
+            [0, 0.7, 0.1, 0.2, 0.2],
+        ],
+        dtype=np.float32,
+    )
+    keypoints = np.array(
+        [[0.15, 0.15, 2], [0.51, 0.51, 2], [0.75, 0.15, 2]], dtype=np.float32
+    )
+    masks = np.zeros((3, 64, 64), dtype=np.uint8)
+    for i, (x, y) in enumerate([(8, 8), (32, 32), (46, 8)]):
+        masks[i, y : y + 6, x : x + 6] = 1
+
+    _, output = engine.apply(
+        [
+            (
+                {"image": np.zeros((64, 64, 3), dtype=np.uint8)},
+                {
+                    "/boundingbox": boxes,
+                    "/keypoints": keypoints,
+                    "/instance_segmentation": masks,
+                },
+            )
+        ]
+    )
+
+    assert output["/boundingbox"].shape[0] == 2
+    assert_boxes_match_keypoints(output["/boundingbox"], output["/keypoints"])
+    assert_boxes_match_masks(
+        output["/boundingbox"], output["/instance_segmentation"]
+    )
+
+
 def test_standalone_labels_survive_bboxes_from_another_task_group() -> None:
     targets = {
         "detection/boundingbox": "boundingbox",
@@ -771,8 +885,13 @@ def test_partially_annotated_batches_stay_aligned() -> None:
         "task/boundingbox": "boundingbox",
         "task/instance_segmentation": "instance_segmentation",
     }
-    boxes = np.array(
+    annotated_boxes = np.array(
         [[0.0, 0.12, 0.12, 0.14, 0.14], [0.0, 0.62, 0.62, 0.14, 0.14]]
+    )
+    # The unannotated sample's boxes sit on the opposite diagonal, so a mask
+    # that drifts onto them lands outside the box it would have to match.
+    unannotated_boxes = np.array(
+        [[0.0, 0.62, 0.12, 0.14, 0.14], [0.0, 0.12, 0.62, 0.14, 0.14]]
     )
     masks = np.zeros((2, 64, 64), dtype=np.uint8)
     masks[0, 9:17, 9:17] = 1
@@ -794,11 +913,11 @@ def test_partially_annotated_batches_stay_aligned() -> None:
             (
                 {"image": image},
                 {
-                    "task/boundingbox": boxes.copy(),
+                    "task/boundingbox": annotated_boxes.copy(),
                     "task/instance_segmentation": masks.copy(),
                 },
             ),
-            ({"image": image}, {"task/boundingbox": boxes.copy()}),
+            ({"image": image}, {"task/boundingbox": unannotated_boxes.copy()}),
         ]
     )
 
@@ -809,7 +928,9 @@ def test_partially_annotated_batches_stay_aligned() -> None:
     # The two annotated instances keep their own masks; the two that were
     # never annotated get an empty one rather than someone else's.
     annotated = [i for i, mask in enumerate(out_masks) if mask.any()]
-    assert len(annotated) == 2
+    assert annotated == [0, 1], (
+        "the masks moved onto the boxes of the sample that had none"
+    )
     assert_boxes_match_masks(out_boxes[annotated], out_masks[annotated])
 
 

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
-from luxonis_ml.data.augmentations import BatchCompose, MixUp, Mosaic4
+from luxonis_ml.data.augmentations import BatchCompose, MixUp
 from luxonis_ml.typing import Labels
 
 from .helpers import KeepFirstSample
@@ -69,7 +69,6 @@ def assert_boxes_match_keypoints(
 
 
 def assert_masks_match_values(masks: np.ndarray, values: np.ndarray) -> None:
-    """Assert each mask channel carries its associated scalar value."""
     assert masks.shape[0] == values.shape[0]
     for mask, value in zip(masks, values, strict=True):
         assert np.unique(mask[mask != 0]).tolist() == [value]
@@ -415,7 +414,6 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
 
 
 def test_batch_transforms_keep_nested_task_groups_independent() -> None:
-
     def make_mask(
         instances: list[tuple[int, float, float]], size: int = 64
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -838,40 +836,6 @@ def test_unmatched_label_counts_are_left_as_is() -> None:
     )
 
     assert output["task/metadata/id"].size > 0
-
-
-@pytest.mark.parametrize("target", ["keypoints", "bboxes"])
-def test_mixup_pads_empty_targets_to_the_sibling_width(target: str) -> None:
-    """Emptied targets must keep the column count of their sibling.
-
-    Compaction can empty one half of a MixUp pair while the other half keeps
-    its rows, and a placeholder of the wrong width then fails to concatenate.
-    """
-    mixup = MixUp(p=1.0)
-    batch = [np.zeros((0, 6)), np.ones((2, 6))]
-    apply_to_target = getattr(mixup, f"apply_to_{target}")
-
-    output = apply_to_target(batch, image_shapes=[(16, 16), (16, 16)])
-
-    assert output.shape == (2, 6)
-
-
-@pytest.mark.parametrize("target", ["keypoints", "bboxes"])
-def test_mosaic_pads_empty_targets_to_the_sibling_width(target: str) -> None:
-    """Emptied targets must keep the column count of their sibling.
-
-    The width depends on which optional fields the pipeline uses, so a
-    hardcoded placeholder fails to concatenate with the populated samples.
-    """
-    mosaic = Mosaic4(height=16, width=16, p=1.0)
-    batch = [np.ones((2, 5)), *(np.zeros((0, 5)) for _ in range(3))]
-    apply_to_target = getattr(mosaic, f"apply_to_{target}")
-
-    output = apply_to_target(
-        batch, image_shapes=[(16, 16)] * 4, x_crop=0, y_crop=0
-    )
-
-    assert output.shape == (2, 5)
 
 
 def test_partially_annotated_batches_stay_aligned() -> None:

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -1,13 +1,14 @@
 from copy import deepcopy
-from typing import Any, cast
 
 import albumentations as A
 import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
-from luxonis_ml.data.augmentations import BatchCompose, BatchTransform, MixUp
+from luxonis_ml.data.augmentations import BatchCompose, MixUp
 from luxonis_ml.typing import Labels
+
+from .helpers import KeepFirstSample
 
 
 def assert_boxes_match_masks(
@@ -15,11 +16,10 @@ def assert_boxes_match_masks(
 ) -> None:
     """Assert every instance mask is paired with the correct bounding box.
 
-    Box and instance mask undergo the same geometric transforms, so a
-    correctly paired mask always has its nonzero pixels inside its box.
-    A reindexing bug that scrambles the box-to-mask mapping (e.g. pairing a
-    box with a mask blob located elsewhere in the image) is caught here even
-    when the row counts still match.
+    Box and mask undergo the same geometric transforms, so a correctly
+    paired mask always has its nonzero pixels inside its box. This catches
+    a reindexing bug that scrambles the mapping even when the row counts
+    still line up.
     """
     assert boxes.shape[0] == masks.shape[0]
     _, height, width = masks.shape
@@ -30,12 +30,12 @@ def assert_boxes_match_masks(
         cy = ys.mean() / height
         x, y, w, h = box[1:5]
         assert x - tol <= cx <= x + w + tol, (
-            f"instance {i}: mask centroid x={cx:.3f} outside box "
-            f"[{x:.3f}, {x + w:.3f}] — box paired with the wrong mask"
+            f"instance {i} is paired with the wrong mask: centroid "
+            f"x={cx:.3f} outside box [{x:.3f}, {x + w:.3f}]"
         )
         assert y - tol <= cy <= y + h + tol, (
-            f"instance {i}: mask centroid y={cy:.3f} outside box "
-            f"[{y:.3f}, {y + h:.3f}] — box paired with the wrong mask"
+            f"instance {i} is paired with the wrong mask: centroid "
+            f"y={cy:.3f} outside box [{y:.3f}, {y + h:.3f}]"
         )
 
 
@@ -213,7 +213,6 @@ def test_batched_p_0(
 
 
 def test_batch_compose_without_bbox_params() -> None:
-    """BatchCompose remains usable for image-only batch transformations."""
     first = np.zeros((8, 8, 3), dtype=np.uint8)
     second = np.ones((8, 8, 3), dtype=np.uint8)
     compose = BatchCompose([MixUp(p=0)])
@@ -295,11 +294,9 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
 ) -> None:
     """Boxes dropped by ``min_bbox_visibility`` must not scramble masks.
 
-    When a batch transform (here Mosaic4) crops instances so some boxes fall
-    below the visibility threshold, ``check_data_post_transform`` drops those
-    boxes while every instance-mask channel remains. The surviving boxes must
-    still be paired with their own masks; reindexing them to a contiguous
-    range after the drop would silently pair them with the wrong masks.
+    ``check_data_post_transform`` drops the boxes Mosaic4 cropped below the
+    threshold while every instance-mask channel remains. Reindexing the
+    survivors to a contiguous range would pair them with the wrong masks.
     """
     image = np.zeros((320, 320, 3), dtype=np.uint8)
     # Four instances in the four corners, each mask centered in its box.
@@ -309,10 +306,9 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
     def make_labels(sample: int) -> Labels:
         """Build one sample whose per-instance ids are unique batch-wide.
 
-        Repeating the same ids in every batch member would make the value
-        oracles below hold under any permutation that maps instance *i* of
-        one sample onto instance *i* of another, which is exactly the kind
-        of wrong pairing compaction can introduce.
+        Reusing ids across batch members would let the checks below pass
+        under a permutation mapping instance *i* of one sample onto
+        instance *i* of another - exactly the mispairing they look for.
         """
         instance_mask = np.zeros((4, 320, 320), dtype=np.uint8)
         boxes_in = []
@@ -387,7 +383,6 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
 
 
 def test_batch_transforms_keep_nested_task_groups_independent() -> None:
-    """Associated labels from nested task groups must not be compacted together."""
 
     def make_mask(
         instances: list[tuple[int, float, float]], size: int = 64
@@ -469,7 +464,6 @@ def test_batch_transforms_keep_nested_task_groups_independent() -> None:
 
 
 def test_standalone_labels_survive_bboxes_from_another_task_group() -> None:
-    """A bbox task must not filter standalone labels from another task group."""
     targets = {
         "detection/boundingbox": "boundingbox",
         "pose/keypoints": "keypoints",
@@ -511,10 +505,8 @@ def test_standalone_labels_survive_bboxes_from_another_task_group() -> None:
 def test_compaction_handles_all_filtered_bboxes() -> None:
     """Associated labels stay present but empty when no bbox survives.
 
-    Driven end to end rather than by calling the compaction helper, so it
-    covers how ``bbox_counts`` is derived and how the emptied labels travel
-    back out through postprocessing. Dropping the task keys entirely would
-    let ``LuxonisLoader._add_empty_annotations`` refill metadata with
+    Dropping the task keys entirely would let
+    ``LuxonisLoader._add_empty_annotations`` refill metadata with
     ``n_classes`` phantom rows.
     """
     targets = {
@@ -536,41 +528,35 @@ def test_compaction_handles_all_filtered_bboxes() -> None:
         "task/metadata/id": np.array([7]),
     }
 
-    all_filtered_seen = False
-    for seed in range(10):
-        augmentations = AlbumentationsEngine(
-            64,
-            64,
-            targets,
-            dict.fromkeys(targets, 1),
-            ["image"],
-            [
-                {
-                    "name": "Mosaic4",
-                    "params": {"p": 1.0, "height": 64, "width": 64},
-                },
-                {"name": "MixUp", "params": {"p": 1.0}},
-            ],
-            min_bbox_visibility=1.0,
-            seed=seed,
-        )
-        _, output = augmentations.apply(
-            [({"image": image}, deepcopy(labels)) for _ in range(8)]
-        )
+    augmentations = AlbumentationsEngine(
+        64,
+        64,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        [
+            {
+                "name": "Mosaic4",
+                "params": {"p": 1.0, "height": 64, "width": 64},
+            },
+            {"name": "MixUp", "params": {"p": 1.0}},
+        ],
+        min_bbox_visibility=1.0,
+        seed=0,
+    )
 
-        if output.get("task/boundingbox", np.zeros((0, 5))).shape[0]:
-            continue
+    _, output = augmentations.apply(
+        [({"image": image}, deepcopy(labels)) for _ in range(8)]
+    )
 
-        all_filtered_seen = True
-        # The bbox task itself is dropped, as it always has been; the loader
-        # refills it with a correctly shaped empty array. The labels hanging
-        # off it are the ones that must not disappear.
-        assert output["task/instance_segmentation"].shape == (0, 64, 64)
-        assert output["task/keypoints"].shape == (0, 3)
-        assert output["task/array"].shape == (0, 2)
-        assert output["task/metadata/id"].shape == (0,)
-
-    assert all_filtered_seen, "no seed produced the all-filtered case"
+    # The bbox task itself is dropped, as it always has been; the loader
+    # refills it with a correctly shaped empty array. The labels hanging off
+    # it are the ones that must not disappear.
+    assert "task/boundingbox" not in output
+    assert output["task/instance_segmentation"].shape == (0, 64, 64)
+    assert output["task/keypoints"].shape == (0, 3)
+    assert output["task/array"].shape == (0, 2)
+    assert output["task/metadata/id"].shape == (0,)
 
 
 def test_instance_masks_without_bboxes_in_their_task_group() -> None:
@@ -602,11 +588,7 @@ def test_instance_masks_without_bboxes_in_their_task_group() -> None:
 
 
 def test_bbox_label_column_is_left_alone_without_associations() -> None:
-    """Plain Albumentations use keeps its class column.
-
-    Without ``bbox_associations`` the trailing bbox column is the class
-    label, not an index, so the composition must not restamp it.
-    """
+    """Without ``bbox_associations`` the trailing column is a class label."""
     compose = BatchCompose(
         [MixUp(p=1.0)],
         bbox_params=A.BboxParams(format="albumentations"),
@@ -626,47 +608,7 @@ def test_bbox_label_column_is_left_alone_without_associations() -> None:
     assert sorted(output["bboxes"][:, -1].tolist()) == [7.0, 7.0, 9.0, 9.0]
 
 
-def test_bbox_params_cannot_be_passed_positionally() -> None:
-    """``bbox_associations`` must not occupy ``A.Compose``'s second slot."""
-    untyped_compose = cast(Any, BatchCompose)
-    with pytest.raises(TypeError):
-        untyped_compose([MixUp(p=1.0)], A.BboxParams(format="albumentations"))
-
-
-class KeepFirstSample(BatchTransform):
-    """Batch transform that keeps the first sample's targets untouched.
-
-    Lets a test observe what `BatchCompose` itself does to the data,
-    without a real transform rewriting the targets on the way through.
-    """
-
-    def __init__(self):
-        super().__init__(batch_size=2, p=1.0)
-
-    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
-        return image_batch[0]
-
-    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_instance_mask(
-        self, masks_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_bboxes(
-        self, bboxes_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return bboxes_batch[0]
-
-    def apply_to_keypoints(
-        self, keypoints_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return keypoints_batch[0]
-
-
 def test_read_only_bboxes_are_not_mutated_in_place() -> None:
-    """Reindexing must not write into a caller's read-only buffer."""
     boxes = np.array([[0.1, 0.1, 0.3, 0.3, 0.0, 5.0]])
     boxes.setflags(write=False)
     compose = BatchCompose(
@@ -691,11 +633,7 @@ def test_read_only_bboxes_are_not_mutated_in_place() -> None:
 
 
 def test_associations_are_kept_when_bboxes_are_not_processed() -> None:
-    """A missing bbox processor must not be read as "every bbox was cut".
-
-    Without ``bbox_params`` there is no bbox count to compare against, which
-    is not the same thing as a count of zero.
-    """
+    """Having no bbox count to compare against is not a count of zero."""
     compose = BatchCompose(
         [MixUp(p=1.0)],
         bbox_associations={"bboxes": {"metadata": "metadata"}},

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -1,10 +1,12 @@
 from copy import deepcopy
+from typing import Any, cast
 
+import albumentations as A
 import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
-from luxonis_ml.data.augmentations import BatchCompose, MixUp
+from luxonis_ml.data.augmentations import BatchCompose, BatchTransform, MixUp
 from luxonis_ml.typing import Labels
 
 
@@ -303,22 +305,36 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
     # Four instances in the four corners, each mask centered in its box.
     corners = [(0.05, 0.05), (0.80, 0.05), (0.05, 0.80), (0.80, 0.80)]
     size = 0.15
-    instance_mask = np.zeros((4, 320, 320), dtype=np.uint8)
-    boxes_in = []
-    keypoints_in = []
-    for i, (x, y) in enumerate(corners):
-        r0, r1 = int(y * 320), int((y + size) * 320)
-        c0, c1 = int(x * 320), int((x + size) * 320)
-        instance_mask[i, r0:r1, c0:c1] = i + 1
-        boxes_in.append([0.0, x, y, size, size])
-        keypoints_in.append([x + size / 2, y + size / 2, 2.0])
-    labels: Labels = {
-        "task/boundingbox": np.array(boxes_in),
-        "task/instance_segmentation": instance_mask,
-        "task/keypoints": np.array(keypoints_in),
-        "task/array": np.arange(1, 5),
-        "task/metadata/id": np.arange(11, 15),
-    }
+
+    def make_labels(sample: int) -> Labels:
+        """Build one sample whose per-instance ids are unique batch-wide.
+
+        Repeating the same ids in every batch member would make the value
+        oracles below hold under any permutation that maps instance *i* of
+        one sample onto instance *i* of another, which is exactly the kind
+        of wrong pairing compaction can introduce.
+        """
+        instance_mask = np.zeros((4, 320, 320), dtype=np.uint8)
+        boxes_in = []
+        keypoints_in = []
+        values = []
+        for i, (x, y) in enumerate(corners):
+            r0, r1 = int(y * 320), int((y + size) * 320)
+            c0, c1 = int(x * 320), int((x + size) * 320)
+            value = sample * len(corners) + i + 1
+            instance_mask[i, r0:r1, c0:c1] = value
+            boxes_in.append([0.0, x, y, size, size])
+            keypoints_in.append([x + size / 2, y + size / 2, 2.0])
+            values.append(value)
+        ids = np.array(values)
+        return {
+            "task/boundingbox": np.array(boxes_in),
+            "task/instance_segmentation": instance_mask,
+            "task/keypoints": np.array(keypoints_in),
+            "task/array": ids,
+            "task/metadata/id": ids + 100,
+        }
+
     targets = {
         "task/boundingbox": "boundingbox",
         "task/instance_segmentation": "instance_segmentation",
@@ -349,7 +365,10 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
     )
 
     _, out_labels = augmentations.apply(
-        [({"image": image}, deepcopy(labels)) for _ in range(batch_size)]
+        [
+            ({"image": image}, make_labels(sample))
+            for sample in range(batch_size)
+        ]
     )
 
     boxes = out_labels["task/boundingbox"]
@@ -364,7 +383,7 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
     assert_boxes_match_keypoints(boxes, keypoints)
     assert arrays.shape == metadata.shape == (boxes.shape[0],)
     assert_masks_match_values(masks, arrays)
-    assert np.array_equal(metadata, arrays + 10)
+    assert np.array_equal(metadata, arrays + 100)
 
 
 def test_batch_transforms_keep_nested_task_groups_independent() -> None:
@@ -490,32 +509,262 @@ def test_standalone_labels_survive_bboxes_from_another_task_group() -> None:
 
 
 def test_compaction_handles_all_filtered_bboxes() -> None:
-    """All associated labels are emptied when no bbox survives filtering."""
-    compose = BatchCompose(
-        [],
-        bbox_associations={
-            "bboxes": {
-                "instances": "instance_mask",
-                "keypoints": "keypoints",
-                "array": "array",
-                "metadata": "metadata",
-            }
-        },
-    )
-    data = {
-        "bboxes": np.array([]),
-        "instances": np.ones((8, 8, 2), dtype=np.uint8),
-        "keypoints": np.ones((4, 3)),
-        "array": np.ones((2, 4)),
-        "metadata": np.ones(2),
+    """Associated labels stay present but empty when no bbox survives.
+
+    Driven end to end rather than by calling the compaction helper, so it
+    covers how ``bbox_counts`` is derived and how the emptied labels travel
+    back out through postprocessing. Dropping the task keys entirely would
+    let ``LuxonisLoader._add_empty_annotations`` refill metadata with
+    ``n_classes`` phantom rows.
+    """
+    targets = {
+        "task/boundingbox": "boundingbox",
+        "task/instance_segmentation": "instance_segmentation",
+        "task/keypoints": "keypoints",
+        "task/array": "array",
+        "task/metadata/id": "metadata",
+    }
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    # One instance filling the whole image: any Mosaic crop that is not
+    # exactly quadrant-aligned clips it, and min_bbox_visibility=1.0 then
+    # drops it.
+    labels: Labels = {
+        "task/boundingbox": np.array([[0.0, 0.0, 0.0, 1.0, 1.0]]),
+        "task/instance_segmentation": np.ones((1, 64, 64), dtype=np.uint8),
+        "task/keypoints": np.array([[0.5, 0.5, 2.0]]),
+        "task/array": np.array([[1, 2]]),
+        "task/metadata/id": np.array([7]),
     }
 
-    compose._compact_bbox_associated_labels(data, {"bboxes": 2})
+    all_filtered_seen = False
+    for seed in range(10):
+        augmentations = AlbumentationsEngine(
+            64,
+            64,
+            targets,
+            dict.fromkeys(targets, 1),
+            ["image"],
+            [
+                {
+                    "name": "Mosaic4",
+                    "params": {"p": 1.0, "height": 64, "width": 64},
+                },
+                {"name": "MixUp", "params": {"p": 1.0}},
+            ],
+            min_bbox_visibility=1.0,
+            seed=seed,
+        )
+        _, output = augmentations.apply(
+            [({"image": image}, deepcopy(labels)) for _ in range(8)]
+        )
 
-    assert data["instances"].shape == (8, 8, 0)
-    assert data["keypoints"].shape == (0, 3)
-    assert data["array"].shape == (0, 4)
-    assert data["metadata"].shape == (0,)
+        if output.get("task/boundingbox", np.zeros((0, 5))).shape[0]:
+            continue
+
+        all_filtered_seen = True
+        # The bbox task itself is dropped, as it always has been; the loader
+        # refills it with a correctly shaped empty array. The labels hanging
+        # off it are the ones that must not disappear.
+        assert output["task/instance_segmentation"].shape == (0, 64, 64)
+        assert output["task/keypoints"].shape == (0, 3)
+        assert output["task/array"].shape == (0, 2)
+        assert output["task/metadata/id"].shape == (0,)
+
+    assert all_filtered_seen, "no seed produced the all-filtered case"
+
+
+def test_instance_masks_without_bboxes_in_their_task_group() -> None:
+    """An instance-mask task needs no bbox task in its own group.
+
+    Sizing the pass-through ordering by the mask's leading axis reads the
+    image height instead of the instance count and raises ``IndexError``.
+    """
+    targets = {
+        "det/boundingbox": "boundingbox",
+        "seg/instance_segmentation": "instance_segmentation",
+    }
+    instance_mask = np.zeros((2, 64, 64), dtype=np.uint8)
+    instance_mask[0, 8:24, 8:24] = 1
+    instance_mask[1, 40:56, 40:56] = 2
+    labels: Labels = {
+        "det/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]]),
+        "seg/instance_segmentation": instance_mask,
+    }
+    augmentations = AlbumentationsEngine(
+        64, 64, targets, dict.fromkeys(targets, 1), ["image"], []
+    )
+
+    _, output = augmentations.apply(
+        [({"image": np.zeros((64, 64, 3), dtype=np.uint8)}, labels)]
+    )
+
+    assert output["seg/instance_segmentation"].shape == (2, 64, 64)
+
+
+def test_bbox_label_column_is_left_alone_without_associations() -> None:
+    """Plain Albumentations use keeps its class column.
+
+    Without ``bbox_associations`` the trailing bbox column is the class
+    label, not an index, so the composition must not restamp it.
+    """
+    compose = BatchCompose(
+        [MixUp(p=1.0)],
+        bbox_params=A.BboxParams(format="albumentations"),
+    )
+    boxes = np.array([[0.1, 0.1, 0.3, 0.3, 7.0], [0.5, 0.5, 0.9, 0.9, 9.0]])
+
+    output = compose(
+        [
+            {
+                "image": np.zeros((16, 16, 3), dtype=np.uint8),
+                "bboxes": boxes.copy(),
+            }
+            for _ in range(2)
+        ]
+    )
+
+    assert sorted(output["bboxes"][:, -1].tolist()) == [7.0, 7.0, 9.0, 9.0]
+
+
+def test_bbox_params_cannot_be_passed_positionally() -> None:
+    """``bbox_associations`` must not occupy ``A.Compose``'s second slot."""
+    untyped_compose = cast(Any, BatchCompose)
+    with pytest.raises(TypeError):
+        untyped_compose([MixUp(p=1.0)], A.BboxParams(format="albumentations"))
+
+
+class KeepFirstSample(BatchTransform):
+    """Batch transform that keeps the first sample's targets untouched.
+
+    Lets a test observe what `BatchCompose` itself does to the data,
+    without a real transform rewriting the targets on the way through.
+    """
+
+    def __init__(self):
+        super().__init__(batch_size=2, p=1.0)
+
+    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
+        return image_batch[0]
+
+    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_instance_mask(
+        self, masks_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_bboxes(
+        self, bboxes_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return bboxes_batch[0]
+
+    def apply_to_keypoints(
+        self, keypoints_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return keypoints_batch[0]
+
+
+def test_read_only_bboxes_are_not_mutated_in_place() -> None:
+    """Reindexing must not write into a caller's read-only buffer."""
+    boxes = np.array([[0.1, 0.1, 0.3, 0.3, 0.0, 5.0]])
+    boxes.setflags(write=False)
+    compose = BatchCompose(
+        [KeepFirstSample()],
+        bbox_params=A.BboxParams(format="albumentations"),
+        bbox_associations={"bboxes": {"metadata": "metadata"}},
+    )
+
+    output = compose(
+        [
+            {
+                "image": np.zeros((16, 16, 3), dtype=np.uint8),
+                "bboxes": boxes,
+                "metadata": np.array([3]),
+            }
+            for _ in range(2)
+        ]
+    )
+
+    assert output["bboxes"].shape[0] == 1
+    assert boxes[0, -1] == 5.0
+
+
+def test_associations_are_kept_when_bboxes_are_not_processed() -> None:
+    """A missing bbox processor must not be read as "every bbox was cut".
+
+    Without ``bbox_params`` there is no bbox count to compare against, which
+    is not the same thing as a count of zero.
+    """
+    compose = BatchCompose(
+        [MixUp(p=1.0)],
+        bbox_associations={"bboxes": {"metadata": "metadata"}},
+    )
+
+    output = compose(
+        [
+            {
+                "image": np.zeros((16, 16, 3), dtype=np.uint8),
+                "bboxes": np.array([[0.1, 0.1, 0.3, 0.3, 0.0, 0.0]]),
+                "metadata": np.array([7]),
+            }
+            for _ in range(2)
+        ]
+    )
+
+    assert output["metadata"].tolist() == [7, 7]
+
+
+def test_unmatched_label_counts_are_left_as_is() -> None:
+    """Labels that cannot be matched to bboxes must not abort the batch.
+
+    Instance counts and bbox counts can legitimately disagree, for example
+    when some annotations carry metadata but no bounding box.
+    """
+    targets = {
+        "task/boundingbox": "boundingbox",
+        "task/metadata/id": "metadata",
+    }
+    augmentations = AlbumentationsEngine(
+        64,
+        64,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        [{"name": "MixUp", "params": {"p": 1.0}}],
+    )
+    labels: Labels = {
+        "task/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]]),
+        "task/metadata/id": np.array([11, 12, 13]),
+    }
+
+    _, output = augmentations.apply(
+        [
+            (
+                {"image": np.zeros((64, 64, 3), dtype=np.uint8)},
+                deepcopy(labels),
+            )
+            for _ in range(2)
+        ]
+    )
+
+    assert output["task/metadata/id"].size > 0
+
+
+@pytest.mark.parametrize("target", ["keypoints", "bboxes"])
+def test_mixup_pads_empty_targets_to_the_sibling_width(target: str) -> None:
+    """Emptied targets must keep the column count of their sibling.
+
+    Compaction can empty one half of a MixUp pair while the other half keeps
+    its rows, and a placeholder of the wrong width then fails to concatenate.
+    """
+    mixup = MixUp(p=1.0)
+    batch = [np.zeros((0, 6)), np.ones((2, 6))]
+    apply_to_target = getattr(mixup, f"apply_to_{target}")
+
+    output = apply_to_target(batch, image_shapes=[(16, 16), (16, 16)])
+
+    assert output.shape == (2, 6)
 
 
 def test_multiple_bbox_targets_in_one_task_group_are_rejected() -> None:

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -7,6 +7,35 @@ from luxonis_ml.data import AlbumentationsEngine
 from luxonis_ml.typing import Labels
 
 
+def assert_boxes_match_masks(
+    boxes: np.ndarray, masks: np.ndarray, tol: float = 0.05
+) -> None:
+    """Assert every instance mask is paired with the correct bounding box.
+
+    Box and instance mask undergo the same geometric transforms, so a
+    correctly paired mask always has its nonzero pixels inside its box.
+    A reindexing bug that scrambles the box-to-mask mapping (e.g. pairing a
+    box with a mask blob located elsewhere in the image) is caught here even
+    when the row counts still match.
+    """
+    assert boxes.shape[0] == masks.shape[0]
+    _, height, width = masks.shape
+    for i, (box, mask) in enumerate(zip(boxes, masks, strict=True)):
+        ys, xs = np.nonzero(mask)
+        assert ys.size > 0, f"instance {i} has an empty mask"
+        cx = xs.mean() / width
+        cy = ys.mean() / height
+        x, y, w, h = box[1:5]
+        assert x - tol <= cx <= x + w + tol, (
+            f"instance {i}: mask centroid x={cx:.3f} outside box "
+            f"[{x:.3f}, {x + w:.3f}] — box paired with the wrong mask"
+        )
+        assert y - tol <= cy <= y + h + tol, (
+            f"instance {i}: mask centroid y={cy:.3f} outside box "
+            f"[{y:.3f}, {y + h:.3f}] — box paired with the wrong mask"
+        )
+
+
 @pytest.fixture(
     params=[
         {"image": np.zeros((320, 320, 3), dtype=np.uint8)},
@@ -161,14 +190,16 @@ def test_batched_p_0(
 
 def test_skipped_mosaic_before_mixup_reindexes_instance_masks() -> None:
     image = np.zeros((320, 320, 3), dtype=np.uint8)
+    # Two instances whose masks are centered inside their boxes, so a
+    # box-to-mask mispairing is detectable geometrically.
     instance_mask = np.zeros((2, 320, 320), dtype=np.uint8)
-    instance_mask[0, 10:100, 10:100] = 1
-    instance_mask[1, 150:250, 150:250] = 1
+    instance_mask[0, 48:112, 48:112] = 1  # box 0 spans [0.15, 0.35]
+    instance_mask[1, 192:256, 192:256] = 1  # box 1 spans [0.60, 0.80]
     labels: Labels = {
         "task/instance_segmentation/boundingbox": np.array(
             [
-                [0.0, 0.17, 0.17, 0.28, 0.28],
-                [0.0, 0.63, 0.63, 0.31, 0.31],
+                [0.0, 0.15, 0.15, 0.20, 0.20],
+                [0.0, 0.60, 0.60, 0.20, 0.20],
             ]
         ),
         "task/instance_segmentation/segmentation": instance_mask,
@@ -197,8 +228,64 @@ def test_skipped_mosaic_before_mixup_reindexes_instance_masks() -> None:
         [({"image": image}, deepcopy(labels)) for _ in range(8)]
     )
 
-    assert (
-        out_labels["task/instance_segmentation/boundingbox"].shape[0]
-        == out_labels["task/instance_segmentation/segmentation"].shape[0]
-        == 4
+    boxes = out_labels["task/instance_segmentation/boundingbox"]
+    masks = out_labels["task/instance_segmentation/segmentation"]
+    assert boxes.shape[0] == masks.shape[0] == 4
+    assert_boxes_match_masks(boxes, masks)
+
+
+def test_mosaic_drops_boxes_keeps_masks_aligned() -> None:
+    """Boxes dropped by ``min_bbox_visibility`` must not scramble masks.
+
+    When a batch transform (here Mosaic4) crops instances so some boxes fall
+    below the visibility threshold, ``check_data_post_transform`` drops those
+    boxes while every instance-mask channel remains. The surviving boxes must
+    still be paired with their own masks; reindexing them to a contiguous
+    range after the drop would silently pair them with the wrong masks.
+    """
+    image = np.zeros((320, 320, 3), dtype=np.uint8)
+    # Four instances in the four corners, each mask centered in its box.
+    corners = [(0.05, 0.05), (0.80, 0.05), (0.05, 0.80), (0.80, 0.80)]
+    size = 0.15
+    instance_mask = np.zeros((4, 320, 320), dtype=np.uint8)
+    boxes_in = []
+    for i, (x, y) in enumerate(corners):
+        r0, r1 = int(y * 320), int((y + size) * 320)
+        c0, c1 = int(x * 320), int((x + size) * 320)
+        instance_mask[i, r0:r1, c0:c1] = 1
+        boxes_in.append([0.0, x, y, size, size])
+    labels: Labels = {
+        "task/instance_segmentation/boundingbox": np.array(boxes_in),
+        "task/instance_segmentation/segmentation": instance_mask,
+    }
+    targets = {
+        "task/instance_segmentation/boundingbox": "boundingbox",
+        "task/instance_segmentation/segmentation": "instance_segmentation",
+    }
+    config = [
+        {
+            "name": "Mosaic4",
+            "params": {"p": 1.0, "out_width": 640, "out_height": 640},
+        }
+    ]
+    augmentations = AlbumentationsEngine(
+        256,
+        256,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        config,
+        min_bbox_visibility=0.1,
+        seed=42,
     )
+
+    _, out_labels = augmentations.apply(
+        [({"image": image}, deepcopy(labels)) for _ in range(4)]
+    )
+
+    boxes = out_labels["task/instance_segmentation/boundingbox"]
+    masks = out_labels["task/instance_segmentation/segmentation"]
+    # The mosaic crop must drop at least one of the 16 candidate instances,
+    # otherwise the non-contiguous-index path is never exercised.
+    assert 0 < boxes.shape[0] < 16
+    assert_boxes_match_masks(boxes, masks)

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
-from luxonis_ml.data.augmentations import BatchCompose, MixUp
+from luxonis_ml.data.augmentations import BatchCompose, MixUp, Mosaic4
 from luxonis_ml.typing import Labels
 
 from .helpers import KeepFirstSample
@@ -42,15 +42,30 @@ def assert_boxes_match_masks(
 def assert_boxes_match_keypoints(
     boxes: np.ndarray, keypoints: np.ndarray, tol: float = 0.05
 ) -> None:
-    """Assert visible keypoints remain paired with their bounding boxes."""
+    """Assert every visible keypoint stays inside its own bounding box.
+
+    Checking only the first keypoint of each instance would miss a regroup
+    that permutes keypoints within an instance, and skipping instances whose
+    first keypoint was pushed out of frame would drop them from the check
+    entirely.
+    """
     assert boxes.shape[0] == keypoints.shape[0]
-    visible = keypoints[:, 2] > 0
-    assert np.any(visible)
-    for box, keypoint in zip(boxes[visible], keypoints[visible], strict=True):
+    instances = keypoints.reshape(len(keypoints), -1, 3)
+    assert np.any(instances[..., 2] > 0), "no keypoint survived to check"
+
+    for i, (box, instance) in enumerate(zip(boxes, instances, strict=True)):
         x, y, w, h = box[1:5]
-        px, py = keypoint[:2]
-        assert x - tol <= px <= x + w + tol
-        assert y - tol <= py <= y + h + tol
+        for k, (px, py, visibility) in enumerate(instance):
+            if visibility == 0:
+                continue
+            assert x - tol <= px <= x + w + tol, (
+                f"instance {i} keypoint {k} is paired with the wrong box: "
+                f"x={px:.3f} outside [{x:.3f}, {x + w:.3f}]"
+            )
+            assert y - tol <= py <= y + h + tol, (
+                f"instance {i} keypoint {k} is paired with the wrong box: "
+                f"y={py:.3f} outside [{y:.3f}, {y + h:.3f}]"
+            )
 
 
 def assert_masks_match_values(masks: np.ndarray, values: np.ndarray) -> None:
@@ -320,7 +335,18 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
             value = sample * len(corners) + i + 1
             instance_mask[i, r0:r1, c0:c1] = value
             boxes_in.append([0.0, x, y, size, size])
-            keypoints_in.append([x + size / 2, y + size / 2, 2.0])
+            # Two keypoints at opposite corners of the box, so a regroup
+            # that shuffles keypoints within an instance is visible too.
+            keypoints_in.append(
+                [
+                    x + size / 4,
+                    y + size / 4,
+                    2.0,
+                    x + 3 * size / 4,
+                    y + 3 * size / 4,
+                    2.0,
+                ]
+            )
             values.append(value)
         ids = np.array(values)
         return {
@@ -377,6 +403,12 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
     assert 0 < boxes.shape[0] < 4 * batch_size
     assert_boxes_match_masks(boxes, masks)
     assert_boxes_match_keypoints(boxes, keypoints)
+    # Being inside the right box does not pin down which keypoint is which,
+    # so check the two are still in the order they were annotated in.
+    instances = keypoints.reshape(len(keypoints), -1, 3)
+    intact = (instances[..., 2] > 0).all(axis=1)
+    assert intact.any()
+    assert np.all(instances[intact, 0, :2] < instances[intact, 1, :2])
     assert arrays.shape == metadata.shape == (boxes.shape[0],)
     assert_masks_match_values(masks, arrays)
     assert np.array_equal(metadata, arrays + 100)
@@ -549,14 +581,19 @@ def test_compaction_handles_all_filtered_bboxes() -> None:
         [({"image": image}, deepcopy(labels)) for _ in range(8)]
     )
 
-    # The bbox task itself is dropped, as it always has been; the loader
-    # refills it with a correctly shaped empty array. The labels hanging off
-    # it are the ones that must not disappear.
-    assert "task/boundingbox" not in output
+    # The whole group is reported empty, the bbox task included. Emitting
+    # the associated labels while omitting their boxes would leave a sample
+    # whose keys collating code cannot line up with the rest of the batch.
+    assert output["task/boundingbox"].shape == (0, 5)
     assert output["task/instance_segmentation"].shape == (0, 64, 64)
     assert output["task/keypoints"].shape == (0, 3)
     assert output["task/array"].shape == (0, 2)
     assert output["task/metadata/id"].shape == (0,)
+
+    for task, array in output.items():
+        assert array.dtype == labels[task].dtype, (
+            f"'{task}' came back as {array.dtype}, not {labels[task].dtype}"
+        )
 
 
 def test_instance_masks_without_bboxes_in_their_task_group() -> None:
@@ -703,6 +740,137 @@ def test_mixup_pads_empty_targets_to_the_sibling_width(target: str) -> None:
     output = apply_to_target(batch, image_shapes=[(16, 16), (16, 16)])
 
     assert output.shape == (2, 6)
+
+
+@pytest.mark.parametrize("target", ["keypoints", "bboxes"])
+def test_mosaic_pads_empty_targets_to_the_sibling_width(target: str) -> None:
+    """Emptied targets must keep the column count of their sibling.
+
+    The width depends on which optional fields the pipeline uses, so a
+    hardcoded placeholder fails to concatenate with the populated samples.
+    """
+    mosaic = Mosaic4(height=16, width=16, p=1.0)
+    batch = [np.ones((2, 5)), *(np.zeros((0, 5)) for _ in range(3))]
+    apply_to_target = getattr(mosaic, f"apply_to_{target}")
+
+    output = apply_to_target(
+        batch, image_shapes=[(16, 16)] * 4, x_crop=0, y_crop=0
+    )
+
+    assert output.shape == (2, 5)
+
+
+def test_partially_annotated_batches_stay_aligned() -> None:
+    """Only some samples in a batch carry the instance masks.
+
+    A batch transform concatenates only the samples that have them, so the
+    merged masks used to come back short and the ordering ran off the end of
+    the array.
+    """
+    targets = {
+        "task/boundingbox": "boundingbox",
+        "task/instance_segmentation": "instance_segmentation",
+    }
+    boxes = np.array(
+        [[0.0, 0.12, 0.12, 0.14, 0.14], [0.0, 0.62, 0.62, 0.14, 0.14]]
+    )
+    masks = np.zeros((2, 64, 64), dtype=np.uint8)
+    masks[0, 9:17, 9:17] = 1
+    masks[1, 41:49, 41:49] = 2
+
+    augmentations = AlbumentationsEngine(
+        64,
+        64,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        [{"name": "MixUp", "params": {"p": 1.0}}],
+        seed=0,
+    )
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+
+    _, output = augmentations.apply(
+        [
+            (
+                {"image": image},
+                {
+                    "task/boundingbox": boxes.copy(),
+                    "task/instance_segmentation": masks.copy(),
+                },
+            ),
+            ({"image": image}, {"task/boundingbox": boxes.copy()}),
+        ]
+    )
+
+    out_boxes = output["task/boundingbox"]
+    out_masks = output["task/instance_segmentation"]
+    assert out_boxes.shape[0] == out_masks.shape[0] == 4
+
+    # The two annotated instances keep their own masks; the two that were
+    # never annotated get an empty one rather than someone else's.
+    annotated = [i for i, mask in enumerate(out_masks) if mask.any()]
+    assert len(annotated) == 2
+    assert_boxes_match_masks(out_boxes[annotated], out_masks[annotated])
+
+
+def test_tasks_only_a_discarded_sample_had_are_not_reported() -> None:
+    """A batch transform that does not fire throws the other samples away.
+
+    A task none of the surviving samples was annotated for is not part of
+    the output at all, empty or otherwise.
+    """
+    targets = {
+        "task/boundingbox": "boundingbox",
+        "task/metadata/id": "metadata",
+    }
+    augmentations = AlbumentationsEngine(
+        16,
+        16,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        [{"name": "MixUp", "params": {"p": 0.0}}],
+    )
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+
+    _, output = augmentations.apply(
+        [
+            ({"image": image}, {}),
+            (
+                {"image": image},
+                {
+                    "task/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]]),
+                    "task/metadata/id": np.array([5.0]),
+                },
+            ),
+        ]
+    )
+
+    assert "task/metadata/id" not in output
+
+
+def test_unnamed_tasks_of_different_types_do_not_share_a_group() -> None:
+    """``boundingbox`` and ``keypoints`` name types, not a common group.
+
+    Grouping them ties the keypoints to boxes they have nothing to do with,
+    and the keypoints are then reordered by, or cut down to, those boxes.
+    """
+    targets = {"boundingbox": "boundingbox", "keypoints": "keypoints"}
+    augmentations = AlbumentationsEngine(
+        32, 32, targets, dict.fromkeys(targets, 1), ["image"], []
+    )
+    labels: Labels = {
+        "boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]]),
+        "keypoints": np.array(
+            [[0.2, 0.2, 2.0], [0.5, 0.5, 2.0], [0.7, 0.7, 2.0]]
+        ),
+    }
+
+    _, output = augmentations.apply(
+        [({"image": np.zeros((32, 32, 3), dtype=np.uint8)}, labels)]
+    )
+
+    assert output["keypoints"].shape == (3, 3)
 
 
 def test_multiple_bbox_targets_in_one_task_group_are_rejected() -> None:

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -12,8 +12,9 @@ import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
+from luxonis_ml.data.augmentations import AugmentationEngine
 from luxonis_ml.data.augmentations.custom import TRANSFORMATIONS
-from luxonis_ml.typing import Labels
+from luxonis_ml.typing import Labels, LoaderMultiOutput
 
 
 @pytest.fixture
@@ -45,6 +46,26 @@ def build(
         config,
         **kwargs,
     )
+
+
+def test_engines_default_to_using_every_input_position() -> None:
+    """An engine that does not track contributors is assumed to use all of them."""
+
+    class UntrackedEngine(
+        AugmentationEngine, register_name="untracked_engine"
+    ):
+        def __init__(self, *_, **__) -> None: ...
+
+        def apply(
+            self, input_batch: list[LoaderMultiOutput]
+        ) -> LoaderMultiOutput:
+            return input_batch[0]
+
+        @property
+        def batch_size(self) -> int:
+            return 4
+
+    assert UntrackedEngine().batch_augmentation_indices == [0, 1, 2, 3]
 
 
 def test_unsupported_task_type_is_rejected() -> None:

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -45,7 +45,6 @@ def build(
 
 
 def test_engines_default_to_using_every_input_position() -> None:
-    """An engine that does not track contributors is assumed to use all."""
 
     class UntrackedEngine(
         AugmentationEngine, register_name="untracked_engine"

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -1,0 +1,298 @@
+"""Tests for how `AlbumentationsEngine` validates its configuration.
+
+Covers the rejections the constructor documents, the way transforms are
+sorted into pipeline stages, and the multi-source pixel-transform replay.
+"""
+
+from collections.abc import Iterator
+from typing import Any
+
+import albumentations as A
+import numpy as np
+import pytest
+
+from luxonis_ml.data import AlbumentationsEngine
+from luxonis_ml.data.augmentations.custom import TRANSFORMATIONS
+from luxonis_ml.typing import Labels
+
+
+@pytest.fixture
+def register_transform() -> Iterator[Any]:
+    """Register transforms for one test and drop them again afterwards."""
+    registered: list[str] = []
+
+    def _register(cls: type) -> type:
+        name = cls.__name__
+        TRANSFORMATIONS[name] = cls  # type: ignore[assignment]
+        registered.append(name)
+        return cls
+
+    yield _register
+
+    for name in registered:
+        TRANSFORMATIONS._module_dict.pop(name, None)
+
+
+def build(
+    targets: dict[str, str], config: list[dict], **kwargs
+) -> AlbumentationsEngine:
+    return AlbumentationsEngine(
+        32,
+        32,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        config,
+        **kwargs,
+    )
+
+
+def test_unsupported_task_type_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported task type: 'depth'"):
+        build({"task/depth": "depth"}, [])
+
+
+def test_only_one_resizing_augmentation_is_allowed() -> None:
+    config = [
+        {
+            "name": "Resize",
+            "params": {"height": 32, "width": 32},
+            "use_for_resizing": True,
+        },
+        {
+            "name": "LetterboxResize",
+            "params": {"height": 32, "width": 32},
+            "use_for_resizing": True,
+        },
+    ]
+
+    with pytest.raises(
+        ValueError, match="Only one resizing augmentation can be provided"
+    ):
+        build({"task/boundingbox": "boundingbox"}, config)
+
+
+@pytest.mark.parametrize("probability", ["1.0", True])
+def test_resizing_probability_must_be_numeric(probability: object) -> None:
+    """Values Albumentations coerces but the resize logic cannot use.
+
+    ``p=None`` never reaches this check: Albumentations rejects it while the
+    transform is being constructed.
+    """
+    config = [
+        {
+            "name": "Resize",
+            "params": {"height": 32, "width": 32, "p": probability},
+            "use_for_resizing": True,
+        }
+    ]
+
+    with pytest.raises(TypeError, match="has invalid p="):
+        build({"task/boundingbox": "boundingbox"}, config)
+
+
+def test_certain_resize_is_used_directly() -> None:
+    """``p >= 1`` needs no ``OneOf`` wrapper around the default resize."""
+    config = [
+        {
+            "name": "Resize",
+            "params": {"height": 32, "width": 32, "p": 1.0},
+            "use_for_resizing": True,
+        }
+    ]
+
+    engine = build({"task/boundingbox": "boundingbox"}, config)
+
+    _, out_labels = engine.apply(
+        [
+            (
+                {"image": np.zeros((64, 64, 3), dtype=np.uint8)},
+                {"task/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]])},
+            )
+        ]
+    )
+    assert out_labels["task/boundingbox"].shape == (1, 5)
+
+
+def test_plain_basic_transforms_run_as_custom_transforms(
+    register_transform: Any,
+) -> None:
+    """A bare ``BasicTransform`` is neither pixel, spatial, nor batch."""
+    seen: list[int] = []
+
+    @register_transform
+    class CountingBasicTransform(A.BasicTransform):
+        @property
+        def targets(self) -> dict:
+            return {"image": self.apply}
+
+        def apply(self, img: np.ndarray, **_) -> np.ndarray:
+            seen.append(1)
+            return img
+
+    assert CountingBasicTransform.__name__ in TRANSFORMATIONS
+    engine = build(
+        {"task/boundingbox": "boundingbox"},
+        [{"name": "CountingBasicTransform", "params": {"p": 1.0}}],
+    )
+    engine.apply(
+        [
+            (
+                {"image": np.zeros((32, 32, 3), dtype=np.uint8)},
+                {"task/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]])},
+            )
+        ]
+    )
+
+    assert seen, "the custom transform stage never ran"
+
+
+def test_non_transform_classes_are_rejected(register_transform: Any) -> None:
+    @register_transform
+    class NotATransform:
+        def __init__(self, **_): ...
+
+    assert NotATransform.__name__ in TRANSFORMATIONS
+    with pytest.raises(
+        ValueError, match="Unsupported transformation type: 'NotATransform'"
+    ):
+        build(
+            {"task/boundingbox": "boundingbox"},
+            [{"name": "NotATransform", "params": {}}],
+        )
+
+
+def test_nested_transform_entries_must_name_a_transform() -> None:
+    config = [
+        {
+            "name": "OneOf",
+            "params": {"transforms": [{"params": {"p": 1.0}}], "p": 1.0},
+        }
+    ]
+
+    with pytest.raises(
+        ValueError, match="Invalid nested transform configuration"
+    ):
+        build({"task/boundingbox": "boundingbox"}, config)
+
+
+def test_tasks_without_a_task_name_share_the_root_group() -> None:
+    """``"classification"`` names a type, not a group, so the group is empty."""
+    assert AlbumentationsEngine._get_task_group("classification") == ""
+    assert AlbumentationsEngine._get_task_group("metadata/id") == ""
+    assert AlbumentationsEngine._get_task_group("group/boundingbox") == "group"
+    assert AlbumentationsEngine._get_task_group("a/b/keypoints") == "a/b"
+
+
+def test_unnamed_tasks_are_usable_end_to_end() -> None:
+    engine = build({"classification": "classification"}, [])
+
+    _, out_labels = engine.apply(
+        [
+            (
+                {"image": np.zeros((32, 32, 3), dtype=np.uint8)},
+                {"classification": np.array([1.0])},
+            )
+        ]
+    )
+
+    assert out_labels["classification"].tolist() == [1.0]
+
+
+def test_pixel_transforms_replay_across_every_image_source() -> None:
+    """One sampled pixel transform must hit all sources identically."""
+    sources = ["rgb", "depth", "ir"]
+    engine = AlbumentationsEngine(
+        32,
+        32,
+        {"task/boundingbox": "boundingbox"},
+        {"task/boundingbox": 1},
+        sources,
+        [{"name": "InvertImg", "params": {"p": 1.0}}],
+    )
+    images = {name: np.zeros((32, 32, 3), dtype=np.uint8) for name in sources}
+    labels: Labels = {
+        "task/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]])
+    }
+
+    out_images, _ = engine.apply([(images, labels)])
+
+    assert set(out_images) == set(sources)
+    for name in sources:
+        assert np.all(out_images[name] == 255), (
+            f"source '{name}' did not receive the pixel transform"
+        )
+
+
+def test_pixel_replay_skips_sources_without_a_channel_axis() -> None:
+    """A 2D source cannot be replayed through an RGB pixel transform."""
+    engine = AlbumentationsEngine(
+        16,
+        16,
+        {"task/boundingbox": "boundingbox"},
+        {"task/boundingbox": 1},
+        ["rgb", "flat"],
+        [{"name": "InvertImg", "params": {"p": 1.0}}],
+    )
+    images = {
+        "rgb": np.zeros((16, 16, 3), dtype=np.uint8),
+        "flat": np.zeros((16, 16), dtype=np.uint8),
+    }
+
+    out_images, _ = engine.apply(
+        [
+            (
+                images,
+                {"task/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]])},
+            )
+        ]
+    )
+
+    assert np.all(out_images["rgb"] == 255)
+    assert np.all(out_images["flat"] == 0), (
+        "a source with no channel axis must be left alone, not corrupted"
+    )
+
+
+def test_wrapped_transforms_tolerate_a_missing_image_key() -> None:
+    """The wrapper only restores the original key when there was one."""
+    wrapped = AlbumentationsEngine._wrap_transform(
+        A.Compose([A.HorizontalFlip(p=1.0)])
+    )
+
+    out = wrapped(image=np.zeros((8, 8, 3), dtype=np.uint8))
+
+    assert "_original_image_key" not in out
+
+
+def test_pixel_transform_wrapper_needs_source_names() -> None:
+    wrapped = AlbumentationsEngine._wrap_transform(
+        A.Compose([A.InvertImg(p=1.0)]), is_pixel=True, source_names=None
+    )
+
+    with pytest.raises(ValueError, match="`source_names` must be provided"):
+        wrapped(image=np.zeros((8, 8, 3), dtype=np.uint8))
+
+
+def test_grayscale_sources_keep_a_channel_axis() -> None:
+    """A 2D image coming out of a transform is restored to (H, W, 1)."""
+    engine = AlbumentationsEngine(
+        16,
+        16,
+        {"task/boundingbox": "boundingbox"},
+        {"task/boundingbox": 1},
+        ["image"],
+        [{"name": "ToGray", "params": {"p": 1.0, "num_output_channels": 1}}],
+    )
+
+    out_images, _ = engine.apply(
+        [
+            (
+                {"image": np.zeros((16, 16, 3), dtype=np.uint8)},
+                {"task/boundingbox": np.array([[0.0, 0.1, 0.1, 0.2, 0.2]])},
+            )
+        ]
+    )
+
+    assert out_images["image"].ndim == 3
+    assert out_images["image"].shape[-1] == 1

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -192,17 +192,29 @@ def test_nested_transform_entries_must_name_a_transform() -> None:
         build({"task/boundingbox": "boundingbox"}, config)
 
 
-def test_each_unnamed_task_is_its_own_group() -> None:
-    """A task with no name is not in a group with every other such task.
+def test_a_task_with_no_separator_is_its_own_group() -> None:
+    """A task with no name at all has nothing to group by.
 
-    Collapsing them all to ``""`` would tie an unnamed keypoints task to an
-    unnamed bbox task it has nothing to do with.
+    Collapsing these to ``""`` would tie a bare keypoints task to a bare
+    bbox task it has nothing to do with.
     """
     assert AlbumentationsEngine._get_task_group("boundingbox") == "boundingbox"
     assert AlbumentationsEngine._get_task_group("keypoints") == "keypoints"
     assert AlbumentationsEngine._get_task_group("metadata/id") == "metadata/id"
     assert AlbumentationsEngine._get_task_group("group/boundingbox") == "group"
     assert AlbumentationsEngine._get_task_group("a/b/keypoints") == "a/b"
+
+
+def test_default_task_types_share_one_group() -> None:
+    """The leading ``"/"`` marks LDF's default task, whose name is empty.
+
+    ``"/boundingbox"`` and ``"/keypoints"`` describe the same annotations,
+    so they have to land in the same group for the keypoints to be filtered
+    and reordered along with the boxes.
+    """
+    assert AlbumentationsEngine._get_task_group("/boundingbox") == ""
+    assert AlbumentationsEngine._get_task_group("/keypoints") == ""
+    assert AlbumentationsEngine._get_task_group("/metadata/id") == ""
 
 
 def test_unnamed_tasks_are_usable_end_to_end() -> None:

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -1,11 +1,4 @@
-"""Tests for how `AlbumentationsEngine` validates its configuration.
-
-Covers the rejections the constructor documents, the way transforms are
-sorted into pipeline stages, and the multi-source pixel-transform replay.
-"""
-
-from collections.abc import Iterator
-from typing import Any
+from collections.abc import Callable, Iterator
 
 import albumentations as A
 import numpy as np
@@ -16,9 +9,11 @@ from luxonis_ml.data.augmentations import AugmentationEngine
 from luxonis_ml.data.augmentations.custom import TRANSFORMATIONS
 from luxonis_ml.typing import Labels, LoaderMultiOutput
 
+Register = Callable[[type], type]
+
 
 @pytest.fixture
-def register_transform() -> Iterator[Any]:
+def register_transform() -> Iterator[Register]:
     """Register transforms for one test and drop them again afterwards."""
     registered: list[str] = []
 
@@ -31,6 +26,7 @@ def register_transform() -> Iterator[Any]:
     yield _register
 
     for name in registered:
+        # `Registry` has no public way to drop an entry again.
         TRANSFORMATIONS._module_dict.pop(name, None)
 
 
@@ -49,7 +45,7 @@ def build(
 
 
 def test_engines_default_to_using_every_input_position() -> None:
-    """An engine that does not track contributors is assumed to use all of them."""
+    """An engine that does not track contributors is assumed to use all."""
 
     class UntrackedEngine(
         AugmentationEngine, register_name="untracked_engine"
@@ -95,10 +91,9 @@ def test_only_one_resizing_augmentation_is_allowed() -> None:
 
 @pytest.mark.parametrize("probability", ["1.0", True])
 def test_resizing_probability_must_be_numeric(probability: object) -> None:
-    """Values Albumentations coerces but the resize logic cannot use.
+    """``p=None`` never reaches this check.
 
-    ``p=None`` never reaches this check: Albumentations rejects it while the
-    transform is being constructed.
+    Albumentations rejects it while the transform is being constructed.
     """
     config = [
         {
@@ -136,7 +131,7 @@ def test_certain_resize_is_used_directly() -> None:
 
 
 def test_plain_basic_transforms_run_as_custom_transforms(
-    register_transform: Any,
+    register_transform: Register,
 ) -> None:
     """A bare ``BasicTransform`` is neither pixel, spatial, nor batch."""
     seen: list[int] = []
@@ -151,10 +146,9 @@ def test_plain_basic_transforms_run_as_custom_transforms(
             seen.append(1)
             return img
 
-    assert CountingBasicTransform.__name__ in TRANSFORMATIONS
     engine = build(
         {"task/boundingbox": "boundingbox"},
-        [{"name": "CountingBasicTransform", "params": {"p": 1.0}}],
+        [{"name": CountingBasicTransform.__name__, "params": {"p": 1.0}}],
     )
     engine.apply(
         [
@@ -168,18 +162,19 @@ def test_plain_basic_transforms_run_as_custom_transforms(
     assert seen, "the custom transform stage never ran"
 
 
-def test_non_transform_classes_are_rejected(register_transform: Any) -> None:
+def test_non_transform_classes_are_rejected(
+    register_transform: Register,
+) -> None:
     @register_transform
     class NotATransform:
         def __init__(self, **_): ...
 
-    assert NotATransform.__name__ in TRANSFORMATIONS
     with pytest.raises(
         ValueError, match="Unsupported transformation type: 'NotATransform'"
     ):
         build(
             {"task/boundingbox": "boundingbox"},
-            [{"name": "NotATransform", "params": {}}],
+            [{"name": NotATransform.__name__, "params": {}}],
         )
 
 
@@ -221,7 +216,6 @@ def test_unnamed_tasks_are_usable_end_to_end() -> None:
 
 
 def test_pixel_transforms_replay_across_every_image_source() -> None:
-    """One sampled pixel transform must hit all sources identically."""
     sources = ["rgb", "depth", "ir"]
     engine = AlbumentationsEngine(
         32,
@@ -246,7 +240,6 @@ def test_pixel_transforms_replay_across_every_image_source() -> None:
 
 
 def test_pixel_replay_skips_sources_without_a_channel_axis() -> None:
-    """A 2D source cannot be replayed through an RGB pixel transform."""
     engine = AlbumentationsEngine(
         16,
         16,
@@ -276,7 +269,6 @@ def test_pixel_replay_skips_sources_without_a_channel_axis() -> None:
 
 
 def test_wrapped_transforms_tolerate_a_missing_image_key() -> None:
-    """The wrapper only restores the original key when there was one."""
     wrapped = AlbumentationsEngine._wrap_transform(
         A.Compose([A.HorizontalFlip(p=1.0)])
     )
@@ -296,7 +288,6 @@ def test_pixel_transform_wrapper_needs_source_names() -> None:
 
 
 def test_grayscale_sources_keep_a_channel_axis() -> None:
-    """A 2D image coming out of a transform is restored to (H, W, 1)."""
     engine = AlbumentationsEngine(
         16,
         16,

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -192,10 +192,15 @@ def test_nested_transform_entries_must_name_a_transform() -> None:
         build({"task/boundingbox": "boundingbox"}, config)
 
 
-def test_tasks_without_a_task_name_share_the_root_group() -> None:
-    """``"classification"`` names a type, not a group, so the group is empty."""
-    assert AlbumentationsEngine._get_task_group("classification") == ""
-    assert AlbumentationsEngine._get_task_group("metadata/id") == ""
+def test_each_unnamed_task_is_its_own_group() -> None:
+    """A task with no name is not in a group with every other such task.
+
+    Collapsing them all to ``""`` would tie an unnamed keypoints task to an
+    unnamed bbox task it has nothing to do with.
+    """
+    assert AlbumentationsEngine._get_task_group("boundingbox") == "boundingbox"
+    assert AlbumentationsEngine._get_task_group("keypoints") == "keypoints"
+    assert AlbumentationsEngine._get_task_group("metadata/id") == "metadata/id"
     assert AlbumentationsEngine._get_task_group("group/boundingbox") == "group"
     assert AlbumentationsEngine._get_task_group("a/b/keypoints") == "a/b"
 

--- a/tests/test_data/test_augmentations/test_label_combinations.py
+++ b/tests/test_data/test_augmentations/test_label_combinations.py
@@ -1,0 +1,211 @@
+"""Property tests over every advertised label type and combination.
+
+`AlbumentationsEngine` documents support for seven label types across any
+number of task groups and image sources. These tests generate combinations of
+them and check the invariants that hold no matter which combination came up,
+rather than pinning one hand-written example per feature.
+
+Runs are derandomized so a failure is reproducible from the test id alone.
+"""
+
+from copy import deepcopy
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from luxonis_ml.data import AlbumentationsEngine
+from luxonis_ml.typing import Labels
+
+from .label_strategies import (
+    ALL_TASK_TYPES,
+    PER_INSTANCE_TASK_TYPES,
+    SampleSpec,
+    TaskGroupSpec,
+    build_labels,
+    sample_specs,
+)
+
+combination_settings = settings(
+    max_examples=150,
+    deadline=None,
+    derandomize=True,
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
+)
+
+
+def run(spec: SampleSpec) -> tuple[dict[str, np.ndarray], Labels]:
+    """Build an engine from ``spec`` and push a full batch through it."""
+    engine = AlbumentationsEngine(
+        spec.height,
+        spec.width,
+        spec.targets,
+        spec.n_classes,
+        spec.source_names,
+        spec.config,
+        seed=42,
+    )
+    labels: Labels = {}
+    for group in spec.groups:
+        labels.update(build_labels(group, spec.image_height, spec.image_width))
+    images = spec.images()
+    batch = [(images, deepcopy(labels)) for _ in range(engine.batch_size)]
+    return engine.apply(batch)
+
+
+def assert_group_is_consistent(
+    group: TaskGroupSpec, out_labels: Labels
+) -> None:
+    """Every per-instance label in a group must describe the same instances."""
+    counts = {}
+    for task_type in group.task_types:
+        if task_type not in PER_INSTANCE_TASK_TYPES:
+            continue
+        task = group.task(task_type)
+        if task not in out_labels:
+            continue
+        array = out_labels[task]
+        if task_type == "keypoints":
+            assert array.ndim == 2, f"{task} should be (N, 3K)"
+            assert array.shape[1] == group.n_keypoints * 3, (
+                f"{task} lost keypoints: {array.shape}"
+            )
+        counts[task_type] = array.shape[0]
+
+    if len(set(counts.values())) > 1:
+        pytest.fail(
+            f"task group '{group.name}' returned mismatched instance "
+            f"counts: {counts}"
+        )
+
+
+@given(spec=sample_specs())
+@combination_settings
+def test_any_label_combination_round_trips(spec: SampleSpec) -> None:
+    """Any combination of advertised labels survives any advertised pipeline."""
+    out_images, out_labels = run(spec)
+
+    assert set(out_images) == set(spec.source_names), (
+        "every image source must come back out"
+    )
+    for name, image in out_images.items():
+        assert image.shape[:2] == (spec.height, spec.width), (
+            f"source '{name}' was not resized to the requested output size"
+        )
+        assert image.shape[2] == spec.source_channels[name], (
+            f"source '{name}' changed channel count"
+        )
+
+    for group in spec.groups:
+        assert_group_is_consistent(group, out_labels)
+
+        if "segmentation" in group.task_types:
+            mask = out_labels[group.task("segmentation")]
+            assert mask.shape == (
+                group.n_classes,
+                spec.height,
+                spec.width,
+            ), "semantic mask must keep one channel per class"
+
+        if "classification" in group.task_types:
+            classes = out_labels[group.task("classification")]
+            assert classes.shape == (group.n_classes,)
+
+
+@given(spec=sample_specs())
+@combination_settings
+def test_instances_never_outnumber_their_bboxes(spec: SampleSpec) -> None:
+    """Per-instance labels are capped by the boxes that survived."""
+    _, out_labels = run(spec)
+
+    for group in spec.groups:
+        if "boundingbox" not in group.task_types:
+            continue
+        boxes = out_labels.get(group.task("boundingbox"))
+        if boxes is None:
+            continue
+        assert boxes.shape[0] <= group.n_instances * 8, (
+            "a batch transform must not invent instances beyond the batch"
+        )
+        for task_type in PER_INSTANCE_TASK_TYPES:
+            if task_type not in group.task_types:
+                continue
+            array = out_labels.get(group.task(task_type))
+            if array is None:
+                continue
+            assert array.shape[0] == boxes.shape[0], (
+                f"'{group.task(task_type)}' has {array.shape[0]} rows for "
+                f"{boxes.shape[0]} boxes"
+            )
+
+
+@given(
+    task_type=st.sampled_from(ALL_TASK_TYPES),
+    config_index=st.integers(min_value=0, max_value=7),
+)
+@combination_settings
+def test_every_label_type_works_on_its_own(
+    task_type: str, config_index: int
+) -> None:
+    """Each advertised label type is usable as the only label in a dataset."""
+    from .label_strategies import BATCH_CONFIGS
+
+    spec = SampleSpec(
+        groups=[
+            TaskGroupSpec(
+                name="solo",
+                task_types=[task_type],
+                n_instances=2,
+                n_classes=2,
+                n_keypoints=2,
+            )
+        ],
+        source_channels={"image": 3},
+        height=64,
+        width=64,
+        image_height=64,
+        image_width=64,
+        config=BATCH_CONFIGS[config_index],
+    )
+
+    _, out_labels = run(spec)
+
+    task = spec.groups[0].task(task_type)
+    assert task in out_labels, (
+        f"'{task}' disappeared from the output; a task present in the input "
+        f"must always be reported, even when empty"
+    )
+
+
+@given(spec=sample_specs(max_groups=3))
+@combination_settings
+def test_task_groups_do_not_interfere(spec: SampleSpec) -> None:
+    """Adding a task group must not change what the other groups return."""
+    if len(spec.groups) < 2:
+        return
+
+    _, combined = run(spec)
+
+    for group in spec.groups:
+        isolated_spec = SampleSpec(
+            groups=[group],
+            source_channels=spec.source_channels,
+            height=spec.height,
+            width=spec.width,
+            image_height=spec.image_height,
+            image_width=spec.image_width,
+            config=spec.config,
+        )
+        _, isolated = run(isolated_spec)
+
+        for task in group.tasks:
+            assert (task in combined) == (task in isolated), (
+                f"'{task}' is reported differently depending on whether "
+                f"other task groups are present"
+            )
+            if task in combined:
+                assert combined[task].shape == isolated[task].shape, (
+                    f"'{task}' has shape {combined[task].shape} alongside "
+                    f"other groups but {isolated[task].shape} on its own"
+                )

--- a/tests/test_data/test_augmentations/test_label_combinations.py
+++ b/tests/test_data/test_augmentations/test_label_combinations.py
@@ -28,7 +28,6 @@ combination_settings = settings(
 
 
 def run(spec: SampleSpec) -> tuple[dict[str, np.ndarray], Labels]:
-    """Build an engine from ``spec`` and push a full batch through it."""
     engine = AlbumentationsEngine(
         spec.height,
         spec.width,
@@ -101,7 +100,6 @@ def test_any_label_combination_round_trips(spec: SampleSpec) -> None:
 @given(spec=sample_specs())
 @combination_settings
 def test_instances_never_outnumber_their_bboxes(spec: SampleSpec) -> None:
-    """Per-instance labels are capped by the boxes that survived."""
     _, out_labels = run(spec)
 
     for group in spec.groups:
@@ -130,7 +128,6 @@ def test_instances_never_outnumber_their_bboxes(spec: SampleSpec) -> None:
 def test_every_label_type_works_on_its_own(
     task_type: str, config: list[dict]
 ) -> None:
-    """Each advertised label type is usable as the only label in a dataset."""
     spec = SampleSpec(
         groups=[
             TaskGroupSpec(
@@ -161,7 +158,6 @@ def test_every_label_type_works_on_its_own(
 @given(spec=sample_specs(min_groups=2, max_groups=3))
 @combination_settings
 def test_task_groups_do_not_interfere(spec: SampleSpec) -> None:
-    """Adding a task group must not change what the other groups return."""
     _, combined = run(spec)
 
     for group in spec.groups:

--- a/tests/test_data/test_augmentations/test_label_combinations.py
+++ b/tests/test_data/test_augmentations/test_label_combinations.py
@@ -1,13 +1,3 @@
-"""Property tests over every advertised label type and combination.
-
-`AlbumentationsEngine` documents support for seven label types across any
-number of task groups and image sources. These tests generate combinations of
-them and check the invariants that hold no matter which combination came up,
-rather than pinning one hand-written example per feature.
-
-Runs are derandomized so a failure is reproducible from the test id alone.
-"""
-
 from copy import deepcopy
 
 import numpy as np
@@ -20,6 +10,7 @@ from luxonis_ml.typing import Labels
 
 from .label_strategies import (
     ALL_TASK_TYPES,
+    BATCH_CONFIGS,
     PER_INSTANCE_TASK_TYPES,
     SampleSpec,
     TaskGroupSpec,
@@ -27,6 +18,7 @@ from .label_strategies import (
     sample_specs,
 )
 
+# Derandomized so that a failure is reproducible from the test id alone.
 combination_settings = settings(
     max_examples=150,
     deadline=None,
@@ -83,12 +75,9 @@ def assert_group_is_consistent(
 @given(spec=sample_specs())
 @combination_settings
 def test_any_label_combination_round_trips(spec: SampleSpec) -> None:
-    """Any combination of advertised labels survives any advertised pipeline."""
     out_images, out_labels = run(spec)
 
-    assert set(out_images) == set(spec.source_names), (
-        "every image source must come back out"
-    )
+    assert set(out_images) == set(spec.source_names)
     for name, image in out_images.items():
         assert image.shape[:2] == (spec.height, spec.width), (
             f"source '{name}' was not resized to the requested output size"
@@ -102,11 +91,7 @@ def test_any_label_combination_round_trips(spec: SampleSpec) -> None:
 
         if "segmentation" in group.task_types:
             mask = out_labels[group.task("segmentation")]
-            assert mask.shape == (
-                group.n_classes,
-                spec.height,
-                spec.width,
-            ), "semantic mask must keep one channel per class"
+            assert mask.shape == (group.n_classes, spec.height, spec.width)
 
         if "classification" in group.task_types:
             classes = out_labels[group.task("classification")]
@@ -125,9 +110,6 @@ def test_instances_never_outnumber_their_bboxes(spec: SampleSpec) -> None:
         boxes = out_labels.get(group.task("boundingbox"))
         if boxes is None:
             continue
-        assert boxes.shape[0] <= group.n_instances * 8, (
-            "a batch transform must not invent instances beyond the batch"
-        )
         for task_type in PER_INSTANCE_TASK_TYPES:
             if task_type not in group.task_types:
                 continue
@@ -142,15 +124,13 @@ def test_instances_never_outnumber_their_bboxes(spec: SampleSpec) -> None:
 
 @given(
     task_type=st.sampled_from(ALL_TASK_TYPES),
-    config_index=st.integers(min_value=0, max_value=7),
+    config=st.sampled_from(BATCH_CONFIGS),
 )
 @combination_settings
 def test_every_label_type_works_on_its_own(
-    task_type: str, config_index: int
+    task_type: str, config: list[dict]
 ) -> None:
     """Each advertised label type is usable as the only label in a dataset."""
-    from .label_strategies import BATCH_CONFIGS
-
     spec = SampleSpec(
         groups=[
             TaskGroupSpec(
@@ -166,7 +146,7 @@ def test_every_label_type_works_on_its_own(
         width=64,
         image_height=64,
         image_width=64,
-        config=BATCH_CONFIGS[config_index],
+        config=config,
     )
 
     _, out_labels = run(spec)
@@ -178,13 +158,10 @@ def test_every_label_type_works_on_its_own(
     )
 
 
-@given(spec=sample_specs(max_groups=3))
+@given(spec=sample_specs(min_groups=2, max_groups=3))
 @combination_settings
 def test_task_groups_do_not_interfere(spec: SampleSpec) -> None:
     """Adding a task group must not change what the other groups return."""
-    if len(spec.groups) < 2:
-        return
-
     _, combined = run(spec)
 
     for group in spec.groups:

--- a/tests/test_data/test_augmentations/test_mixup.py
+++ b/tests/test_data/test_augmentations/test_mixup.py
@@ -52,6 +52,45 @@ def test_mixup(
         )
 
 
+@pytest.mark.parametrize(
+    ("batch", "expected"),
+    [
+        # A bare `np.array([])` has no width of its own and takes the
+        # populated sample's.
+        ([np.array([]), np.zeros((2, 7), np.float32)], (2, 7)),
+        # With nothing populated the width still has to come from the empty
+        # rows, not from the fallback.
+        (
+            [np.zeros((0, 7), np.float32), np.zeros((0, 7), np.float32)],
+            (0, 7),
+        ),
+    ],
+)
+def test_mixup_pads_empty_samples_to_the_batch_width(
+    batch: list[np.ndarray],
+    expected: tuple[int, int],
+    subtests: SubTests,
+) -> None:
+    """A sample with no boxes must not narrow the merged array."""
+    mixup = MixUp(p=1.0)
+    shapes = [(16, 16), (16, 16)]
+
+    with subtests.test("bboxes"):
+        assert mixup.apply_to_bboxes(list(batch), shapes).shape == expected
+
+    with subtests.test("keypoints"):
+        assert mixup.apply_to_keypoints(list(batch), shapes).shape == expected
+
+
+def test_mixup_leaves_the_callers_batch_alone() -> None:
+    mixup = MixUp(p=1.0)
+    batch = [np.array([]), np.zeros((2, 7), dtype=np.float32)]
+
+    mixup.apply_to_bboxes(list(batch), [(16, 16), (16, 16)])
+
+    assert batch[0].shape == (0,)
+
+
 def test_invalid():
     with pytest.raises(ValueError, match="must be in range"):
         MixUp(alpha=(-1, 1))

--- a/tests/test_data/test_augmentations/test_mosaic.py
+++ b/tests/test_data/test_augmentations/test_mosaic.py
@@ -76,6 +76,43 @@ def test_mosaic4():
     assert m["image"].shape == (HEIGHT, WIDTH, 3)
 
 
+@pytest.mark.parametrize(
+    ("batch", "expected"),
+    [
+        # Bare `np.array([])` entries have no width of their own and take
+        # the populated sample's.
+        (
+            [
+                np.array([]),
+                np.zeros((2, 7), np.float32),
+                np.array([]),
+                np.array([]),
+            ],
+            (2, 7),
+        ),
+        # With nothing populated the width still has to come from the empty
+        # rows, not from the fallback.
+        ([np.zeros((0, 7), np.float32)] * 4, (0, 7)),
+    ],
+)
+def test_mosaic4_pads_empty_samples_to_the_batch_width(
+    batch: list[np.ndarray],
+    expected: tuple[int, int],
+    subtests: SubTests,
+) -> None:
+    """Samples with no boxes must not narrow the merged array."""
+    mosaic = Mosaic4(out_height=HEIGHT, out_width=WIDTH, p=1.0)
+    shapes = [(HEIGHT // 2, WIDTH // 2)] * 4
+
+    with subtests.test("bboxes"):
+        merged = mosaic.apply_to_bboxes(batch, shapes, x_crop=0, y_crop=0)
+        assert merged.shape == expected
+
+    with subtests.test("keypoints"):
+        merged = mosaic.apply_to_keypoints(batch, shapes, x_crop=0, y_crop=0)
+        assert merged.shape == expected
+
+
 def test_invalid():
     with pytest.raises(ValueError, match="`height` must be larger"):
         Mosaic4(out_height=0, out_width=WIDTH)

--- a/tests/test_data/test_augmentations/test_transform_internals.py
+++ b/tests/test_data/test_augmentations/test_transform_internals.py
@@ -38,7 +38,6 @@ def test_mixup_can_resize_without_keeping_aspect_ratio() -> None:
 def test_mixup_semantic_mask_tolerates_a_missing_mask(
     empty_index: int,
 ) -> None:
-    """A sample without a segmentation task contributes an empty mask."""
     masks: list[np.ndarray] = [
         np.ones((16, 16, 1), dtype=np.uint8),
         np.ones((16, 16, 1), dtype=np.uint8),
@@ -95,7 +94,6 @@ def test_mixup_instance_masks_regain_a_channel_axis_after_resize() -> None:
 
 @pytest.mark.parametrize("ndim", [2, 3])
 def test_mosaic_semantic_mask_fills_in_missing_masks(ndim: int) -> None:
-    """Samples with no segmentation still occupy their mosaic quadrant."""
     shape = (16, 16) if ndim == 2 else (16, 16, 2)
     # A sample missing the task arrives with the spatial dims collapsed,
     # which is how `_preprocess_batch` represents "no mask here".

--- a/tests/test_data/test_augmentations/test_transform_internals.py
+++ b/tests/test_data/test_augmentations/test_transform_internals.py
@@ -1,19 +1,14 @@
-"""Edge cases in the built-in batch transforms and keypoint flips.
-
-Batch transforms are handed whatever the loader produced, which includes
-samples missing a label entirely and grayscale sources with no channel axis.
-These are the branches that only such inputs reach.
-"""
-
 import numpy as np
 import pytest
 
-from luxonis_ml.data.augmentations import BatchTransform, MixUp, Mosaic4
+from luxonis_ml.data.augmentations import MixUp, Mosaic4
 from luxonis_ml.data.augmentations.custom import (
     HorizontalSymmetricKeypointsFlip,
     TransposeSymmetricKeypoints,
     VerticalSymmetricKeypointsFlip,
 )
+
+from .helpers import KeepFirstSample
 
 SHAPES = [(16, 16), (16, 16)]
 
@@ -72,11 +67,7 @@ def test_mixup_instance_mask_tolerates_a_missing_mask(
 
 
 def test_mixup_masks_regain_a_channel_axis_after_resize() -> None:
-    """A resized (H, W) mask is promoted back to (H, W, 1) before merging.
-
-    Only the plain-resize path can hand back a mask with no channel axis;
-    `LetterboxResize` always keeps one.
-    """
+    """Only the plain-resize path drops it; `LetterboxResize` keeps one."""
     masks = [
         np.ones((16, 16, 1), dtype=np.uint8),
         np.ones((8, 8), dtype=np.uint8),
@@ -124,7 +115,6 @@ def test_mosaic_semantic_mask_fills_in_missing_masks(ndim: int) -> None:
 
 
 def test_mosaic_instance_masks_with_nothing_to_place() -> None:
-    """Zero instances across the whole batch yields a zero-instance mask."""
     output = Mosaic4._apply_mosaic4_to_instance_masks(
         [np.array([]) for _ in range(4)],
         out_height=16,
@@ -148,35 +138,9 @@ def test_mosaic_composes_images_without_a_channel_axis() -> None:
 
 def test_classification_defaults_to_a_single_absent_class() -> None:
     """Samples missing a classification task must not break the OR."""
-
-    class Merge(BatchTransform):
-        def __init__(self):
-            super().__init__(batch_size=2, p=1.0)
-
-        def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
-            return image_batch[0]
-
-        def apply_to_mask(
-            self, masks_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return masks_batch[0]
-
-        def apply_to_instance_mask(
-            self, masks_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return masks_batch[0]
-
-        def apply_to_bboxes(
-            self, bboxes_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return bboxes_batch[0]
-
-        def apply_to_keypoints(
-            self, keypoints_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return keypoints_batch[0]
-
-    output = Merge().apply_to_classification([np.array([]), np.array([1.0])])
+    output = KeepFirstSample().apply_to_classification(
+        [np.array([]), np.array([1.0])]
+    )
 
     assert output.tolist() == [1.0]
 
@@ -184,23 +148,20 @@ def test_classification_defaults_to_a_single_absent_class() -> None:
 @pytest.mark.parametrize("flip", FLIPS)
 def test_flips_pass_empty_bboxes_through(flip: type) -> None:
     transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
-    bboxes = np.zeros((0, 4))
 
-    assert transform.apply_to_bboxes(
-        bboxes, orig_width=8, orig_height=8
-    ).shape == (
-        0,
-        4,
+    output = transform.apply_to_bboxes(
+        np.zeros((0, 4)), orig_width=8, orig_height=8
     )
+
+    assert output.shape == (0, 4)
 
 
 @pytest.mark.parametrize("flip", FLIPS)
 def test_flips_pass_empty_keypoints_through(flip: type) -> None:
     transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
-    keypoints = np.zeros((0, 3))
 
     output = transform.apply_to_keypoints(
-        keypoints, orig_width=8, orig_height=8
+        np.zeros((0, 3)), orig_width=8, orig_height=8
     )
 
     assert output.shape == (0, 3)
@@ -208,7 +169,6 @@ def test_flips_pass_empty_keypoints_through(flip: type) -> None:
 
 @pytest.mark.parametrize("flip", FLIPS)
 def test_flips_reject_a_partial_final_instance(flip: type) -> None:
-    """Keypoint rows must divide evenly into instances to be swapped."""
     transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
     keypoints = np.zeros((3, 3))
 

--- a/tests/test_data/test_augmentations/test_transform_internals.py
+++ b/tests/test_data/test_augmentations/test_transform_internals.py
@@ -1,0 +1,216 @@
+"""Edge cases in the built-in batch transforms and keypoint flips.
+
+Batch transforms are handed whatever the loader produced, which includes
+samples missing a label entirely and grayscale sources with no channel axis.
+These are the branches that only such inputs reach.
+"""
+
+import numpy as np
+import pytest
+
+from luxonis_ml.data.augmentations import BatchTransform, MixUp, Mosaic4
+from luxonis_ml.data.augmentations.custom import (
+    HorizontalSymmetricKeypointsFlip,
+    TransposeSymmetricKeypoints,
+    VerticalSymmetricKeypointsFlip,
+)
+
+SHAPES = [(16, 16), (16, 16)]
+
+FLIPS = [
+    HorizontalSymmetricKeypointsFlip,
+    VerticalSymmetricKeypointsFlip,
+    TransposeSymmetricKeypoints,
+]
+
+
+def test_mixup_can_resize_without_keeping_aspect_ratio() -> None:
+    mixup = MixUp(keep_aspect_ratio=False, p=1.0)
+
+    output = mixup.apply(
+        [
+            np.zeros((16, 16, 3), dtype=np.uint8),
+            np.full((8, 32, 3), 255, dtype=np.uint8),
+        ],
+        image_shapes=[(16, 16), (8, 32)],
+        alpha=0.5,
+    )
+
+    assert output.shape == (16, 16, 3)
+
+
+@pytest.mark.parametrize("empty_index", [0, 1])
+def test_mixup_semantic_mask_tolerates_a_missing_mask(
+    empty_index: int,
+) -> None:
+    """A sample without a segmentation task contributes an empty mask."""
+    masks = [
+        np.ones((16, 16, 1), dtype=np.uint8),
+        np.ones((16, 16, 1), dtype=np.uint8),
+    ]
+    masks[empty_index] = np.array([])
+
+    output = MixUp(p=1.0).apply_to_mask(masks, image_shapes=SHAPES, alpha=0.5)
+
+    assert output.shape == (16, 16, 1)
+
+
+@pytest.mark.parametrize("empty_index", [0, 1])
+def test_mixup_instance_mask_tolerates_a_missing_mask(
+    empty_index: int,
+) -> None:
+    masks = [
+        np.ones((16, 16, 2), dtype=np.uint8),
+        np.ones((16, 16, 3), dtype=np.uint8),
+    ]
+    expected = masks[1 - empty_index].shape
+    masks[empty_index] = np.array([])
+
+    output = MixUp(p=1.0).apply_to_instance_mask(masks, image_shapes=SHAPES)
+
+    assert output.shape == expected
+
+
+def test_mixup_masks_regain_a_channel_axis_after_resize() -> None:
+    """A resized (H, W) mask is promoted back to (H, W, 1) before merging.
+
+    Only the plain-resize path can hand back a mask with no channel axis;
+    `LetterboxResize` always keeps one.
+    """
+    masks = [
+        np.ones((16, 16, 1), dtype=np.uint8),
+        np.ones((8, 8), dtype=np.uint8),
+    ]
+
+    output = MixUp(keep_aspect_ratio=False, p=1.0).apply_to_mask(
+        masks, image_shapes=[(16, 16), (8, 8)], alpha=0.5
+    )
+
+    assert output.ndim == 3
+
+
+def test_mixup_instance_masks_regain_a_channel_axis_after_resize() -> None:
+    masks = [
+        np.ones((16, 16, 1), dtype=np.uint8),
+        np.ones((8, 8), dtype=np.uint8),
+    ]
+
+    output = MixUp(keep_aspect_ratio=False, p=1.0).apply_to_instance_mask(
+        masks, image_shapes=[(16, 16), (8, 8)]
+    )
+
+    assert output.shape == (16, 16, 2)
+
+
+@pytest.mark.parametrize("ndim", [2, 3])
+def test_mosaic_semantic_mask_fills_in_missing_masks(ndim: int) -> None:
+    """Samples with no segmentation still occupy their mosaic quadrant."""
+    shape = (16, 16) if ndim == 2 else (16, 16, 2)
+    # A sample missing the task arrives with the spatial dims collapsed,
+    # which is how `_preprocess_batch` represents "no mask here".
+    empty_shape = (0, 0) if ndim == 2 else (0, 0, 2)
+    masks = [
+        np.ones(shape, dtype=np.uint8),
+        np.empty(empty_shape, dtype=np.uint8),
+        np.ones(shape, dtype=np.uint8),
+        np.empty(empty_shape, dtype=np.uint8),
+    ]
+
+    output = Mosaic4(height=16, width=16, p=1.0).apply_to_mask(
+        masks, x_crop=4, y_crop=4, out_height=16, out_width=16
+    )
+
+    assert output.shape[:2] == (16, 16)
+
+
+def test_mosaic_instance_masks_with_nothing_to_place() -> None:
+    """Zero instances across the whole batch yields a zero-instance mask."""
+    output = Mosaic4._apply_mosaic4_to_instance_masks(
+        [np.array([]) for _ in range(4)],
+        out_height=16,
+        out_width=16,
+        x_crop=0,
+        y_crop=0,
+    )
+
+    assert output.shape == (16, 16, 0)
+
+
+def test_mosaic_composes_images_without_a_channel_axis() -> None:
+    images = [np.full((16, 16), i, dtype=np.uint8) for i in range(4)]
+
+    output = Mosaic4._apply_mosaic4_to_images(
+        images, out_height=16, out_width=16, x_crop=8, y_crop=8
+    )
+
+    assert output.shape == (16, 16)
+
+
+def test_classification_defaults_to_a_single_absent_class() -> None:
+    """Samples missing a classification task must not break the OR."""
+
+    class Merge(BatchTransform):
+        def __init__(self):
+            super().__init__(batch_size=2, p=1.0)
+
+        def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
+            return image_batch[0]
+
+        def apply_to_mask(
+            self, masks_batch: list[np.ndarray], **_
+        ) -> np.ndarray:
+            return masks_batch[0]
+
+        def apply_to_instance_mask(
+            self, masks_batch: list[np.ndarray], **_
+        ) -> np.ndarray:
+            return masks_batch[0]
+
+        def apply_to_bboxes(
+            self, bboxes_batch: list[np.ndarray], **_
+        ) -> np.ndarray:
+            return bboxes_batch[0]
+
+        def apply_to_keypoints(
+            self, keypoints_batch: list[np.ndarray], **_
+        ) -> np.ndarray:
+            return keypoints_batch[0]
+
+    output = Merge().apply_to_classification([np.array([]), np.array([1.0])])
+
+    assert output.tolist() == [1.0]
+
+
+@pytest.mark.parametrize("flip", FLIPS)
+def test_flips_pass_empty_bboxes_through(flip: type) -> None:
+    transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
+    bboxes = np.zeros((0, 4))
+
+    assert transform.apply_to_bboxes(
+        bboxes, orig_width=8, orig_height=8
+    ).shape == (
+        0,
+        4,
+    )
+
+
+@pytest.mark.parametrize("flip", FLIPS)
+def test_flips_pass_empty_keypoints_through(flip: type) -> None:
+    transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
+    keypoints = np.zeros((0, 3))
+
+    output = transform.apply_to_keypoints(
+        keypoints, orig_width=8, orig_height=8
+    )
+
+    assert output.shape == (0, 3)
+
+
+@pytest.mark.parametrize("flip", FLIPS)
+def test_flips_reject_a_partial_final_instance(flip: type) -> None:
+    """Keypoint rows must divide evenly into instances to be swapped."""
+    transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
+    keypoints = np.zeros((3, 3))
+
+    with pytest.raises(ValueError, match="not a multiple of n_keypoints"):
+        transform.apply_to_keypoints(keypoints, orig_width=8, orig_height=8)

--- a/tests/test_data/test_augmentations/test_transform_internals.py
+++ b/tests/test_data/test_augmentations/test_transform_internals.py
@@ -44,7 +44,7 @@ def test_mixup_semantic_mask_tolerates_a_missing_mask(
     empty_index: int,
 ) -> None:
     """A sample without a segmentation task contributes an empty mask."""
-    masks = [
+    masks: list[np.ndarray] = [
         np.ones((16, 16, 1), dtype=np.uint8),
         np.ones((16, 16, 1), dtype=np.uint8),
     ]
@@ -59,7 +59,7 @@ def test_mixup_semantic_mask_tolerates_a_missing_mask(
 def test_mixup_instance_mask_tolerates_a_missing_mask(
     empty_index: int,
 ) -> None:
-    masks = [
+    masks: list[np.ndarray] = [
         np.ones((16, 16, 2), dtype=np.uint8),
         np.ones((16, 16, 3), dtype=np.uint8),
     ]

--- a/tests/test_data/test_augmentations/test_utils.py
+++ b/tests/test_data/test_augmentations/test_utils.py
@@ -1,10 +1,3 @@
-"""Tests for the LDF <-> Albumentations boundary conversions.
-
-These functions are where label layouts change shape, so they are covered
-both by explicit shape cases and by round-trip properties: converting a label
-out and straight back must return what went in.
-"""
-
 import numpy as np
 import pytest
 from hypothesis import given, settings
@@ -21,7 +14,7 @@ from luxonis_ml.data.augmentations.utils import (
     yield_batches,
 )
 
-round_trip = settings(max_examples=100, deadline=None, derandomize=True)
+property_settings = settings(max_examples=100, deadline=None, derandomize=True)
 
 # Coordinates kept clear of the image border so that no keypoint is clipped
 # or marked invisible on the way back.
@@ -49,7 +42,7 @@ def test_postprocess_mask_moves_channels_first() -> None:
     height=st.integers(min_value=1, max_value=8),
     width=st.integers(min_value=1, max_value=8),
 )
-@round_trip
+@property_settings
 def test_mask_round_trip(n_channels: int, height: int, width: int) -> None:
     mask = np.arange(n_channels * height * width, dtype=np.uint8).reshape(
         n_channels, height, width
@@ -59,7 +52,6 @@ def test_mask_round_trip(n_channels: int, height: int, width: int) -> None:
 
 
 def test_postprocess_bboxes_handles_no_boxes() -> None:
-    """An empty bbox array still has to yield usable output shapes."""
     boxes, ordering = postprocess_bboxes(np.zeros((0, 6)))
 
     assert boxes.shape == (0, 5)
@@ -94,7 +86,7 @@ def test_preprocess_bboxes_appends_an_index_column() -> None:
     h=st.floats(min_value=0.05, max_value=0.1),
     class_id=st.integers(min_value=0, max_value=5),
 )
-@round_trip
+@property_settings
 def test_bbox_round_trip(
     x: float, y: float, w: float, h: float, class_id: int
 ) -> None:
@@ -140,7 +132,7 @@ def test_postprocess_keypoints_reorders_by_surviving_bboxes() -> None:
     size=st.integers(min_value=16, max_value=64),
     coords=st.data(),
 )
-@round_trip
+@property_settings
 def test_keypoint_round_trip(
     n_instances: int, n_keypoints: int, size: int, coords: st.DataObject
 ) -> None:
@@ -174,11 +166,10 @@ def test_keypoint_round_trip(
         elements=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
     )
 )
-@round_trip
+@property_settings
 def test_postprocess_keypoints_never_leaves_the_image(
     keypoints: np.ndarray,
 ) -> None:
-    """Coordinates are always clipped into the normalized unit square."""
     out = postprocess_keypoints(
         keypoints, np.arange(keypoints.shape[0]), 10, 10, 1
     )
@@ -199,7 +190,7 @@ def test_yield_batches_groups_by_key() -> None:
     n_samples=st.integers(min_value=1, max_value=10),
     batch_size=st.integers(min_value=1, max_value=5),
 )
-@round_trip
+@property_settings
 def test_yield_batches_covers_every_sample_once(
     n_samples: int, batch_size: int
 ) -> None:
@@ -217,7 +208,6 @@ def test_yield_batches_covers_every_sample_once(
 def test_postprocess_keypoints_keeps_annotation_grouping(
     n_keypoints: int,
 ) -> None:
-    """Rows are regrouped so each output row is one annotation."""
     n_instances = 3
     keypoints = np.zeros((n_instances * n_keypoints, 3))
 

--- a/tests/test_data/test_augmentations/test_utils.py
+++ b/tests/test_data/test_augmentations/test_utils.py
@@ -5,6 +5,7 @@ from hypothesis import strategies as st
 from hypothesis.extra import numpy as npst
 
 from luxonis_ml.data.augmentations.utils import (
+    pad_empty_entries,
     postprocess_bboxes,
     postprocess_keypoints,
     postprocess_mask,
@@ -49,6 +50,38 @@ def test_mask_round_trip(n_channels: int, height: int, width: int) -> None:
     )
 
     assert np.array_equal(postprocess_mask(preprocess_mask(mask)), mask)
+
+
+def test_pad_empty_entries_takes_the_width_of_a_populated_entry() -> None:
+    padded = pad_empty_entries([np.array([]), np.zeros((2, 7))], default=6)
+
+    assert [array.shape for array in padded] == [(0, 7), (2, 7)]
+
+
+def test_pad_empty_entries_reads_the_width_of_an_empty_2d_entry() -> None:
+    """An empty entry is still shaped by the pipeline's optional fields.
+
+    Falling back to ``default`` here would pad the other entries to a
+    different width, and concatenating the batch would then fail.
+    """
+    padded = pad_empty_entries([np.zeros((0, 7)), np.array([])], default=6)
+
+    assert [array.shape for array in padded] == [(0, 7), (0, 7)]
+    assert np.concatenate(padded, axis=0).shape == (0, 7)
+
+
+def test_pad_empty_entries_falls_back_when_no_entry_carries_a_width() -> None:
+    padded = pad_empty_entries([np.array([]), np.array([])], default=6)
+
+    assert [array.shape for array in padded] == [(0, 6), (0, 6)]
+
+
+def test_pad_empty_entries_leaves_populated_entries_alone() -> None:
+    populated = np.arange(6, dtype=np.float32).reshape(2, 3)
+
+    padded = pad_empty_entries([populated], default=6)
+
+    assert padded[0] is populated
 
 
 def test_postprocess_bboxes_handles_no_boxes() -> None:

--- a/tests/test_data/test_augmentations/test_utils.py
+++ b/tests/test_data/test_augmentations/test_utils.py
@@ -1,0 +1,228 @@
+"""Tests for the LDF <-> Albumentations boundary conversions.
+
+These functions are where label layouts change shape, so they are covered
+both by explicit shape cases and by round-trip properties: converting a label
+out and straight back must return what went in.
+"""
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as npst
+
+from luxonis_ml.data.augmentations.utils import (
+    postprocess_bboxes,
+    postprocess_keypoints,
+    postprocess_mask,
+    preprocess_bboxes,
+    preprocess_keypoints,
+    preprocess_mask,
+    yield_batches,
+)
+
+round_trip = settings(max_examples=100, deadline=None, derandomize=True)
+
+# Coordinates kept clear of the image border so that no keypoint is clipped
+# or marked invisible on the way back.
+normalized = st.floats(
+    min_value=0.05, max_value=0.85, allow_nan=False, allow_infinity=False
+)
+
+
+def test_preprocess_mask_moves_channels_last() -> None:
+    mask = np.arange(2 * 3 * 4).reshape(2, 3, 4)
+    assert preprocess_mask(mask).shape == (3, 4, 2)
+
+
+def test_postprocess_mask_promotes_a_flat_mask() -> None:
+    """A transform may hand back a 2D mask; it becomes a single channel."""
+    assert postprocess_mask(np.ones((5, 6))).shape == (1, 5, 6)
+
+
+def test_postprocess_mask_moves_channels_first() -> None:
+    assert postprocess_mask(np.ones((5, 6, 2))).shape == (2, 5, 6)
+
+
+@given(
+    n_channels=st.integers(min_value=1, max_value=4),
+    height=st.integers(min_value=1, max_value=8),
+    width=st.integers(min_value=1, max_value=8),
+)
+@round_trip
+def test_mask_round_trip(n_channels: int, height: int, width: int) -> None:
+    mask = np.arange(n_channels * height * width, dtype=np.uint8).reshape(
+        n_channels, height, width
+    )
+
+    assert np.array_equal(postprocess_mask(preprocess_mask(mask)), mask)
+
+
+def test_postprocess_bboxes_handles_no_boxes() -> None:
+    """An empty bbox array still has to yield usable output shapes."""
+    boxes, ordering = postprocess_bboxes(np.zeros((0, 6)))
+
+    assert boxes.shape == (0, 5)
+    assert ordering.shape == (0,)
+
+
+def test_postprocess_bboxes_drops_boxes_below_the_area_threshold() -> None:
+    boxes = np.array(
+        [[0.0, 0.0, 0.5, 0.5, 1.0, 0.0], [0.0, 0.0, 0.01, 0.01, 2.0, 1.0]]
+    )
+
+    kept, ordering = postprocess_bboxes(boxes, area_threshold=0.1)
+
+    assert kept.shape == (1, 5)
+    assert ordering.tolist() == [0]
+
+
+def test_preprocess_bboxes_appends_an_index_column() -> None:
+    boxes = np.array([[1.0, 0.1, 0.2, 0.3, 0.4], [2.0, 0.5, 0.5, 0.2, 0.2]])
+
+    out = preprocess_bboxes(boxes)
+
+    assert out.shape == (2, 6)
+    assert out[:, -1].tolist() == [0.0, 1.0]
+    assert out[:, 4].tolist() == [1.0, 2.0]
+
+
+@given(
+    x=normalized,
+    y=normalized,
+    w=st.floats(min_value=0.05, max_value=0.1),
+    h=st.floats(min_value=0.05, max_value=0.1),
+    class_id=st.integers(min_value=0, max_value=5),
+)
+@round_trip
+def test_bbox_round_trip(
+    x: float, y: float, w: float, h: float, class_id: int
+) -> None:
+    boxes = np.array([[float(class_id), x, y, w, h]])
+
+    out, ordering = postprocess_bboxes(
+        preprocess_bboxes(boxes.copy()), area_threshold=0.0
+    )
+
+    assert ordering.tolist() == [0]
+    # preprocess nudges the far edge by 1e-6 to avoid zero-area boxes.
+    np.testing.assert_allclose(out, boxes, atol=1e-5)
+
+
+def test_preprocess_keypoints_scales_to_pixels() -> None:
+    keypoints = np.array([[0.5, 0.25, 2.0, 1.0, 0.0, 1.0]])
+
+    out = preprocess_keypoints(keypoints, height=8, width=4)
+
+    assert out.tolist() == [[2.0, 2.0, 2.0], [4.0, 0.0, 1.0]]
+
+
+def test_postprocess_keypoints_marks_out_of_bounds_invisible() -> None:
+    keypoints = np.array([[5.0, 5.0, 2.0], [12.0, -1.0, 2.0]])
+
+    out = postprocess_keypoints(keypoints, np.array([0]), 10, 10, 2)
+
+    assert out[0, 2] == 2.0
+    assert out[0, 5] == 0.0, "the out-of-bounds keypoint must lose visibility"
+
+
+def test_postprocess_keypoints_reorders_by_surviving_bboxes() -> None:
+    keypoints = np.array([[1.0, 1.0, 2.0], [9.0, 9.0, 1.0]])
+
+    out = postprocess_keypoints(keypoints, np.array([1, 0]), 10, 10, 1)
+
+    np.testing.assert_allclose(out, [[0.9, 0.9, 1.0], [0.1, 0.1, 2.0]])
+
+
+@given(
+    n_instances=st.integers(min_value=1, max_value=3),
+    n_keypoints=st.integers(min_value=1, max_value=3),
+    size=st.integers(min_value=16, max_value=64),
+    coords=st.data(),
+)
+@round_trip
+def test_keypoint_round_trip(
+    n_instances: int, n_keypoints: int, size: int, coords: st.DataObject
+) -> None:
+    keypoints = np.array(
+        [
+            [
+                value
+                for _ in range(n_keypoints)
+                for value in (
+                    coords.draw(normalized),
+                    coords.draw(normalized),
+                    2.0,
+                )
+            ]
+            for _ in range(n_instances)
+        ]
+    )
+
+    pixels = preprocess_keypoints(keypoints.copy(), height=size, width=size)
+    out = postprocess_keypoints(
+        pixels, np.arange(n_instances), size, size, n_keypoints
+    )
+
+    np.testing.assert_allclose(out, keypoints, atol=1e-6)
+
+
+@given(
+    keypoints=npst.arrays(
+        dtype=np.float64,
+        shape=st.tuples(st.integers(0, 6), st.just(3)),
+        elements=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
+    )
+)
+@round_trip
+def test_postprocess_keypoints_never_leaves_the_image(
+    keypoints: np.ndarray,
+) -> None:
+    """Coordinates are always clipped into the normalized unit square."""
+    out = postprocess_keypoints(
+        keypoints, np.arange(keypoints.shape[0]), 10, 10, 1
+    )
+
+    assert np.all(out[:, 0::3] >= 0)
+    assert np.all(out[:, 0::3] <= 1)
+    assert np.all(out[:, 1::3] >= 0)
+    assert np.all(out[:, 1::3] <= 1)
+
+
+def test_yield_batches_groups_by_key() -> None:
+    samples = [{"a": 1}, {"a": 2}, {"a": 3}]
+
+    assert list(yield_batches(samples, 2)) == [{"a": [1, 2]}, {"a": [3]}]
+
+
+@given(
+    n_samples=st.integers(min_value=1, max_value=10),
+    batch_size=st.integers(min_value=1, max_value=5),
+)
+@round_trip
+def test_yield_batches_covers_every_sample_once(
+    n_samples: int, batch_size: int
+) -> None:
+    samples = [{"a": i} for i in range(n_samples)]
+
+    batches = list(yield_batches(samples, batch_size))
+
+    assert [value for batch in batches for value in batch["a"]] == list(
+        range(n_samples)
+    )
+    assert all(len(batch["a"]) <= batch_size for batch in batches)
+
+
+@pytest.mark.parametrize("n_keypoints", [2, 3])
+def test_postprocess_keypoints_keeps_annotation_grouping(
+    n_keypoints: int,
+) -> None:
+    """Rows are regrouped so each output row is one annotation."""
+    n_instances = 3
+    keypoints = np.zeros((n_instances * n_keypoints, 3))
+
+    out = postprocess_keypoints(
+        keypoints, np.arange(n_instances), 10, 10, n_keypoints
+    )
+
+    assert out.shape == (n_instances, n_keypoints * 3)

--- a/tests/test_data/test_augmentations/test_utils.py
+++ b/tests/test_data/test_augmentations/test_utils.py
@@ -30,7 +30,6 @@ def test_preprocess_mask_moves_channels_last() -> None:
 
 
 def test_postprocess_mask_promotes_a_flat_mask() -> None:
-    """A transform may hand back a 2D mask; it becomes a single channel."""
     assert postprocess_mask(np.ones((5, 6))).shape == (1, 5, 6)
 
 
@@ -53,7 +52,7 @@ def test_mask_round_trip(n_channels: int, height: int, width: int) -> None:
 
 
 def test_pad_empty_entries_takes_the_width_of_a_populated_entry() -> None:
-    padded = pad_empty_entries([np.array([]), np.zeros((2, 7))], default=6)
+    padded = pad_empty_entries([np.array([]), np.zeros((2, 7))])
 
     assert [array.shape for array in padded] == [(0, 7), (2, 7)]
 
@@ -61,17 +60,17 @@ def test_pad_empty_entries_takes_the_width_of_a_populated_entry() -> None:
 def test_pad_empty_entries_reads_the_width_of_an_empty_2d_entry() -> None:
     """An empty entry is still shaped by the pipeline's optional fields.
 
-    Falling back to ``default`` here would pad the other entries to a
-    different width, and concatenating the batch would then fail.
+    Falling back to the default width here would pad the other entries
+    differently, and concatenating the batch would then fail.
     """
-    padded = pad_empty_entries([np.zeros((0, 7)), np.array([])], default=6)
+    padded = pad_empty_entries([np.zeros((0, 7)), np.array([])])
 
     assert [array.shape for array in padded] == [(0, 7), (0, 7)]
     assert np.concatenate(padded, axis=0).shape == (0, 7)
 
 
 def test_pad_empty_entries_falls_back_when_no_entry_carries_a_width() -> None:
-    padded = pad_empty_entries([np.array([]), np.array([])], default=6)
+    padded = pad_empty_entries([np.array([]), np.array([])])
 
     assert [array.shape for array in padded] == [(0, 6), (0, 6)]
 
@@ -79,7 +78,7 @@ def test_pad_empty_entries_falls_back_when_no_entry_carries_a_width() -> None:
 def test_pad_empty_entries_leaves_populated_entries_alone() -> None:
     populated = np.arange(6, dtype=np.float32).reshape(2, 3)
 
-    padded = pad_empty_entries([populated], default=6)
+    padded = pad_empty_entries([populated])
 
     assert padded[0] is populated
 

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -367,6 +367,16 @@ def test_loader_uses_metadata_from_custom_engine_single_contributor(
             }
 
     dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    # Splits are shuffled when the dataset is created, so which record ends up
+    # at which loader position is not knowable here. Read the positions back
+    # instead of assuming the generator's order survived.
+    reference = LuxonisLoader(
+        dataset,
+        view="train",
+        height=256,
+        width=256,
+        autopopulate_metadata=False,
+    )
     loader = LuxonisLoader(
         dataset,
         view="train",
@@ -379,7 +389,10 @@ def test_loader_uses_metadata_from_custom_engine_single_contributor(
 
     metadata = loader[0].metadata
 
-    assert metadata == {"record_id": 1}
+    # The engine reports input position 1 as its only contributor, so the
+    # loader must report that position's metadata rather than position 0's.
+    assert metadata == reference[1].metadata
+    assert metadata != reference[0].metadata
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Fixes a bug triggered by the following MRE:

**`aug.json`**
```json
[
  {
    "name": "Mosaic4",
    "params": {
      "width": 640,
      "height": 640,
      "p": 0
    }
  },
  {
    "name": "MixUp",
    "params": {
      "p": 1
    }
  }
]
```

```
luxonis_ml data inspect coco_test -a aug.json
```

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batched Albumentations augmentation to preserve per-annotation label metadata, keep empty/filtered bbox tasks, and maintain correct shapes and ordering for dependent labels (keypoints, masks, metadata).
  * Refined bbox-associated label compaction and index re-stamping across batch transforms.
  * Improved MixUp and Mosaic handling for empty/partially annotated inputs to keep batch dimensions stable.

* **Tests**
  * Expanded regression/property-based coverage for box↔keypoint/mask alignment, empty-box behavior, task filtering, and batch-compose warning/compaction semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->