### PR TITLE
Hash files in chunks when computing UUIDs

### DIFF
--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -1,3 +1,5 @@
+import binascii
+import hashlib
 import os.path as osp
 import shutil
 import subprocess
@@ -12,7 +14,7 @@ from importlib.util import find_spec
 from io import BytesIO
 from pathlib import Path, PurePosixPath
 from types import ModuleType
-from typing import Any, Final, Literal, Protocol, cast, overload
+from typing import IO, Any, Final, Literal, Protocol, cast, overload
 
 import fsspec
 from loguru import logger
@@ -39,6 +41,10 @@ class PutFile(Protocol):
 PUT_FILE_REGISTRY: Final[Registry[PutFile]] = Registry(  # type: ignore
     name="put_file",
 )
+
+# Bounds the memory a single UUID computation uses. Each chunk is hex
+# encoded, so the transient cost is twice this, per concurrent call.
+_UUID_CHUNK_SIZE: Final = 1 << 20
 
 
 class FSType(Enum):
@@ -834,19 +840,23 @@ class LuxonisFileSystem:
             ValueError: If using MLflow and either no relative artifact
                 path is specified or the run cannot be resolved.
 
+        Note:
+            The file is hashed in chunks, so memory use does not grow
+            with its size. MLflow is the exception: its artifacts are
+            downloaded through ``read_to_byte_buffer``, which holds the
+            whole file in memory before hashing begins.
+
         """
 
         if local:
-            with open(path, "rb") as f:
-                file_contents = cast(bytes, f.read())
-        elif self.is_mlflow:
-            file_contents = self.read_to_byte_buffer(str(path)).read()
-        else:
-            download_path = str(self._path / path)
-            with self._fs.open(download_path, "rb") as f:
-                file_contents = cast(bytes, f.read())
+            with open(path, "rb") as file:
+                return _uuid_from_stream(file)
 
-        return str(uuid.uuid5(uuid.NAMESPACE_URL, file_contents.hex()))
+        if self.is_mlflow:
+            return _uuid_from_stream(self.read_to_byte_buffer(str(path)))
+
+        with self._fs.open(str(self._path / path), "rb") as file:
+            return _uuid_from_stream(cast(IO[bytes], file))
 
     def get_file_uuids(
         self, paths: Iterable[PathType], local: bool = False
@@ -861,6 +871,10 @@ class LuxonisFileSystem:
 
         Returns:
             Dictionary mapping paths to their UUIDs.
+
+        Note:
+            The files are hashed concurrently, so the memory bound of
+            ``get_file_uuid`` applies once per thread in the pool.
 
         """
 
@@ -1474,6 +1488,37 @@ def _get_protocol_and_path(path: str) -> tuple[str, str | None]:
         protocol = "file"
 
     return protocol, path or None
+
+
+def _uuid_from_stream(stream: IO[bytes]) -> str:
+    """Compute a file's UUID without holding the file in memory.
+
+    ``uuid.uuid5(namespace, name)`` is defined as
+    ``sha1(namespace.bytes + name.encode())``, truncated to 16 bytes and
+    stamped with the version, and the ``name`` used here is the hex of
+    the file's bytes. Hex encodes each byte on its own, so the hex of a
+    concatenation is the concatenation of the hexes -- feeding the hash
+    chunk by chunk therefore produces the exact same digest as hashing
+    the whole file at once.
+
+    Preserving the digest is the entire constraint: these UUIDs are the
+    identity of every file in a dataset, so a value that merely looked
+    reasonable would silently orphan existing data.
+
+    Args:
+        stream: Binary stream positioned at the start of the file.
+
+    Returns:
+        UUID generated from the file bytes.
+
+    """
+    # NOTE: Not a security hash -- this reproduces `uuid.uuid5`, whose
+    # algorithm is fixed by RFC 4122. The flag keeps it working where
+    # SHA-1 is disabled for security use, such as FIPS mode.
+    digest = hashlib.sha1(uuid.NAMESPACE_URL.bytes, usedforsecurity=False)
+    while chunk := stream.read(_UUID_CHUNK_SIZE):
+        digest.update(binascii.hexlify(chunk))
+    return str(uuid.UUID(bytes=digest.digest()[:16], version=5))
 
 
 def _pip_install(protocol: str, package: str) -> None:  # pragma: no cover

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -42,8 +42,9 @@ PUT_FILE_REGISTRY: Final[Registry[PutFile]] = Registry(  # type: ignore
     name="put_file",
 )
 
