### PR TITLE
De-AI pass over the batched-augmentation fix

### DIFF
--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -39,6 +39,12 @@ TargetType: TypeAlias = Literal[
     "metadata",
 ]
 
+# Target types describing individual instances, and so kept in step with the
+# bounding boxes of their task group as those are filtered.
+ASSOCIATED_TARGET_TYPES = frozenset(
+    {"instance_mask", "keypoints", "array", "metadata"}
+)
+
 
 class AlbumentationConfigItem(ConfigItem):
     """Configuration item for `AlbumentationsEngine`.
@@ -578,38 +584,38 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 "seed": seed,
             }
 
-        # Warning issued when "bbox_params" or "keypoint_params"
-        # are provided to a compose with transformations that
-        # do not use them. We don't care about these warnings.
         bbox_targets_by_group = {}
-        for bbox_target, bbox_type in self._targets.items():
-            if bbox_type != "bboxes":
+        for target_name, target_type in self._targets.items():
+            if target_type != "bboxes":
                 continue
-            task_group = self._target_names_to_task_groups[bbox_target]
+            task_group = self._target_names_to_task_groups[target_name]
             if task_group in bbox_targets_by_group:
                 raise ValueError(
                     "Multiple bounding-box targets belong to task group "
                     f"'{task_group}'."
                 )
-            bbox_targets_by_group[task_group] = bbox_target
+            bbox_targets_by_group[task_group] = target_name
 
         self._bbox_task_groups = set(bbox_targets_by_group)
-        bbox_associations = {}
-        for task_group, bbox_target in bbox_targets_by_group.items():
-            bbox_associations[bbox_target] = {
+        bbox_associations = {
+            bbox_target: {
                 target_name: target_type
                 for target_name, target_type in self._targets.items()
-                if target_type
-                in {"instance_mask", "keypoints", "array", "metadata"}
+                if target_type in ASSOCIATED_TARGET_TYPES
                 and self._target_names_to_task_groups[target_name]
                 == task_group
             }
+            for task_group, bbox_target in bbox_targets_by_group.items()
+        }
         self._bbox_associated_targets = {
             target_name
             for associations in bbox_associations.values()
             for target_name in associations
         }
 
+        # Warning issued when "bbox_params" or "keypoint_params"
+        # are provided to a compose with transformations that
+        # do not use them. We don't care about these warnings.
         with warnings.catch_warnings(record=True):
             self._batch_transform = BatchCompose(
                 batch_transforms,
@@ -653,9 +659,9 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         )
 
         # Albumentations chokes on zero-size targets, so they are dropped
-        # before the remaining stages. Labels that a batch transform emptied
-        # are remembered so postprocessing can still report them as empty
-        # instead of silently omitting the task.
+        # here. Ones a batch transform emptied are remembered so that
+        # postprocessing can still report them as empty rather than omit
+        # the task entirely.
         emptied_targets = set()
         for target_name in list(data.keys()):
             value = data[target_name]
@@ -878,8 +884,6 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
                 out_labels[task] = array
 
         for target_name in emptied_targets:
-            # These were dropped before the remaining stages ran, so none of
-            # the loops above can have produced a label for them.
             task = self._target_names_to_tasks[target_name]
             if self._targets[target_name] == "instance_mask":
                 # The recorded shape is the pre-augmentation one.
@@ -978,12 +982,12 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
     @staticmethod
     def _get_task_group(task: str) -> str:
-        """Return the complete task path without its task-type suffix."""
-        task_type = get_task_type(task)
-        suffix = f"/{task_type}"
-        if task.endswith(suffix):
-            return task[: -len(suffix)]
-        return ""
+        """Return the complete task path without its task-type suffix.
+
+        Unlike `get_task_name`, this keeps every level of a nested task
+        name, so ``"a/b/keypoints"`` groups under ``"a/b"``.
+        """
+        return task.removesuffix(get_task_type(task)).removesuffix("/")
 
     @staticmethod
     def _task_to_target_name(task: str) -> str:

--- a/luxonis_ml/data/augmentations/batch_compose.py
+++ b/luxonis_ml/data/augmentations/batch_compose.py
@@ -34,12 +34,10 @@ class BatchCompose(A.Compose):
         Args:
             transforms: Transformations to compose.
             bbox_associations: Bbox fields mapped to their associated target
-                fields and target types. Keyword-only so it cannot be
-                mistaken for `A.Compose`_'s positional ``bbox_params``.
-                Bbox fields listed here are expected to carry a dedicated
+                fields and target types. Fields listed here must carry the
                 index column appended by
                 `luxonis_ml.data.augmentations.utils.preprocess_bboxes`;
-                fields not listed here are left untouched.
+                any other bbox field is left untouched.
             **kwargs: Additional arguments passed to `A.Compose`_.
 
         .. _A.Compose:
@@ -71,9 +69,9 @@ class BatchCompose(A.Compose):
             data_batch: Batch of Albumentations data dictionaries. Its
                 length must equal ``batch_size``.
             keypoints_per_instance: Number of keypoints each instance of a
-                keypoint field carries. Needed to regroup keypoint rows by
-                instance when compacting bbox-associated labels; keypoint
-                fields missing from this mapping are left untouched.
+                keypoint field carries, used to regroup keypoint rows by
+                instance. Fields missing from this mapping are left
+                untouched.
 
         Returns:
             Single transformed data dictionary.
@@ -147,13 +145,10 @@ class BatchCompose(A.Compose):
     def _reindex_bboxes(self, data: dict[str, np.ndarray]) -> dict[str, int]:
         """Give each bbox field contiguous indices and return its size.
 
-        Only fields declared in ``bbox_associations`` are touched. Those carry
-        an index column appended by the engine; for any other bbox field the
-        last column is the class label and must be left alone.
-
-        The indices are local positions into bbox-associated labels. They are
-        assigned before bbox filtering so the surviving indices can be used to
-        compact those labels in lockstep.
+        Only fields declared in ``bbox_associations`` are touched; for any
+        other bbox field the last column is the class label. The indices are
+        positions into the bbox-associated labels, stamped before filtering so
+        that the survivors can be used to compact those labels in lockstep.
         """
         bbox_counts = {}
         bbox_processor = self.processors.get("bboxes")
@@ -173,8 +168,7 @@ class BatchCompose(A.Compose):
                 raise ValueError(
                     f"Bbox field '{field_name}' must be a 2D array."
                 )
-            # A copy rather than an in-place write: the caller's array may
-            # be read-only, and it is not this composition's to modify.
+            # The caller's array may be read-only, and is not ours to modify.
             bboxes = bboxes.copy()
             bboxes[:, -1] = np.arange(len(bboxes), dtype=bboxes.dtype)
             data[field_name] = bboxes
@@ -188,23 +182,21 @@ class BatchCompose(A.Compose):
     ) -> None:
         """Drop labels associated with bboxes filtered from the current stage.
 
