### PR TITLE
Fix sample metadata merging on batched augmentations

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -601,6 +601,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
     def batch_size(self) -> int:
         return self._batch_transform.batch_size
 
+    @property
+    @override
+    def batch_augmentation_indices(self) -> list[int]:
+        """Input positions contributing to the last augmented output."""
+        return self._batch_transform.batch_augmentation_indices
+
     @override
     def apply(self, input_batch: list[LoaderMultiOutput]) -> LoaderMultiOutput:
         data_batch, n_keypoints = self._preprocess_batch(input_batch)

--- a/luxonis_ml/data/augmentations/base_engine.py
+++ b/luxonis_ml/data/augmentations/base_engine.py
@@ -112,7 +112,7 @@ class AugmentationEngine(
     def batch_augmentation_indices(self) -> list[int]:
         """Input positions contributing to the last augmented output.
 
-        Engines that do not expose this information return the first input
-        position, so loaders preserve its metadata.
+        Engines that do not expose this information are assumed to use every
+        input position, preserving the behavior of existing batch engines.
         """
-        return [0]
+        return list(range(self.batch_size))

--- a/luxonis_ml/data/augmentations/base_engine.py
+++ b/luxonis_ml/data/augmentations/base_engine.py
@@ -107,3 +107,12 @@ class AugmentationEngine(
         the batch size should be :math:`8 = \left(2 \cdot 4\right)`.
         """
         ...
+
+    @property
+    def batch_augmentation_indices(self) -> list[int]:
+        """Input positions contributing to the last augmented output.
+
+        Engines that do not expose this information return the first input
+        position, so loaders preserve its metadata.
+        """
+        return [0]

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -38,6 +38,7 @@ class BatchCompose(A.Compose):
         np.random.seed(self.seed)
 
         self.batch_size = 1
+        self.batch_augmentation_indices = [0]
         for transform in self.transforms:
             self.batch_size *= transform.batch_size
 
@@ -65,6 +66,7 @@ class BatchCompose(A.Compose):
                 f"but got {len(data_batch)}."
             )
 
+        input_indices = [[i] for i in range(len(data_batch))]
         if not self.transforms:
             return data_batch[0]
 
@@ -74,17 +76,34 @@ class BatchCompose(A.Compose):
 
         for transform in self.transforms:
             new_batch = []
-            for batch in yield_batches(data_batch, transform.batch_size):
+            new_indices = []
+            for i, batch in enumerate(
+                yield_batches(data_batch, transform.batch_size)
+            ):
                 data = transform(**batch)  # type: ignore
+                batch_indices = input_indices[
+                    i * transform.batch_size : (i + 1) * transform.batch_size
+                ]
 
-                if isinstance(next(iter(data.values())), list):
+                if not transform.params:
                     data = {key: value[0] for key, value in batch.items()}
+                    new_indices.append(batch_indices[0])
+                else:
+                    new_indices.append(
+                        [
+                            index
+                            for indices in batch_indices
+                            for index in indices
+                        ]
+                    )
 
                 data = self.check_data_post_transform(data)
                 new_batch.append(data)
             data_batch = new_batch
+            input_indices = new_indices
 
         assert len(data_batch) == 1
+        self.batch_augmentation_indices = input_indices[0]
         data = data_batch[0]
 
         data = self._make_contiguous(data)

--- a/luxonis_ml/data/loaders/__init__.py
+++ b/luxonis_ml/data/loaders/__init__.py
@@ -162,7 +162,7 @@ Pass ``autopopulate_metadata=False`` to return only stored metadata:
     loader = LuxonisLoader(dataset, autopopulate_metadata=False)
     metadata = loader[0].metadata
 
-When batch augmentations combine several samples, metadata from the input
+When a batch augmentation combines several samples, metadata from the input
 samples is preserved in ``"batch_augmentation_metadata"``:
 
 .. python::

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -589,17 +589,26 @@ class LuxonisLoader(BaseLoader):
             sample_metadata_list.append(sample_etadata)
 
         img_dict, labels = self._augmentations.apply(loaded_anns)
-        sample_etadata = self._merge_sample_metadata(sample_metadata_list)
+        sample_etadata = sample_metadata_list[0]
+        metadata_indices = self._augmentations.batch_augmentation_indices
+        if len(metadata_indices) > 1:
+            sample_etadata = self._merge_sample_metadata(
+                [sample_metadata_list[i] for i in metadata_indices],
+                metadata_indices,
+            )
         return img_dict, labels, sample_etadata
 
     @staticmethod
-    def _merge_sample_metadata(metadata_batch: list[Params]) -> Params:
+    def _merge_sample_metadata(
+        metadata_batch: list[Params], input_indices: list[int] | None = None
+    ) -> Params:
         """Merge metadata from samples used by a batch augmentation.
 
         The first sample's metadata remains at the top level. Metadata from
-        every input sample is also preserved in
+        every contributing input sample is also preserved in
         ``"batch_augmentation_metadata"`` so consumers can inspect which
-        records contributed to the augmented output.
+        records contributed to the augmented output. ``input_index`` is the
+        source sample's position in the original augmentation batch.
 
         Example:
             .. python::
@@ -623,6 +632,9 @@ class LuxonisLoader(BaseLoader):
         if not metadata_batch:
             return {}
 
+        if input_indices is None:
+            input_indices = list(range(len(metadata_batch)))
+
         metadata = deepcopy(metadata_batch[0])
 
         metadata["batch_augmentation_metadata"] = [  # type: ignore
@@ -630,7 +642,7 @@ class LuxonisLoader(BaseLoader):
                 "input_index": i,
                 "sample_metadata": deepcopy(m),
             }
-            for i, m in enumerate(metadata_batch)
+            for i, m in zip(input_indices, metadata_batch, strict=True)
         ]
         return metadata
 

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -589,8 +589,8 @@ class LuxonisLoader(BaseLoader):
             sample_metadata_list.append(sample_etadata)
 
         img_dict, labels = self._augmentations.apply(loaded_anns)
-        sample_etadata = sample_metadata_list[0]
         metadata_indices = self._augmentations.batch_augmentation_indices
+        sample_etadata = sample_metadata_list[metadata_indices[0]]
         if len(metadata_indices) > 1:
             sample_etadata = self._merge_sample_metadata(
                 [sample_metadata_list[i] for i in metadata_indices],

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -161,6 +161,14 @@ class CompatibilityOnlyEngine(
         return 1
 
 
+class CompatibilityBatchEngine(
+    CompatibilityOnlyEngine, register_name="compatibility_batch_engine"
+):
+    @property
+    def batch_size(self) -> int:
+        return 2
+
+
 @contextmanager
 def set_seed(seed: int):
     np_state = np.random.get_state()
@@ -299,6 +307,42 @@ def test_loader_passes_is_validation_pipeline_to_legacy_engines(
     )
 
     assert CompatibilityOnlyEngine.last_is_validation_pipeline is True
+
+
+def test_loader_preserves_metadata_for_custom_batch_engines(
+    dataset_name: str, tempdir: Path
+) -> None:
+    def generator() -> DatasetIterator:
+        for i in range(2):
+            yield {
+                "file": create_image(i, tempdir),
+                "sample_metadata": {"record_id": i},
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    loader = LuxonisLoader(
+        dataset,
+        view="train",
+        height=256,
+        width=256,
+        autopopulate_metadata=False,
+        augmentation_engine="compatibility_batch_engine",
+        augmentation_config=[{"name": "Normalize"}],
+    )
+
+    metadata = loader[0].metadata
+    batch_metadata = cast(
+        list[dict[str, Params]], metadata["batch_augmentation_metadata"]
+    )
+
+    assert [cast(int, entry["input_index"]) for entry in batch_metadata] == [
+        0,
+        1,
+    ]
+    assert {
+        cast(int, entry["sample_metadata"]["record_id"])
+        for entry in batch_metadata
+    } == {0, 1}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -341,7 +341,7 @@ def test_loader_merges_metadata_only_for_applied_batch_augmentations(
             1,
         }
         assert {
-            cast(Params, entry["sample_metadata"])["record_id"]
+            cast(int, entry["sample_metadata"]["record_id"])
             for entry in batch_metadata
         } == {0, 1}
         assert (
@@ -357,6 +357,8 @@ def test_loader_merges_metadata_only_for_applied_batch_augmentations(
     [
         (0.0, 0.0, None),
         (1.0, 0.0, [0, 1, 2, 3]),
+        # A skipped Mosaic4 passes through the first input from each group of
+        # four, so MixUp combines source inputs 0 and 4.
         (0.0, 1.0, [0, 4]),
         (1.0, 1.0, list(range(8))),
     ],
@@ -409,7 +411,7 @@ def test_loader_tracks_metadata_through_multiple_batch_augmentations(
     ] == expected_input_indices
     assert len(
         {
-            cast(Params, entry["sample_metadata"])["record_id"]
+            cast(int, entry["sample_metadata"]["record_id"])
             for entry in batch_metadata
         }
     ) == len(expected_input_indices)

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -169,6 +169,17 @@ class CompatibilityBatchEngine(
         return 2
 
 
+class SelectiveBatchEngine(
+    CompatibilityBatchEngine, register_name="selective_batch_engine"
+):
+    def apply(self, data: list[LoaderMultiOutput]) -> LoaderMultiOutput:
+        return data[1]
+
+    @property
+    def batch_augmentation_indices(self) -> list[int]:
+        return [1]
+
+
 @contextmanager
 def set_seed(seed: int):
     np_state = np.random.get_state()
@@ -343,6 +354,32 @@ def test_loader_preserves_metadata_for_custom_batch_engines(
         cast(int, entry["sample_metadata"]["record_id"])
         for entry in batch_metadata
     } == {0, 1}
+
+
+def test_loader_uses_metadata_from_custom_engine_single_contributor(
+    dataset_name: str, tempdir: Path
+) -> None:
+    def generator() -> DatasetIterator:
+        for i in range(2):
+            yield {
+                "file": create_image(i, tempdir),
+                "sample_metadata": {"record_id": i},
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    loader = LuxonisLoader(
+        dataset,
+        view="train",
+        height=256,
+        width=256,
+        autopopulate_metadata=False,
+        augmentation_engine="selective_batch_engine",
+        augmentation_config=[{"name": "Normalize"}],
+    )
+
+    metadata = loader[0].metadata
+
+    assert metadata == {"record_id": 1}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -301,6 +301,120 @@ def test_loader_passes_is_validation_pipeline_to_legacy_engines(
     assert CompatibilityOnlyEngine.last_is_validation_pipeline is True
 
 
+@pytest.mark.parametrize(
+    ("probability", "metadata_is_merged"), [(0.0, False), (1.0, True)]
+)
+def test_loader_merges_metadata_only_for_applied_batch_augmentations(
+    dataset_name: str,
+    tempdir: Path,
+    probability: float,
+    metadata_is_merged: bool,
+) -> None:
+    def generator() -> DatasetIterator:
+        for i in range(2):
+            yield {
+                "file": create_image(i, tempdir),
+                "sample_metadata": {"record_id": i},
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    loader = LuxonisLoader(
+        dataset,
+        view="train",
+        height=256,
+        width=256,
+        autopopulate_metadata=False,
+        augmentation_config=[{"name": "MixUp", "params": {"p": probability}}],
+    )
+
+    metadata = loader[0].metadata
+
+    assert ("batch_augmentation_metadata" in metadata) is metadata_is_merged
+    if metadata_is_merged:
+        batch_metadata = cast(
+            list[dict[str, Params]], metadata["batch_augmentation_metadata"]
+        )
+        assert {
+            cast(int, entry["input_index"]) for entry in batch_metadata
+        } == {
+            0,
+            1,
+        }
+        assert {
+            cast(Params, entry["sample_metadata"])["record_id"]
+            for entry in batch_metadata
+        } == {0, 1}
+        assert (
+            metadata["record_id"]
+            == cast(Params, batch_metadata[0]["sample_metadata"])["record_id"]
+        )
+    else:
+        assert metadata in ({"record_id": 0}, {"record_id": 1})
+
+
+@pytest.mark.parametrize(
+    ("mosaic_probability", "mixup_probability", "expected_input_indices"),
+    [
+        (0.0, 0.0, None),
+        (1.0, 0.0, [0, 1, 2, 3]),
+        (0.0, 1.0, [0, 4]),
+        (1.0, 1.0, list(range(8))),
+    ],
+)
+def test_loader_tracks_metadata_through_multiple_batch_augmentations(
+    dataset_name: str,
+    tempdir: Path,
+    mosaic_probability: float,
+    mixup_probability: float,
+    expected_input_indices: list[int] | None,
+) -> None:
+    def generator() -> DatasetIterator:
+        for i in range(8):
+            yield {
+                "file": create_image(i, tempdir),
+                "sample_metadata": {"record_id": i},
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    loader = LuxonisLoader(
+        dataset,
+        view="train",
+        height=256,
+        width=256,
+        autopopulate_metadata=False,
+        augmentation_config=[
+            {
+                "name": "Mosaic4",
+                "params": {
+                    "p": mosaic_probability,
+                    "out_width": 256,
+                    "out_height": 256,
+                },
+            },
+            {"name": "MixUp", "params": {"p": mixup_probability}},
+        ],
+    )
+
+    metadata = loader[0].metadata
+
+    if expected_input_indices is None:
+        assert "batch_augmentation_metadata" not in metadata
+        return
+
+    batch_metadata = cast(
+        list[dict[str, Params]], metadata["batch_augmentation_metadata"]
+    )
+    assert [
+        cast(int, entry["input_index"]) for entry in batch_metadata
+    ] == expected_input_indices
+    assert len(
+        {
+            cast(Params, entry["sample_metadata"])["record_id"]
+            for entry in batch_metadata
+        }
+    ) == len(expected_input_indices)
+
+
 def load_annotations(annotation_name: str) -> list[dict[str, Any]]:
     dest_dir = Path("./tests/data/")
     local_path = dest_dir / annotation_name


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
When we use batch augmentations we have to also combine the sample metadata of all the records.
Previously we were always merging the metadata no matter whether the batch augmentation was actually applied or not, now we only include metadata of records that were really used.


## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
- New property `AugmentationsEngine.batch_augmentation_indices` which other engines can override if they want the metadata merging be handled. 
- Implementation of the above in `AlbumentationsEngine`

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch augmentations now expose per-sample provenance for augmented outputs.
  * Loader metadata now records which input positions contributed to each augmented result.
* **Bug Fixes**
  * Improved preservation and merging of sample metadata when augmentations combine multiple inputs.
  * Metadata is no longer attached when no batch augmentation is applied.
* **Tests**
  * Added coverage for custom batch engines and multi-augmentation metadata/index propagation.
* **Documentation**
  * Refined wording around how batch augmentations preserve batch augmentation metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->