### PR TITLE
Stop filesystem tests leaking into the shared bucket

### DIFF
--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterator
-from contextlib import suppress
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from _pytest.fixtures import SubRequest
@@ -73,13 +73,12 @@ def fs(
 
 def _remove_remote(fs: LuxonisFileSystem, name: str) -> None:
     """Delete a remote file or directory, if it is there at all."""
-    with suppress(Exception):
-        if not fs.exists(name):
-            return
-        if fs.is_directory(name):
-            fs.delete_dir(name)
-        else:
-            fs.delete_file(name)
+    if not fs.exists(name):
+        return
+    if fs.is_directory(name):
+        fs.delete_dir(name)
+    else:
+        fs.delete_file(name)
 
 
 @pytest.fixture
@@ -87,25 +86,24 @@ def remote(fs: LuxonisFileSystem) -> Iterator[Callable[[str], str]]:
     """Reserve remote names and remove them once the test is done.
 
     The ``s3://`` and ``gcs://`` filesystems address a bucket shared by
-    every run, on every platform and Python version, so whatever a test
-    uploads and does not delete stays there for good. Several of these
-    tests then open with ``assert not fs.exists(name)`` on a name built
-    from ``randint``, which is drawn from a range of 100_000 -- so as
-    the leftovers pile up, the chance of a run colliding with one grows
-    with every run, until a test fails on a name it never created. That
-    is what made ``test_static_directory`` fail on a green branch.
-
-    Clearing the name on the way in, and not only on the way out, is
-    what makes this self-correcting: a run killed before its teardown,
-    and every name already sitting in the bucket, stop being able to
-    fail the next test that happens to draw them.
+    every run, on every platform and Python version. Each logical test
+    name therefore gets a UUID-backed remote name, which isolates it
+    from leftovers and concurrent runs. Repeated reservations of the
+    same logical name return the same remote name and clear it before
+    use, protecting retries within the test as well.
     """
     reserved: list[str] = []
+    names: dict[str, str] = {}
 
     def reserve(name: str) -> str:
-        _remove_remote(fs, name)
-        reserved.append(name)
-        return name
+        if name not in names:
+            unique_name = f"{name}.{uuid4().hex}"
+            names[name] = unique_name
+            reserved.append(unique_name)
+
+        unique_name = names[name]
+        _remove_remote(fs, unique_name)
+        return unique_name
 
     yield reserve
 
@@ -121,32 +119,31 @@ def test_remote_names_are_cleared_before_use(
 ):
     """Regression test for the shared bucket accumulating uploads.
 
-    Reserving a name has to clear it, not just schedule it for deletion.
-    The bucket still holds every leftover from before this fixture
-    existed, and a run killed between its upload and its teardown will
-    keep adding more, so the tests that open with ``assert not
-    fs.exists(name)`` stay exposed until reserving is what frees the
-    name. ``test_static_directory`` failed exactly that way, on a branch
-    that changed nothing but a hashing routine.
+    Reserving a name has to clear it, not just schedule it for deletion,
+    and repeated reservations must resolve to the same UUID-backed
+    remote name.
 
     Files and directories are both covered because they are removed
     through different calls, and a directory left behind by an
     interrupted run is the more likely of the two -- uploads are what
     these tests mostly do.
 
-    Reserving up front, before the leftover is planted, is what keeps
-    this test from leaking the very thing it is testing when an
-    assertion fails.
+    Reserving up front, before the leftover is planted, keeps this test
+    from leaking the very thing it is testing when an assertion fails.
     """
-    leftover_file = remote(f"leftover_file_{randint}.txt")
+    file_name = f"leftover_file_{randint}.txt"
+    leftover_file = remote(file_name)
     fs.put_bytes(b"leftover", leftover_file)
     assert fs.exists(leftover_file)
-    assert not fs.exists(remote(leftover_file))
+    assert remote(file_name) == leftover_file
+    assert not fs.exists(leftover_file)
 
-    leftover_dir = remote(f"leftover_dir_{randint}")
+    dir_name = f"leftover_dir_{randint}"
+    leftover_dir = remote(dir_name)
     fs.put_dir(local_dir, leftover_dir)
     assert fs.is_directory(leftover_dir)
-    assert not fs.exists(remote(leftover_dir))
+    assert remote(dir_name) == leftover_dir
+    assert not fs.exists(leftover_dir)
 
 
 def test_file(

--- a/tests/test_utils/test_filesystem.py
+++ b/tests/test_utils/test_filesystem.py
@@ -1,4 +1,5 @@
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from contextlib import suppress
 from pathlib import Path
 
 import pytest
@@ -70,16 +71,92 @@ def fs(
     return LuxonisFileSystem(url_path)
 
 
+def _remove_remote(fs: LuxonisFileSystem, name: str) -> None:
+    """Delete a remote file or directory, if it is there at all."""
+    with suppress(Exception):
+        if not fs.exists(name):
+            return
+        if fs.is_directory(name):
+            fs.delete_dir(name)
+        else:
+            fs.delete_file(name)
+
+
+@pytest.fixture
+def remote(fs: LuxonisFileSystem) -> Iterator[Callable[[str], str]]:
+    """Reserve remote names and remove them once the test is done.
+
+    The ``s3://`` and ``gcs://`` filesystems address a bucket shared by
+    every run, on every platform and Python version, so whatever a test
+    uploads and does not delete stays there for good. Several of these
+    tests then open with ``assert not fs.exists(name)`` on a name built
+    from ``randint``, which is drawn from a range of 100_000 -- so as
+    the leftovers pile up, the chance of a run colliding with one grows
+    with every run, until a test fails on a name it never created. That
+    is what made ``test_static_directory`` fail on a green branch.
+
+    Clearing the name on the way in, and not only on the way out, is
+    what makes this self-correcting: a run killed before its teardown,
+    and every name already sitting in the bucket, stop being able to
+    fail the next test that happens to draw them.
+    """
+    reserved: list[str] = []
+
+    def reserve(name: str) -> str:
+        _remove_remote(fs, name)
+        reserved.append(name)
+        return name
+
+    yield reserve
+
+    for name in reserved:
+        _remove_remote(fs, name)
+
+
+def test_remote_names_are_cleared_before_use(
+    fs: LuxonisFileSystem,
+    local_dir: Path,
+    randint: int,
+    remote: Callable[[str], str],
+):
+    """Regression test for the shared bucket accumulating uploads.
+
+    Reserving a name has to clear it, not just schedule it for deletion.
+    The bucket still holds every leftover from before this fixture
+    existed, and a run killed between its upload and its teardown will
+    keep adding more, so the tests that open with ``assert not
+    fs.exists(name)`` stay exposed until reserving is what frees the
+    name. ``test_static_directory`` failed exactly that way, on a branch
+    that changed nothing but a hashing routine.
+
+    Files and directories are both covered because they are removed
+    through different calls, and a directory left behind by an
+    interrupted run is the more likely of the two -- uploads are what
+    these tests mostly do.
+
+    Reserving up front, before the leftover is planted, is what keeps
+    this test from leaking the very thing it is testing when an
+    assertion fails.
+    """
+    leftover_file = remote(f"leftover_file_{randint}.txt")
+    fs.put_bytes(b"leftover", leftover_file)
+    assert fs.exists(leftover_file)
+    assert not fs.exists(remote(leftover_file))
+
+    leftover_dir = remote(f"leftover_dir_{randint}")
+    fs.put_dir(local_dir, leftover_dir)
+    assert fs.is_directory(leftover_dir)
+    assert not fs.exists(remote(leftover_dir))
+
+
 def test_file(
     fs: LuxonisFileSystem,
     local_file: Path,
     subtests: SubTests,
     protocol_tempdir: Path,
+    remote: Callable[[str], str],
 ):
-    uploaded_file = f"upload_{local_file.name}"
-    if fs.exists(uploaded_file):  # pragma: no cover
-        fs.delete_file(uploaded_file)
-
+    uploaded_file = remote(f"upload_{local_file.name}")
     assert not fs.exists(uploaded_file)
 
     with subtests.test("upload"):
@@ -104,8 +181,9 @@ def test_static_file(
     protocol_tempdir: Path,
     subtests: SubTests,
     randint: int,
+    remote: Callable[[str], str],
 ):
-    file_name = f"static_file_upload_{randint}.txt"
+    file_name = remote(f"static_file_upload_{randint}.txt")
     url = f"{fs._url}/{file_name}"
     with subtests.test("upload"):
         assert not fs.exists(file_name)
@@ -124,9 +202,10 @@ def test_directory(
     local_dir: Path,
     subtests: SubTests,
     protocol_tempdir: Path,
+    remote: Callable[[str], str],
 ):
     with subtests.test("name"):
-        uploaded_dir = f"upload_{local_dir.name}_name"
+        uploaded_dir = remote(f"upload_{local_dir.name}_name")
         assert not fs.exists(uploaded_dir)
 
         fs.put_dir(local_dir, uploaded_dir)
@@ -139,7 +218,7 @@ def test_directory(
         compare_directories(dir_path, local_dir)
 
     with subtests.test("list"):
-        uploaded_dir = f"upload_{local_dir.name}_list"
+        uploaded_dir = remote(f"upload_{local_dir.name}_list")
         assert not fs.exists(uploaded_dir)
 
         fs.put_dir([str(p) for p in local_dir.rglob("*.txt")], uploaded_dir)
@@ -161,8 +240,9 @@ def test_static_directory(
     protocol_tempdir: Path,
     subtests: SubTests,
     randint: int,
+    remote: Callable[[str], str],
 ):
-    dir_name = f"static_dir_upload_{randint}"
+    dir_name = remote(f"static_dir_upload_{randint}")
     url = f"{fs._url}/{dir_name}"
     with subtests.test("upload"):
         assert not fs.exists(dir_name)
@@ -175,11 +255,13 @@ def test_static_directory(
         compare_directories(dir, local_dir)
 
 
-def test_walk_dir(fs: LuxonisFileSystem, local_dir: Path, subtests: SubTests):
-    uploaded_dir = f"dir_upload_{local_dir.name}"
-
-    if fs.exists(uploaded_dir):  # pragma: no cover
-        fs.delete_dir(uploaded_dir)
+def test_walk_dir(
+    fs: LuxonisFileSystem,
+    local_dir: Path,
+    subtests: SubTests,
+    remote: Callable[[str], str],
+):
+    uploaded_dir = remote(f"dir_upload_{local_dir.name}")
 
     fs.put_dir(local_dir, uploaded_dir)
 
@@ -312,8 +394,10 @@ def test_ignored_cache_storage_is_reported(
     assert warnings_log == []
 
 
-def test_bytes(fs: LuxonisFileSystem, randint: int):
-    bytes_file = f"bytes_test_{randint}.txt"
+def test_bytes(
+    fs: LuxonisFileSystem, randint: int, remote: Callable[[str], str]
+):
+    bytes_file = remote(f"bytes_test_{randint}.txt")
     fs.put_bytes(f"bytes test {randint}".encode(), bytes_file)
     assert fs.exists(bytes_file)
     buffer = fs.read_to_byte_buffer(bytes_file)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`test_static_directory[s3]` failed on #464, a branch that changed nothing but a hashing routine ([failing job](https://github.com/luxonis/luxonis-ml/actions/runs/30713102692/job/91404209251)):

```
>       assert not fs.exists(dir_name)
E       AssertionError: assert not True
E        +  where True = exists('static_dir_upload_70182')
```

That assertion is a *precondition* — it checks the name is free before uploading — and it failed because the directory was already in the bucket.

The `s3://` and `gcs://` filesystems address a bucket shared by every run, on every platform and Python version. Five of the six tests that upload there never deleted what they created, so every run left more behind, permanently:

| test | remote artifact | cleaned up before |
| --- | --- | --- |
| `test_file` | `upload_file_{randint}.txt` | yes |
| `test_static_file` | `static_file_upload_{randint}.txt` | **no** |
| `test_directory` | `upload_dir_{randint}_{name,list}` | **no** |
| `test_static_directory` | `static_dir_upload_{randint}` | **no** |
| `test_walk_dir` | `dir_upload_dir_{randint}` | pre-guarded, never deleted |
| `test_bytes` | `bytes_test_{randint}.txt` | **no** |

Four of those open by asserting the name is free, and the names come from `randint`, drawn from a range of 100_000. So the collision probability grows with every run — this was not a one-off, it gets steadily more likely.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Adds a `remote` fixture that reserves names and removes them when the test finishes, and routes every remote upload in the module through it. It follows the idiom already used by `dataset_name` in `tests/conftest.py`, which yields and then deletes remotely.

Reserving a name **clears** it as well as scheduling it for deletion. That part is what makes the fix self-correcting rather than merely forward-looking: the bucket still holds every leftover from before this change, and a run killed between its upload and its teardown will keep adding more. Clearing on the way in means neither can fail the next test that draws the same name.

This also removes the two hand-rolled `if fs.exists(...): delete` pre-guards in `test_file` and `test_walk_dir`, which were doing half of this job in two places.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
Tests only — no library code is touched.

The one behavioral consequence worth naming: the suite now issues extra `exists`/`delete` calls against the shared bucket, one pair per reserved name. That is the point of the change, but it does mean slightly more remote traffic per run.

Existing leftovers in the bucket are **not** purged by this PR — that needs credentials and is a one-off cleanup. It is no longer urgent, though, since a collision with an old leftover is now cleared rather than fatal.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable — test-only change, nothing to roll out.

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
Adds `test_remote_names_are_cleared_before_use`, which plants a leftover file and a leftover directory and asserts that reserving the name frees it. Both kinds are covered because they are removed through different calls (`delete_file` vs `delete_dir`). It reserves each name *before* planting the leftover, so a failing assertion cannot leak the very thing the test is about.


## AI Usage
<!--
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Claude Code:claude-opus-5 [pyright] [ruff]

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES

🤖 Generated with [Claude Code](https://claude.com/claude-code)