-        A field whose length disagrees with the bbox count cannot be matched
-        up instance by instance, so it is left untouched rather than dropped
-        or regrouped on a guess.
+        A field whose instance count disagrees with the bbox count cannot be
+        matched up instance by instance, so it is left untouched rather than
+        dropped or regrouped on a guess.
         """
         for bbox_field, associations in self._bbox_associations.items():
-            # A field is in `bbox_counts` only if `_reindex_bboxes` saw it in
-            # this same dict, and it validated the layout there too.
             if bbox_field not in bbox_counts:
                 continue
-            bboxes = data[bbox_field]
 
             bbox_count = bbox_counts[bbox_field]
-            if bboxes.size == 0:
-                indices = np.array([], dtype=int)
-            else:
-                indices = bboxes[:, -1].astype(int)
-
+            bboxes = data[bbox_field]
+            indices = (
+                bboxes[:, -1].astype(int)
+                if bboxes.size
+                else np.array([], dtype=int)
+            )
             if bbox_count and np.array_equal(indices, np.arange(bbox_count)):
                 continue
 
@@ -223,57 +215,64 @@ class BatchCompose(A.Compose):
                 if value.size == 0:
                     continue
 
-                if target_type == "instance_mask":
-                    if value.shape[-1] != bbox_count:
-                        self._warn_unmatched(
-                            field_name,
-                            f"{value.shape[-1]} instances",
-                            bbox_count,
-                            bbox_field,
-                        )
-                        continue
-                    data[field_name] = value[..., indices]
-                elif target_type == "keypoints":
-                    n_keypoints = keypoints_per_instance.get(field_name)
-                    if (
-                        n_keypoints is None
-                        or value.shape[0] != bbox_count * n_keypoints
-                    ):
-                        self._warn_unmatched(
-                            field_name,
-                            f"{value.shape[0]} keypoint rows",
-                            bbox_count,
-                            bbox_field,
-                        )
-                        continue
-                    grouped = value.reshape(
-                        bbox_count, n_keypoints, *value.shape[1:]
-                    )
-                    data[field_name] = grouped[indices].reshape(
-                        -1, *value.shape[1:]
+                compacted = self._select_instances(
+                    value,
+                    target_type,
+                    indices,
+                    bbox_count,
+                    keypoints_per_instance.get(field_name, 0),
+                )
+                if compacted is None:
+                    self._warn_unmatched(
+                        field_name, value, bbox_count, bbox_field
                     )
                 else:
-                    if len(value) != bbox_count:
-                        self._warn_unmatched(
-                            field_name,
-                            f"{len(value)} values",
-                            bbox_count,
-                            bbox_field,
-                        )
-                        continue
-                    data[field_name] = value[indices]
+                    data[field_name] = compacted
+
+    @staticmethod
+    def _select_instances(
+        value: np.ndarray,
+        target_type: str,
+        indices: np.ndarray,
+        bbox_count: int,
+        n_keypoints: int,
+    ) -> np.ndarray | None:
+        """Keep only the instances at ``indices``, in that order.
+
+        Returns ``None`` if the field does not hold exactly ``bbox_count``
+        instances, in which case it cannot be matched up with the boxes.
+        """
+        if target_type == "instance_mask":
+            # Instance masks are (H, W, N) at this point.
+            if value.shape[-1] != bbox_count:
+                return None
+            return value[..., indices]
+
+        if target_type == "keypoints":
+            if not n_keypoints or value.shape[0] != bbox_count * n_keypoints:
+                return None
+            grouped = value.reshape(bbox_count, n_keypoints, *value.shape[1:])
+            return grouped[indices].reshape(-1, *value.shape[1:])
+
+        if len(value) != bbox_count:
+            return None
+        return value[indices]
 
     def _warn_unmatched(
-        self, field_name: str, found: str, bbox_count: int, bbox_field: str
+        self,
+        field_name: str,
+        value: np.ndarray,
+        bbox_count: int,
+        bbox_field: str,
     ) -> None:
         if field_name in self._mismatched_fields:
             return
         self._mismatched_fields.add(field_name)
         logger.warning(
-            f"Field '{field_name}' has {found} for {bbox_count} bounding "
-            f"boxes in '{bbox_field}', so the two cannot be matched up. "
-            f"Leaving it as is; it may end up misaligned with the bounding "
-            f"boxes that survive augmentation."
+            f"Field '{field_name}' with shape {value.shape} cannot be matched "
+            f"to the {bbox_count} bounding boxes in '{bbox_field}'; leaving "
+            f"it as is. It may end up misaligned with the boxes that survive "
+            f"augmentation."
         )
 
     @staticmethod

--- a/luxonis_ml/data/augmentations/custom/mixup.py
+++ b/luxonis_ml/data/augmentations/custom/mixup.py
@@ -14,8 +14,7 @@ def _column_count(batch: list[np.ndarray], default: int) -> int:
     """Column count to give empty entries so concatenation lines up.
 
     Albumentations sizes these rows differently depending on which optional
-    fields a pipeline uses, so the width is taken from a populated entry
-    rather than assumed.
+    fields a pipeline uses, so the width is read off a populated entry.
     """
     for array in batch:
         if array.size > 0 and array.ndim == 2:

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -454,8 +454,6 @@ class Mosaic4(BatchTransform):
                 ]
                 out_masks.append(combined_mask)
 
-        # Any mask with a nonzero size has at least one instance, so the
-        # guard above is the only way to end up with nothing to stack.
         return np.stack(out_masks, axis=-1)
 
     @staticmethod

--- a/tests/test_data/test_augmentations/helpers.py
+++ b/tests/test_data/test_augmentations/helpers.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from luxonis_ml.data.augmentations import BatchTransform
+
+
+class KeepFirstSample(BatchTransform):
+    """Passes the first sample's targets through untouched.
+
+    Lets a test see exactly what `BatchCompose` did to the data, without a
+    real transform rewriting the targets on the way through.
+    """
+
+    def __init__(self):
+        super().__init__(batch_size=2, p=1.0)
+
+    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
+        return image_batch[0]
+
+    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_instance_mask(
+        self, masks_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return masks_batch[0]
+
+    def apply_to_bboxes(
+        self, bboxes_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return bboxes_batch[0]
+
+    def apply_to_keypoints(
+        self, keypoints_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return keypoints_batch[0]
+
+    def apply_to_metadata(
+        self, metadata_batch: list[np.ndarray], **_
+    ) -> np.ndarray:
+        return metadata_batch[0]
+
+    def apply_to_array(self, array_batch: list[np.ndarray], **_) -> np.ndarray:
+        return array_batch[0]

--- a/tests/test_data/test_augmentations/label_strategies.py
+++ b/tests/test_data/test_augmentations/label_strategies.py
@@ -1,22 +1,19 @@
 """Hypothesis strategies for the label types the engine advertises.
 