-# Bounds the memory a single UUID computation uses. Each chunk is hex
-# encoded, so the transient cost is twice this, per concurrent call.
+# Bounds the memory a single UUID computation uses. While each chunk
+# remains live, hex encoding allocates a buffer twice its size, making the
+# peak transient cost approximately three times this per concurrent call.
 _UUID_CHUNK_SIZE: Final = 1 << 20
 
 

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -1516,7 +1516,9 @@ def _uuid_from_stream(stream: IO[bytes]) -> str:
     # NOTE: Not a security hash -- this reproduces `uuid.uuid5`, whose
     # algorithm is fixed by RFC 4122. The flag keeps it working where
     # SHA-1 is disabled for security use, such as FIPS mode.
-    digest = hashlib.sha1(uuid.NAMESPACE_URL.bytes, usedforsecurity=False)
+    digest = hashlib.sha1(
+        uuid.NAMESPACE_URL.bytes, usedforsecurity=False
+    )  # nosemgrep
     while chunk := stream.read(_UUID_CHUNK_SIZE):
         digest.update(binascii.hexlify(chunk))
     return str(uuid.UUID(bytes=digest.digest()[:16], version=5))

--- a/luxonis_ml/utils/filesystem.py
+++ b/luxonis_ml/utils/filesystem.py
@@ -1516,9 +1516,9 @@ def _uuid_from_stream(stream: IO[bytes]) -> str:
     # NOTE: Not a security hash -- this reproduces `uuid.uuid5`, whose
     # algorithm is fixed by RFC 4122. The flag keeps it working where
     # SHA-1 is disabled for security use, such as FIPS mode.
-    digest = hashlib.sha1(
+    digest = hashlib.sha1(  # nosemgrep
         uuid.NAMESPACE_URL.bytes, usedforsecurity=False
-    )  # nosemgrep
+    )
     while chunk := stream.read(_UUID_CHUNK_SIZE):
         digest.update(binascii.hexlify(chunk))
     return str(uuid.UUID(bytes=digest.digest()[:16], version=5))

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -396,8 +396,7 @@ def test_file_uuid_does_not_hold_the_file_in_memory(tempdir: Path):
 
     The assertion is on the *shape* of the cost rather than a measured
     number: memory must be bounded by the chunk size, not by the file,