-`AlbumentationsEngine` documents support for seven label types, spread over
-any number of task groups and image sources. The strategies here build
-*self-consistent* samples for arbitrary combinations of them: within one task
-group every per-instance label describes the same instances, so a generated
-sample is something `LuxonisLoader` could plausibly hand over.
+Samples are built *self-consistent*: within one task group every per-instance
+label describes the same instances, so a generated sample is something
+`LuxonisLoader` could plausibly hand over.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import numpy as np
 from hypothesis import strategies as st
 
 from luxonis_ml.typing import Labels
 
-# Every task type `AlbumentationsEngine` claims to handle. "metadata" is
-# spelled as a task-type suffix here and expanded to "metadata/<field>" when
-# the task string is built.
+# "metadata" is spelled as a bare task type here and expanded to
+# "metadata/<field>" when the task string is built.
 PER_INSTANCE_TASK_TYPES = [
     "boundingbox",
     "keypoints",
@@ -38,16 +35,17 @@ class TaskGroupSpec:
     n_classes: int
     n_keypoints: int
 
+    @staticmethod
+    def _suffix(task_type: str) -> str:
+        return "metadata/id" if task_type == "metadata" else task_type
+
     def task(self, task_type: str) -> str:
-        suffix = "metadata/id" if task_type == "metadata" else task_type
-        return f"{self.name}/{suffix}"
+        return f"{self.name}/{self._suffix(task_type)}"
 
     @property
     def tasks(self) -> dict[str, str]:
         return {
-            self.task(task_type): (
-                "metadata/id" if task_type == "metadata" else task_type
-            )
+            self.task(task_type): self._suffix(task_type)
             for task_type in self.task_types
         }
 
@@ -62,7 +60,7 @@ class SampleSpec:
     width: int
     image_height: int
     image_width: int
-    config: list[dict] = field(default_factory=list)
+    config: list[dict]
 
     @property
     def source_names(self) -> list[str]:
@@ -189,8 +187,10 @@ BATCH_CONFIGS = [
 
 
 @st.composite
-def sample_specs(draw: st.DrawFn, max_groups: int = 2) -> SampleSpec:
-    n_groups = draw(st.integers(min_value=1, max_value=max_groups))
+def sample_specs(
+    draw: st.DrawFn, min_groups: int = 1, max_groups: int = 2
+) -> SampleSpec:
+    n_groups = draw(st.integers(min_value=min_groups, max_value=max_groups))
     groups = [draw(task_groups(f"group{i}")) for i in range(n_groups)]
 
     n_sources = draw(st.integers(min_value=1, max_value=3))

--- a/tests/test_data/test_augmentations/test_batch_compose_internals.py
+++ b/tests/test_data/test_augmentations/test_batch_compose_internals.py
@@ -1,11 +1,3 @@
-"""Behaviour of `BatchCompose` on inputs the engine does not normally send.
-
-`BatchCompose` is exported, so it can be driven directly with bbox
-associations that do not line up with the data. These tests pin down what it
-does then: warn once and leave the data alone, rather than raise or silently
-regroup it.
-"""
-
 from collections.abc import Iterator
 
 import albumentations as A
@@ -16,6 +8,8 @@ from loguru import logger
 from luxonis_ml.data import AlbumentationsEngine
 from luxonis_ml.data.augmentations import BatchCompose, BatchTransform
 from luxonis_ml.typing import Labels
+
+from .helpers import KeepFirstSample
 
 IMAGE = np.zeros((16, 16, 3), dtype=np.uint8)
 
@@ -29,51 +23,11 @@ def warnings_log() -> Iterator[list[str]]:
     logger.remove(handler)
 
 
-class KeepFirstSample(BatchTransform):
-    """Keeps the first sample's targets exactly as they arrived.
-
-    Every target is passed through untouched so a test can see precisely what
-    `BatchCompose` itself did to the data.
-    """
-
-    def __init__(self):
-        super().__init__(batch_size=2, p=1.0)
-
-    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
-        return image_batch[0]
-
-    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_instance_mask(
-        self, masks_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_bboxes(
-        self, bboxes_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return bboxes_batch[0]
-
-    def apply_to_keypoints(
-        self, keypoints_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return keypoints_batch[0]
-
-    def apply_to_metadata(
-        self, metadata_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return metadata_batch[0]
-
-    def apply_to_array(self, array_batch: list[np.ndarray], **_) -> np.ndarray:
-        return array_batch[0]
-
-
 class PushFirstBoxOutOfFrame(KeepFirstSample):
     """Moves the first box outside the image so filtering drops it.
 
     Indices are stamped before filtering, so the surviving boxes then carry
-    non-contiguous indices - the state compaction exists to handle.
+    the non-contiguous indices that compaction exists to handle.
     """
 
     def apply_to_bboxes(
@@ -85,8 +39,6 @@ class PushFirstBoxOutOfFrame(KeepFirstSample):
 
 
 class ReturnsFlatBoxes(KeepFirstSample):
-    """Hands back a one-dimensional bbox array, which is never valid."""
-
     def apply_to_bboxes(self, _batch: list[np.ndarray], **_) -> np.ndarray:
         return np.array([1.0, 2.0, 3.0])
 
@@ -129,7 +81,6 @@ def test_batch_size_must_match_the_composition() -> None:
 
 
 def test_bbox_fields_absent_from_the_data_are_skipped() -> None:
-    """A declared association need not appear in every sample."""
     composition = compose({"bboxes": {"metadata": "metadata"}})
 
     output = composition(batch(metadata=np.array([1.0])))
@@ -161,17 +112,14 @@ def test_already_empty_associated_fields_are_left_alone() -> None:
 
 
 @pytest.mark.parametrize(
-    ("target_type", "value", "expected_message"),
+    ("target_type", "value"),
     [
-        ("instance_mask", np.ones((16, 16, 5), dtype=np.uint8), "5 instances"),
-        ("metadata", np.ones(5), "5 values"),
+        ("instance_mask", np.ones((16, 16, 5), dtype=np.uint8)),
+        ("metadata", np.ones(5)),
     ],
 )
 def test_unmatched_fields_warn_once_and_are_left_alone(
-    target_type: str,
-    value: np.ndarray,
-    expected_message: str,
-    warnings_log: list[str],
+    target_type: str, value: np.ndarray, warnings_log: list[str]
 ) -> None:
     """Counts that cannot be matched to boxes must not be regrouped."""
     composition = compose(
@@ -181,18 +129,16 @@ def test_unmatched_fields_warn_once_and_are_left_alone(
 
     output = composition(batch(bboxes=boxes(2), label=value))
 
-    assert np.array_equal(output["label"], original), (
-        "an unmatched field must be passed through untouched"
-    )
+    assert np.array_equal(output["label"], original)
     warned = "".join(warnings_log)
-    assert expected_message in warned
-    assert "cannot be matched up" in warned
+    assert f"shape {value.shape}" in warned
+    assert "cannot be matched" in warned
 
 
 def test_unmatched_keypoints_warn_and_are_left_alone(
     warnings_log: list[str],
 ) -> None:
-    """Keypoint rows must be exactly ``bbox_count * n_keypoints``."""
+    """Keypoint rows must number exactly ``bbox_count * n_keypoints``."""
     composition = compose(
         {"bboxes": {"label": "keypoints"}}, {"label": "keypoints"}
     )
@@ -204,7 +150,7 @@ def test_unmatched_keypoints_warn_and_are_left_alone(
     )
 
     assert output["label"].shape[0] == 5
-    assert "5 keypoint rows" in "".join(warnings_log)
+    assert "cannot be matched" in "".join(warnings_log)
 
 
 def test_keypoints_without_a_known_count_are_left_alone(
@@ -218,7 +164,7 @@ def test_keypoints_without_a_known_count_are_left_alone(
 
     composition(batch(bboxes=boxes(2), label=keypoints))
 
-    assert "cannot be matched up" in "".join(warnings_log)
+    assert "cannot be matched" in "".join(warnings_log)
 
 
 def test_the_same_field_only_warns_once(warnings_log: list[str]) -> None:
@@ -229,11 +175,10 @@ def test_the_same_field_only_warns_once(warnings_log: list[str]) -> None:
     composition(batch(bboxes=boxes(2), label=np.ones(5)))
     composition(batch(bboxes=boxes(2), label=np.ones(5)))
 
-    assert "".join(warnings_log).count("cannot be matched up") == 1
+    assert "".join(warnings_log).count("cannot be matched") == 1
 
 
 def test_make_contiguous_leaves_non_arrays_alone() -> None:
-    """Not every value in the data dict is a numpy array."""
     data = {"image": np.zeros((4, 4))[::2], "note": "kept as is"}
 
     out = BatchCompose._make_contiguous(data)  # type: ignore[arg-type]
@@ -272,5 +217,5 @@ def test_labels_emptied_by_a_spatial_transform_are_reported_empty() -> None:
         [({"image": np.zeros((16, 16, 3), dtype=np.uint8)}, labels)]
     )
 
-    assert out_labels.get("task/boundingbox", np.zeros((0, 5))).shape[0] == 0
-    assert out_labels.get("task/metadata/id", np.zeros(0)).shape[0] == 0
+    assert "task/boundingbox" not in out_labels
+    assert out_labels["task/metadata/id"].shape[0] == 0

--- a/tests/test_data/test_augmentations/test_batched.py
+++ b/tests/test_data/test_augmentations/test_batched.py
@@ -1,13 +1,14 @@
 from copy import deepcopy
-from typing import Any, cast
 
 import albumentations as A
 import numpy as np
 import pytest
 
 from luxonis_ml.data import AlbumentationsEngine
-from luxonis_ml.data.augmentations import BatchCompose, BatchTransform, MixUp
+from luxonis_ml.data.augmentations import BatchCompose, MixUp
 from luxonis_ml.typing import Labels
+
+from .helpers import KeepFirstSample
 
 
 def assert_boxes_match_masks(
@@ -15,11 +16,10 @@ def assert_boxes_match_masks(
 ) -> None:
     """Assert every instance mask is paired with the correct bounding box.
 
-    Box and instance mask undergo the same geometric transforms, so a
-    correctly paired mask always has its nonzero pixels inside its box.
-    A reindexing bug that scrambles the box-to-mask mapping (e.g. pairing a
-    box with a mask blob located elsewhere in the image) is caught here even
-    when the row counts still match.
+    Box and mask undergo the same geometric transforms, so a correctly
+    paired mask always has its nonzero pixels inside its box. This catches
+    a reindexing bug that scrambles the mapping even when the row counts
+    still line up.
     """
     assert boxes.shape[0] == masks.shape[0]
     _, height, width = masks.shape
@@ -30,12 +30,12 @@ def assert_boxes_match_masks(
         cy = ys.mean() / height
         x, y, w, h = box[1:5]
         assert x - tol <= cx <= x + w + tol, (
-            f"instance {i}: mask centroid x={cx:.3f} outside box "
-            f"[{x:.3f}, {x + w:.3f}] — box paired with the wrong mask"
+            f"instance {i} is paired with the wrong mask: centroid "
+            f"x={cx:.3f} outside box [{x:.3f}, {x + w:.3f}]"
         )
         assert y - tol <= cy <= y + h + tol, (
-            f"instance {i}: mask centroid y={cy:.3f} outside box "
-            f"[{y:.3f}, {y + h:.3f}] — box paired with the wrong mask"
+            f"instance {i} is paired with the wrong mask: centroid "
+            f"y={cy:.3f} outside box [{y:.3f}, {y + h:.3f}]"
         )
 
 
@@ -213,7 +213,6 @@ def test_batched_p_0(
 
 
 def test_batch_compose_without_bbox_params() -> None:
-    """BatchCompose remains usable for image-only batch transformations."""
     first = np.zeros((8, 8, 3), dtype=np.uint8)
     second = np.ones((8, 8, 3), dtype=np.uint8)
     compose = BatchCompose([MixUp(p=0)])
@@ -295,11 +294,9 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
 ) -> None:
     """Boxes dropped by ``min_bbox_visibility`` must not scramble masks.
 
-    When a batch transform (here Mosaic4) crops instances so some boxes fall
-    below the visibility threshold, ``check_data_post_transform`` drops those
-    boxes while every instance-mask channel remains. The surviving boxes must
-    still be paired with their own masks; reindexing them to a contiguous
-    range after the drop would silently pair them with the wrong masks.
+    ``check_data_post_transform`` drops the boxes Mosaic4 cropped below the
+    threshold while every instance-mask channel remains. Reindexing the
+    survivors to a contiguous range would pair them with the wrong masks.
     """
     image = np.zeros((320, 320, 3), dtype=np.uint8)
     # Four instances in the four corners, each mask centered in its box.
@@ -309,10 +306,9 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
     def make_labels(sample: int) -> Labels:
         """Build one sample whose per-instance ids are unique batch-wide.
 
-        Repeating the same ids in every batch member would make the value
-        oracles below hold under any permutation that maps instance *i* of
-        one sample onto instance *i* of another, which is exactly the kind
-        of wrong pairing compaction can introduce.
+        Reusing ids across batch members would let the checks below pass
+        under a permutation mapping instance *i* of one sample onto
+        instance *i* of another - exactly the mispairing they look for.
         """
         instance_mask = np.zeros((4, 320, 320), dtype=np.uint8)
         boxes_in = []
@@ -387,7 +383,6 @@ def test_mosaic_drops_boxes_keeps_masks_aligned(
 
 
 def test_batch_transforms_keep_nested_task_groups_independent() -> None:
-    """Associated labels from nested task groups must not be compacted together."""
 
     def make_mask(
         instances: list[tuple[int, float, float]], size: int = 64
@@ -469,7 +464,6 @@ def test_batch_transforms_keep_nested_task_groups_independent() -> None:
 
 
 def test_standalone_labels_survive_bboxes_from_another_task_group() -> None:
-    """A bbox task must not filter standalone labels from another task group."""
     targets = {
         "detection/boundingbox": "boundingbox",
         "pose/keypoints": "keypoints",
@@ -511,10 +505,8 @@ def test_standalone_labels_survive_bboxes_from_another_task_group() -> None:
 def test_compaction_handles_all_filtered_bboxes() -> None:
     """Associated labels stay present but empty when no bbox survives.
 
-    Driven end to end rather than by calling the compaction helper, so it
-    covers how ``bbox_counts`` is derived and how the emptied labels travel
-    back out through postprocessing. Dropping the task keys entirely would
-    let ``LuxonisLoader._add_empty_annotations`` refill metadata with
+    Dropping the task keys entirely would let
+    ``LuxonisLoader._add_empty_annotations`` refill metadata with
     ``n_classes`` phantom rows.
     """
     targets = {
@@ -536,41 +528,35 @@ def test_compaction_handles_all_filtered_bboxes() -> None:
         "task/metadata/id": np.array([7]),
     }
 
-    all_filtered_seen = False
-    for seed in range(10):
-        augmentations = AlbumentationsEngine(
-            64,
-            64,
-            targets,
-            dict.fromkeys(targets, 1),
-            ["image"],
-            [
-                {
-                    "name": "Mosaic4",
-                    "params": {"p": 1.0, "height": 64, "width": 64},
-                },
-                {"name": "MixUp", "params": {"p": 1.0}},
-            ],
-            min_bbox_visibility=1.0,
-            seed=seed,
-        )
-        _, output = augmentations.apply(
-            [({"image": image}, deepcopy(labels)) for _ in range(8)]
-        )
+    augmentations = AlbumentationsEngine(
+        64,
+        64,
+        targets,
+        dict.fromkeys(targets, 1),
+        ["image"],
+        [
+            {
+                "name": "Mosaic4",
+                "params": {"p": 1.0, "height": 64, "width": 64},
+            },
+            {"name": "MixUp", "params": {"p": 1.0}},
+        ],
+        min_bbox_visibility=1.0,
+        seed=0,
+    )
 
-        if output.get("task/boundingbox", np.zeros((0, 5))).shape[0]:
-            continue
+    _, output = augmentations.apply(
+        [({"image": image}, deepcopy(labels)) for _ in range(8)]
+    )
 
-        all_filtered_seen = True
-        # The bbox task itself is dropped, as it always has been; the loader
-        # refills it with a correctly shaped empty array. The labels hanging
-        # off it are the ones that must not disappear.
-        assert output["task/instance_segmentation"].shape == (0, 64, 64)
-        assert output["task/keypoints"].shape == (0, 3)
-        assert output["task/array"].shape == (0, 2)
-        assert output["task/metadata/id"].shape == (0,)
-
-    assert all_filtered_seen, "no seed produced the all-filtered case"
+    # The bbox task itself is dropped, as it always has been; the loader
+    # refills it with a correctly shaped empty array. The labels hanging off
+    # it are the ones that must not disappear.
+    assert "task/boundingbox" not in output
+    assert output["task/instance_segmentation"].shape == (0, 64, 64)
+    assert output["task/keypoints"].shape == (0, 3)
+    assert output["task/array"].shape == (0, 2)
+    assert output["task/metadata/id"].shape == (0,)
 
 
 def test_instance_masks_without_bboxes_in_their_task_group() -> None:
@@ -602,11 +588,7 @@ def test_instance_masks_without_bboxes_in_their_task_group() -> None:
 
 
 def test_bbox_label_column_is_left_alone_without_associations() -> None:
-    """Plain Albumentations use keeps its class column.
-
-    Without ``bbox_associations`` the trailing bbox column is the class
-    label, not an index, so the composition must not restamp it.
-    """
+    """Without ``bbox_associations`` the trailing column is a class label."""
     compose = BatchCompose(
         [MixUp(p=1.0)],
         bbox_params=A.BboxParams(format="albumentations"),
@@ -626,47 +608,7 @@ def test_bbox_label_column_is_left_alone_without_associations() -> None:
     assert sorted(output["bboxes"][:, -1].tolist()) == [7.0, 7.0, 9.0, 9.0]
 
 
-def test_bbox_params_cannot_be_passed_positionally() -> None:
-    """``bbox_associations`` must not occupy ``A.Compose``'s second slot."""
-    untyped_compose = cast(Any, BatchCompose)
-    with pytest.raises(TypeError):
-        untyped_compose([MixUp(p=1.0)], A.BboxParams(format="albumentations"))
-
-
-class KeepFirstSample(BatchTransform):
-    """Batch transform that keeps the first sample's targets untouched.
-
-    Lets a test observe what `BatchCompose` itself does to the data,
-    without a real transform rewriting the targets on the way through.
-    """
-
-    def __init__(self):
-        super().__init__(batch_size=2, p=1.0)
-
-    def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
-        return image_batch[0]
-
-    def apply_to_mask(self, masks_batch: list[np.ndarray], **_) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_instance_mask(
-        self, masks_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return masks_batch[0]
-
-    def apply_to_bboxes(
-        self, bboxes_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return bboxes_batch[0]
-
-    def apply_to_keypoints(
-        self, keypoints_batch: list[np.ndarray], **_
-    ) -> np.ndarray:
-        return keypoints_batch[0]
-
-
 def test_read_only_bboxes_are_not_mutated_in_place() -> None:
-    """Reindexing must not write into a caller's read-only buffer."""
     boxes = np.array([[0.1, 0.1, 0.3, 0.3, 0.0, 5.0]])
     boxes.setflags(write=False)
     compose = BatchCompose(
@@ -691,11 +633,7 @@ def test_read_only_bboxes_are_not_mutated_in_place() -> None:
 
 
 def test_associations_are_kept_when_bboxes_are_not_processed() -> None:
-    """A missing bbox processor must not be read as "every bbox was cut".
-
-    Without ``bbox_params`` there is no bbox count to compare against, which
-    is not the same thing as a count of zero.
-    """
+    """Having no bbox count to compare against is not a count of zero."""
     compose = BatchCompose(
         [MixUp(p=1.0)],
         bbox_associations={"bboxes": {"metadata": "metadata"}},

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -1,11 +1,4 @@
-"""Tests for how `AlbumentationsEngine` validates its configuration.
-
-Covers the rejections the constructor documents, the way transforms are
-sorted into pipeline stages, and the multi-source pixel-transform replay.
-"""
-
-from collections.abc import Iterator
-from typing import Any
+from collections.abc import Callable, Iterator
 
 import albumentations as A
 import numpy as np
@@ -16,9 +9,11 @@ from luxonis_ml.data.augmentations import AugmentationEngine
 from luxonis_ml.data.augmentations.custom import TRANSFORMATIONS
 from luxonis_ml.typing import Labels, LoaderMultiOutput
 
+Register = Callable[[type], type]
+
 
 @pytest.fixture
-def register_transform() -> Iterator[Any]:
+def register_transform() -> Iterator[Register]:
     """Register transforms for one test and drop them again afterwards."""
     registered: list[str] = []
 
@@ -31,6 +26,7 @@ def register_transform() -> Iterator[Any]:
     yield _register
 
     for name in registered:
+        # `Registry` has no public way to drop an entry again.
         TRANSFORMATIONS._module_dict.pop(name, None)
 
 
@@ -49,7 +45,7 @@ def build(
 
 
 def test_engines_default_to_using_every_input_position() -> None:
-    """An engine that does not track contributors is assumed to use all of them."""
+    """An engine that does not track contributors is assumed to use all."""
 
     class UntrackedEngine(
         AugmentationEngine, register_name="untracked_engine"
@@ -95,10 +91,9 @@ def test_only_one_resizing_augmentation_is_allowed() -> None:
 
 @pytest.mark.parametrize("probability", ["1.0", True])
 def test_resizing_probability_must_be_numeric(probability: object) -> None:
-    """Values Albumentations coerces but the resize logic cannot use.
+    """``p=None`` never reaches this check.
 
-    ``p=None`` never reaches this check: Albumentations rejects it while the
-    transform is being constructed.
+    Albumentations rejects it while the transform is being constructed.
     """
     config = [
         {
@@ -136,7 +131,7 @@ def test_certain_resize_is_used_directly() -> None:
 
 
 def test_plain_basic_transforms_run_as_custom_transforms(
-    register_transform: Any,
+    register_transform: Register,
 ) -> None:
     """A bare ``BasicTransform`` is neither pixel, spatial, nor batch."""
     seen: list[int] = []
@@ -151,10 +146,9 @@ def test_plain_basic_transforms_run_as_custom_transforms(
             seen.append(1)
             return img
 
-    assert CountingBasicTransform.__name__ in TRANSFORMATIONS
     engine = build(
         {"task/boundingbox": "boundingbox"},
-        [{"name": "CountingBasicTransform", "params": {"p": 1.0}}],
+        [{"name": CountingBasicTransform.__name__, "params": {"p": 1.0}}],
     )
     engine.apply(
         [
@@ -168,18 +162,19 @@ def test_plain_basic_transforms_run_as_custom_transforms(
     assert seen, "the custom transform stage never ran"
 
 
-def test_non_transform_classes_are_rejected(register_transform: Any) -> None:
+def test_non_transform_classes_are_rejected(
+    register_transform: Register,
+) -> None:
     @register_transform
     class NotATransform:
         def __init__(self, **_): ...
 
-    assert NotATransform.__name__ in TRANSFORMATIONS
     with pytest.raises(
         ValueError, match="Unsupported transformation type: 'NotATransform'"
     ):
         build(
             {"task/boundingbox": "boundingbox"},
-            [{"name": "NotATransform", "params": {}}],
+            [{"name": NotATransform.__name__, "params": {}}],
         )
 
 
@@ -221,7 +216,6 @@ def test_unnamed_tasks_are_usable_end_to_end() -> None:
 
 
 def test_pixel_transforms_replay_across_every_image_source() -> None:
-    """One sampled pixel transform must hit all sources identically."""
     sources = ["rgb", "depth", "ir"]
     engine = AlbumentationsEngine(
         32,
@@ -246,7 +240,6 @@ def test_pixel_transforms_replay_across_every_image_source() -> None:
 
 
 def test_pixel_replay_skips_sources_without_a_channel_axis() -> None:
-    """A 2D source cannot be replayed through an RGB pixel transform."""
     engine = AlbumentationsEngine(
         16,
         16,
@@ -276,7 +269,6 @@ def test_pixel_replay_skips_sources_without_a_channel_axis() -> None:
 
 
 def test_wrapped_transforms_tolerate_a_missing_image_key() -> None:
-    """The wrapper only restores the original key when there was one."""
     wrapped = AlbumentationsEngine._wrap_transform(
         A.Compose([A.HorizontalFlip(p=1.0)])
     )
@@ -296,7 +288,6 @@ def test_pixel_transform_wrapper_needs_source_names() -> None:
 
 
 def test_grayscale_sources_keep_a_channel_axis() -> None:
-    """A 2D image coming out of a transform is restored to (H, W, 1)."""
     engine = AlbumentationsEngine(
         16,
         16,

--- a/tests/test_data/test_augmentations/test_label_combinations.py
+++ b/tests/test_data/test_augmentations/test_label_combinations.py
@@ -1,13 +1,3 @@
-"""Property tests over every advertised label type and combination.
-
-`AlbumentationsEngine` documents support for seven label types across any
-number of task groups and image sources. These tests generate combinations of
-them and check the invariants that hold no matter which combination came up,
-rather than pinning one hand-written example per feature.
-
-Runs are derandomized so a failure is reproducible from the test id alone.
-"""
-
 from copy import deepcopy
 
 import numpy as np
@@ -20,6 +10,7 @@ from luxonis_ml.typing import Labels
 
 from .label_strategies import (
     ALL_TASK_TYPES,
+    BATCH_CONFIGS,
     PER_INSTANCE_TASK_TYPES,
     SampleSpec,
     TaskGroupSpec,
@@ -27,6 +18,7 @@ from .label_strategies import (
     sample_specs,
 )
 
+# Derandomized so that a failure is reproducible from the test id alone.
 combination_settings = settings(
     max_examples=150,
     deadline=None,
@@ -83,12 +75,9 @@ def assert_group_is_consistent(
 @given(spec=sample_specs())
 @combination_settings
 def test_any_label_combination_round_trips(spec: SampleSpec) -> None:
-    """Any combination of advertised labels survives any advertised pipeline."""
     out_images, out_labels = run(spec)
 
-    assert set(out_images) == set(spec.source_names), (
-        "every image source must come back out"
-    )
+    assert set(out_images) == set(spec.source_names)
     for name, image in out_images.items():
         assert image.shape[:2] == (spec.height, spec.width), (
             f"source '{name}' was not resized to the requested output size"
@@ -102,11 +91,7 @@ def test_any_label_combination_round_trips(spec: SampleSpec) -> None:
 
         if "segmentation" in group.task_types:
             mask = out_labels[group.task("segmentation")]
-            assert mask.shape == (
-                group.n_classes,
-                spec.height,
-                spec.width,
-            ), "semantic mask must keep one channel per class"
+            assert mask.shape == (group.n_classes, spec.height, spec.width)
 
         if "classification" in group.task_types:
             classes = out_labels[group.task("classification")]
@@ -125,9 +110,6 @@ def test_instances_never_outnumber_their_bboxes(spec: SampleSpec) -> None:
         boxes = out_labels.get(group.task("boundingbox"))
         if boxes is None:
             continue
-        assert boxes.shape[0] <= group.n_instances * 8, (
-            "a batch transform must not invent instances beyond the batch"
-        )
         for task_type in PER_INSTANCE_TASK_TYPES:
             if task_type not in group.task_types:
                 continue
@@ -142,15 +124,13 @@ def test_instances_never_outnumber_their_bboxes(spec: SampleSpec) -> None:
 
 @given(
     task_type=st.sampled_from(ALL_TASK_TYPES),
-    config_index=st.integers(min_value=0, max_value=7),
+    config=st.sampled_from(BATCH_CONFIGS),
 )
 @combination_settings
 def test_every_label_type_works_on_its_own(
-    task_type: str, config_index: int
+    task_type: str, config: list[dict]
 ) -> None:
     """Each advertised label type is usable as the only label in a dataset."""
-    from .label_strategies import BATCH_CONFIGS
-
     spec = SampleSpec(
         groups=[
             TaskGroupSpec(
@@ -166,7 +146,7 @@ def test_every_label_type_works_on_its_own(
         width=64,
         image_height=64,
         image_width=64,
-        config=BATCH_CONFIGS[config_index],
+        config=config,
     )
 
     _, out_labels = run(spec)
@@ -178,13 +158,10 @@ def test_every_label_type_works_on_its_own(
     )
 
 
-@given(spec=sample_specs(max_groups=3))
+@given(spec=sample_specs(min_groups=2, max_groups=3))
 @combination_settings
 def test_task_groups_do_not_interfere(spec: SampleSpec) -> None:
     """Adding a task group must not change what the other groups return."""
-    if len(spec.groups) < 2:
-        return
-
     _, combined = run(spec)
 
     for group in spec.groups:

--- a/tests/test_data/test_augmentations/test_transform_internals.py
+++ b/tests/test_data/test_augmentations/test_transform_internals.py
@@ -1,19 +1,14 @@
-"""Edge cases in the built-in batch transforms and keypoint flips.
-
-Batch transforms are handed whatever the loader produced, which includes
-samples missing a label entirely and grayscale sources with no channel axis.
-These are the branches that only such inputs reach.
-"""
-
 import numpy as np
 import pytest
 
-from luxonis_ml.data.augmentations import BatchTransform, MixUp, Mosaic4
+from luxonis_ml.data.augmentations import MixUp, Mosaic4
 from luxonis_ml.data.augmentations.custom import (
     HorizontalSymmetricKeypointsFlip,
     TransposeSymmetricKeypoints,
     VerticalSymmetricKeypointsFlip,
 )
+
+from .helpers import KeepFirstSample
 
 SHAPES = [(16, 16), (16, 16)]
 
@@ -72,11 +67,7 @@ def test_mixup_instance_mask_tolerates_a_missing_mask(
 
 
 def test_mixup_masks_regain_a_channel_axis_after_resize() -> None:
-    """A resized (H, W) mask is promoted back to (H, W, 1) before merging.
-
-    Only the plain-resize path can hand back a mask with no channel axis;
-    `LetterboxResize` always keeps one.
-    """
+    """Only the plain-resize path drops it; `LetterboxResize` keeps one."""
     masks = [
         np.ones((16, 16, 1), dtype=np.uint8),
         np.ones((8, 8), dtype=np.uint8),
@@ -124,7 +115,6 @@ def test_mosaic_semantic_mask_fills_in_missing_masks(ndim: int) -> None:
 
 
 def test_mosaic_instance_masks_with_nothing_to_place() -> None:
-    """Zero instances across the whole batch yields a zero-instance mask."""
     output = Mosaic4._apply_mosaic4_to_instance_masks(
         [np.array([]) for _ in range(4)],
         out_height=16,
@@ -148,35 +138,9 @@ def test_mosaic_composes_images_without_a_channel_axis() -> None:
 
 def test_classification_defaults_to_a_single_absent_class() -> None:
     """Samples missing a classification task must not break the OR."""
-
-    class Merge(BatchTransform):
-        def __init__(self):
-            super().__init__(batch_size=2, p=1.0)
-
-        def apply(self, image_batch: list[np.ndarray], **_) -> np.ndarray:
-            return image_batch[0]
-
-        def apply_to_mask(
-            self, masks_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return masks_batch[0]
-
-        def apply_to_instance_mask(
-            self, masks_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return masks_batch[0]
-
-        def apply_to_bboxes(
-            self, bboxes_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return bboxes_batch[0]
-
-        def apply_to_keypoints(
-            self, keypoints_batch: list[np.ndarray], **_
-        ) -> np.ndarray:
-            return keypoints_batch[0]
-
-    output = Merge().apply_to_classification([np.array([]), np.array([1.0])])
+    output = KeepFirstSample().apply_to_classification(
+        [np.array([]), np.array([1.0])]
+    )
 
     assert output.tolist() == [1.0]
 
@@ -184,23 +148,20 @@ def test_classification_defaults_to_a_single_absent_class() -> None:
 @pytest.mark.parametrize("flip", FLIPS)
 def test_flips_pass_empty_bboxes_through(flip: type) -> None:
     transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
-    bboxes = np.zeros((0, 4))
 
-    assert transform.apply_to_bboxes(
-        bboxes, orig_width=8, orig_height=8
-    ).shape == (
-        0,
-        4,
+    output = transform.apply_to_bboxes(
+        np.zeros((0, 4)), orig_width=8, orig_height=8
     )
+
+    assert output.shape == (0, 4)
 
 
 @pytest.mark.parametrize("flip", FLIPS)
 def test_flips_pass_empty_keypoints_through(flip: type) -> None:
     transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
-    keypoints = np.zeros((0, 3))
 
     output = transform.apply_to_keypoints(
-        keypoints, orig_width=8, orig_height=8
+        np.zeros((0, 3)), orig_width=8, orig_height=8
     )
 
     assert output.shape == (0, 3)
@@ -208,7 +169,6 @@ def test_flips_pass_empty_keypoints_through(flip: type) -> None:
 
 @pytest.mark.parametrize("flip", FLIPS)
 def test_flips_reject_a_partial_final_instance(flip: type) -> None:
-    """Keypoint rows must divide evenly into instances to be swapped."""
     transform = flip(keypoint_pairs=[(0, 1)], p=1.0)
     keypoints = np.zeros((3, 3))
 

--- a/tests/test_data/test_augmentations/test_utils.py
+++ b/tests/test_data/test_augmentations/test_utils.py
@@ -1,10 +1,3 @@
-"""Tests for the LDF <-> Albumentations boundary conversions.
-
-These functions are where label layouts change shape, so they are covered
-both by explicit shape cases and by round-trip properties: converting a label
-out and straight back must return what went in.
-"""
-
 import numpy as np
 import pytest
 from hypothesis import given, settings
@@ -21,7 +14,7 @@ from luxonis_ml.data.augmentations.utils import (
     yield_batches,
 )
 
-round_trip = settings(max_examples=100, deadline=None, derandomize=True)
+property_settings = settings(max_examples=100, deadline=None, derandomize=True)
 
 # Coordinates kept clear of the image border so that no keypoint is clipped
 # or marked invisible on the way back.
@@ -49,7 +42,7 @@ def test_postprocess_mask_moves_channels_first() -> None:
     height=st.integers(min_value=1, max_value=8),
     width=st.integers(min_value=1, max_value=8),
 )
-@round_trip
+@property_settings
 def test_mask_round_trip(n_channels: int, height: int, width: int) -> None:
     mask = np.arange(n_channels * height * width, dtype=np.uint8).reshape(
         n_channels, height, width
@@ -59,7 +52,6 @@ def test_mask_round_trip(n_channels: int, height: int, width: int) -> None:
 
 
 def test_postprocess_bboxes_handles_no_boxes() -> None:
-    """An empty bbox array still has to yield usable output shapes."""
     boxes, ordering = postprocess_bboxes(np.zeros((0, 6)))
 
     assert boxes.shape == (0, 5)
@@ -94,7 +86,7 @@ def test_preprocess_bboxes_appends_an_index_column() -> None:
     h=st.floats(min_value=0.05, max_value=0.1),
     class_id=st.integers(min_value=0, max_value=5),
 )
-@round_trip
+@property_settings
 def test_bbox_round_trip(
     x: float, y: float, w: float, h: float, class_id: int
 ) -> None:
@@ -140,7 +132,7 @@ def test_postprocess_keypoints_reorders_by_surviving_bboxes() -> None:
     size=st.integers(min_value=16, max_value=64),
     coords=st.data(),
 )
-@round_trip
+@property_settings
 def test_keypoint_round_trip(
     n_instances: int, n_keypoints: int, size: int, coords: st.DataObject
 ) -> None:
@@ -174,11 +166,10 @@ def test_keypoint_round_trip(
         elements=st.floats(-5, 5, allow_nan=False, allow_infinity=False),
     )
 )
-@round_trip
+@property_settings
 def test_postprocess_keypoints_never_leaves_the_image(
     keypoints: np.ndarray,
 ) -> None:
-    """Coordinates are always clipped into the normalized unit square."""
     out = postprocess_keypoints(
         keypoints, np.arange(keypoints.shape[0]), 10, 10, 1
     )
@@ -199,7 +190,7 @@ def test_yield_batches_groups_by_key() -> None:
     n_samples=st.integers(min_value=1, max_value=10),
     batch_size=st.integers(min_value=1, max_value=5),
 )
-@round_trip
+@property_settings
 def test_yield_batches_covers_every_sample_once(
     n_samples: int, batch_size: int
 ) -> None:
@@ -217,7 +208,6 @@ def test_yield_batches_covers_every_sample_once(
 def test_postprocess_keypoints_keeps_annotation_grouping(
     n_keypoints: int,
 ) -> None:
-    """Rows are regrouped so each output row is one annotation."""
     n_instances = 3
     keypoints = np.zeros((n_instances * n_keypoints, 3))
 


### PR DESCRIPTION
Readability pass over `fix/batched-augs`. **No behaviour change** — targeted at `fix/batched-augs` so the diff shows only this pass.

Net **−199 lines** (+217/−416). Tests: 195 passed, matching the branch baseline of 196 minus the one deleted test; the same 3 `test_loader.py` failures are pre-existing and caused by missing `GOOGLE_APPLICATION_CREDENTIALS`. `pre-commit run` and `pyright --warnings --level warning --pythonversion 3.10` are both clean.

## Source

- **`_compact_bbox_associated_labels`** had three near-identical branches, each with its own count check, its own 4-line `_warn_unmatched` call and its own `continue`. Extracted `_select_instances`, which returns `None` when a field cannot be matched to its boxes, leaving one warn call site. The warning now reports the field's shape instead of a pre-formatted English fragment (`"5 instances"` / `"5 values"` / `"5 keypoint rows"`) picked per target type.
- **`_get_task_group`** was an `endswith`/`else: return ""` branch; it is now a `removesuffix` pair. Checked equivalent against the old implementation over 4680 generated task strings, including malformed ones.
- The new bbox-grouping block had been **inserted between an existing comment and the `catch_warnings` statement it describes**; moved back together.
- Named `ASSOCIATED_TARGET_TYPES` instead of inlining the set literal, and renamed `bbox_target`/`bbox_type` (the loop walks *all* targets, not just bboxes).
- Dropped a comment in `mosaic.py` referring to "the guard above" 60 lines away.

## Tests

The strongest tell was documentation style. No test file on `main` has a module docstring (0/14) and about 1 in 18 tests has one at all; this branch added 7 module docstrings and ~50 test docstrings, many restating the test name. Removed those, kept the ones recording a real failure mode.

- One shared `KeepFirstSample` in `helpers.py` replaces three near-copies across three files.
- `test_compaction_handles_all_filtered_bboxes` looped over 10 seeds with an `all_filtered_seen` flag, `continue`, and a final assert that the case was ever reached — every seed in that range hits it, so it is now a single deterministic run.
- `test_task_groups_do_not_interfere` returned early whenever fewer than 2 groups were drawn, silently passing on most examples; it now requires 2 via `sample_specs(min_groups=2)`.
- `test_every_label_type_works_on_its_own` sampled a config *index* bounded by a magic `7` and re-imported `BATCH_CONFIGS` inside the test body while the same module was imported at the top; it now samples the list directly.
- Deleted `test_bbox_params_cannot_be_passed_positionally`, which used `cast(Any, ...)` to defeat the type checker in order to assert that Python rejects a positional keyword-only argument.
- Replaced `out_labels.get(key, np.zeros(...)).shape[0] == 0` with assertions on what the output actually contains.
- Removed `assert SomeClass.__name__ in TRANSFORMATIONS` lines that checked the fixture rather than the code under test.

## One judgement call worth review

I dropped `assert boxes.shape[0] <= group.n_instances * 8` from `test_instances_never_outnumber_their_bboxes`. The `8` was the max batch size, unrelated to the invariant the test is named for, and the remaining assertion covers that invariant. Happy to restore it with the bound derived from `engine.batch_size` if you'd rather keep the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)