-    which is what makes the peak flat as files grow. The old code would
-    reach ~112 MiB here.
+    which is what makes the peak flat as files grow.
     """
     file_path = tempdir / "payload.bin"
     file_path.write_bytes(os.urandom(16 * _UUID_CHUNK_SIZE))

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -1,3 +1,6 @@
+import os
+import tracemalloc
+import uuid
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -8,6 +11,7 @@ from pytest_subtests import SubTests
 
 from luxonis_ml.utils.environ import environ
 from luxonis_ml.utils.filesystem import (
+    _UUID_CHUNK_SIZE,
     LuxonisFileSystem,
     _get_protocol_and_path,
 )
@@ -310,6 +314,104 @@ def test_ignored_cache_storage_is_reported(
         "mlflow://experiment/run", tracking_uri="http://127.0.0.1:1"
     )
     assert warnings_log == []
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param(b"", id="empty"),
+        pytest.param(b"luxonis", id="ascii"),
+        pytest.param(b"\x00\x01\xff", id="non-utf8"),
+        pytest.param(bytes(range(256)) * 8, id="all-byte-values"),
+    ],
+)
+def test_file_uuid_survives_chunked_hashing(tempdir: Path, content: bytes):
+    """Pins the file UUIDs against the whole-file hash they replaced.
+
+    ``get_file_uuid`` used to read the entire file, hex encode it and
+    hand the result to ``uuid.uuid5``. It now feeds the hash in chunks
+    instead, which is only safe because hex encodes every byte on its
+    own, so the hex of a concatenation is the concatenation of the
+    hexes.
+
+    These UUIDs are the identity of every file in a dataset, so this
+    compares against the original expression rather than a recomputed
+    one -- a value that merely looked reasonable would silently orphan
+    existing data. The empty and non-UTF-8 cases are here because a hex
+    string hides both: an empty file must still hash the namespace, and
+    raw bytes must never reach a UTF-8 decode.
+    """
+    file_path = tempdir / "payload.bin"
+    file_path.write_bytes(content)
+
+    fs = LuxonisFileSystem(str(tempdir))
+    expected = str(uuid.uuid5(uuid.NAMESPACE_URL, content.hex()))
+
+    assert fs.get_file_uuid(file_path, local=True) == expected
+    assert fs.get_file_uuid(file_path.name) == expected
+
+
+@pytest.mark.parametrize(
+    "size",
+    [
+        _UUID_CHUNK_SIZE - 1,
+        _UUID_CHUNK_SIZE,
+        _UUID_CHUNK_SIZE + 1,
+        2 * _UUID_CHUNK_SIZE + 7,
+    ],
+)
+def test_file_uuid_is_independent_of_chunk_boundaries(
+    tempdir: Path, size: int
+):
+    """Pins the UUID across the read boundaries chunking introduces.
+
+    Sizes either side of ``_UUID_CHUNK_SIZE`` are the ones that would
+    expose a partial read or an off-by-one in the loop, and they are the
+    only place a chunked hash can diverge from a whole-file one. Tuning
+    the chunk size must stay a pure performance decision, so this is
+    parametrized on the constant rather than on fixed numbers.
+    """
+    content = os.urandom(size)
+    file_path = tempdir / "payload.bin"
+    file_path.write_bytes(content)
+
+    fs = LuxonisFileSystem(str(tempdir))
+
+    assert fs.get_file_uuid(file_path, local=True) == str(
+        uuid.uuid5(uuid.NAMESPACE_URL, content.hex())
+    )
+
+
+def test_file_uuid_does_not_hold_the_file_in_memory(tempdir: Path):
+    """Regression test for hashing a file at 7x its size in memory.
+
+    The old expression, ``uuid5(NAMESPACE_URL, f.read().hex())``, peaked
+    at seven times the file size: the bytes, the hex string at two bytes
+    per byte, that string UTF-8 encoded inside ``uuid5``, and the
+    namespace concatenation copying it once more. ``get_file_uuids``
+    then fans this out over a thread pool -- up to ``min(32, cpu + 4)``
+    files at once -- and ``LuxonisDataset`` calls it for every file in a
+    batch, so a directory of large media could exhaust memory before it
+    was ever loaded.
+
+    The assertion is on the *shape* of the cost rather than a measured
+    number: memory must be bounded by the chunk size, not by the file,
+    which is what makes the peak flat as files grow. The old code would
+    reach ~112 MiB here.
+    """
+    file_path = tempdir / "payload.bin"
+    file_path.write_bytes(os.urandom(16 * _UUID_CHUNK_SIZE))
+
+    fs = LuxonisFileSystem(str(tempdir))
+
+    tracemalloc.start()
+    try:
+        fs.get_file_uuid(file_path, local=True)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert peak < 8 * _UUID_CHUNK_SIZE
 
 
 def test_bytes(fs: LuxonisFileSystem, randint: int):


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`LuxonisFileSystem.get_file_uuid` hashed a file at **seven times its own size in memory**:

```python
file_contents = ...read()
return str(uuid.uuid5(uuid.NAMESPACE_URL, file_contents.hex()))
```

Measured with `tracemalloc` on a 20 MB payload:

| step | peak |
| --- | --- |
| read the bytes | 1.0x |
| `+ .hex()` — two ASCII bytes per input byte | 3.0x |
| `+ uuid5()` — UTF-8 encodes that hex string, then the namespace concatenation copies it again | 7.0x |

`get_file_uuids` fans this out over a `ThreadPoolExecutor` with default workers (`min(32, cpu + 4)`), and `LuxonisDataset._add_process_batch` calls it for every file in a batch. A directory of large media could therefore exhaust memory during UUID generation, before any of it was loaded.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
The hash is now fed in chunks, via a new `_uuid_from_stream` helper, and all three branches of `get_file_uuid` (local, MLflow, fsspec) go through it.

**The UUIDs do not change.** `uuid.uuid5(namespace, name)` is `sha1(namespace.bytes + name.encode())` truncated to 16 bytes and stamped with the version, and hex encodes each byte independently — so the hex of a concatenation is the concatenation of the hexes, and hashing chunk by chunk yields the identical digest. This is the entire constraint on the change: these UUIDs are the identity of every file in a dataset, so a value that merely looked reasonable would silently orphan existing data.

Peak memory drops from **112 MiB to 3 MiB** on a 16 MiB file, and the bound is chunk-driven rather than file-driven, so it stays flat as files grow.

Two details worth review:

- `usedforsecurity=False` on the SHA-1 — this reproduces `uuid5`, whose algorithm is fixed by RFC 4122, and the flag keeps it working where SHA-1 is disabled for security use (FIPS mode).
- MLflow improves but does not become constant: its branch goes through `read_to_byte_buffer`, which still materializes the whole artifact before hashing begins. That is pre-existing and out of scope here; the `get_file_uuid` docstring names the exception rather than overstating the guarantee.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
No API change, no new dependencies (`hashlib` and `binascii` are stdlib), no config change.

The risk that matters is UUID drift, since file UUIDs are dataset identity and a silent change would orphan existing datasets. That is covered directly — see Testing below — by comparing against the exact expression this replaces rather than a recomputed one.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable — library change with no migration or rollout step. Because the UUIDs are unchanged, existing datasets need no regeneration and a rollback is a plain revert.

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Three regression tests added in `tests/test_utils/test_filesystem.py`:

- `test_file_uuid_survives_chunked_hashing` — pins values against the replaced expression for empty, ASCII, non-UTF-8 and all-256-byte-values content. Empty and non-UTF-8 are there because a hex string hides both: an empty file must still hash the namespace, and raw bytes must never reach a UTF-8 decode.
- `test_file_uuid_is_independent_of_chunk_boundaries` — sizes at `CHUNK-1`, `CHUNK`, `CHUNK+1`, `2*CHUNK+7`, the only places a chunked hash can diverge from a whole-file one. Parametrized on the constant, so retuning the chunk size stays a pure performance decision.
- `test_file_uuid_does_not_hold_the_file_in_memory` — asserts peak `< 8 * _UUID_CHUNK_SIZE`. Confirmed to be a real guard: the old expression peaks at 112 MiB against that 8 MiB threshold, so it fails without the fix, and the new code peaks at 3 MiB, so neither direction is marginal.


## AI Usage
<!--
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Claude Code:claude-opus-5 [tracemalloc] [pyright] [ruff]

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file UUID generation for large files by processing data in bounded chunks, reducing memory usage.
  * Preserved compatibility with previously generated UUID values regardless of file chunk boundaries.
  * Reduced memory demands during batch processing, including when multiple files are handled concurrently.

* **Tests**
  * Added coverage for UUID compatibility, chunk-boundary independence, and bounded memory usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->