### PR TITLE
Shared color utilities in `luxonis_ml.utils.color`

### DIFF
--- a/luxonis_ml/utils/__init__.py
+++ b/luxonis_ml/utils/__init__.py
@@ -33,6 +33,7 @@ from luxonis_ml.guard_extras import guard_missing_extra
 with guard_missing_extra("utils"):
     from luxonis_ml.typing import BaseModelExtraForbid
 
+    from .color import Color
     from .config import LuxonisConfig
     from .environ import Environ, environ
     from .filesystem import PUT_FILE_REGISTRY, LuxonisFileSystem
@@ -45,6 +46,7 @@ __all__ = [
     "PUT_FILE_REGISTRY",
     "AutoRegisterMeta",
     "BaseModelExtraForbid",
+    "Color",
     "Environ",
     "LuxonisConfig",
     "LuxonisFileSystem",

--- a/luxonis_ml/utils/color/__init__.py
+++ b/luxonis_ml/utils/color/__init__.py
@@ -8,12 +8,6 @@ module reimplements it:
   for every non-label color (backgrounds, cards, dividers, verdict marks).
 - `Palette` / `GoldenRatioColors` / `SequenceColors` — distinct per-class label
   colors from a pluggable index-based generator.
-
-None of the above needs NumPy, so importing this package stays cheap for a base
-``luxonis-ml[utils]`` install. `Gradient` (colormaps for scalar fields such as
-heatmaps) lives in `luxonis_ml.utils.color.gradient` and is imported from there
-rather than re-exported here. It too imports without NumPy: only its
-`colorize` method needs it, and that one is handed a NumPy array anyway.
 """
 
 from . import brand

--- a/luxonis_ml/utils/color/__init__.py
+++ b/luxonis_ml/utils/color/__init__.py
@@ -11,10 +11,9 @@ module reimplements it:
 
 None of the above needs NumPy, so importing this package stays cheap for a base
 ``luxonis-ml[utils]`` install. `Gradient` (colormaps for scalar fields such as
-heatmaps) lives in `luxonis_ml.utils.color.gradient` and is imported directly
-from there rather than re-exported here; it also imports without NumPy, and only
-its `Gradient.colorize` method — which takes a NumPy array in the first place —
-needs it. NumPy is therefore never a dependency of importing any of this.
+heatmaps) lives in `luxonis_ml.utils.color.gradient` and is imported from there
+rather than re-exported here. It too imports without NumPy: only its
+`colorize` method needs it, and that one is handed a NumPy array anyway.
 """
 
 from . import brand

--- a/luxonis_ml/utils/color/__init__.py
+++ b/luxonis_ml/utils/color/__init__.py
@@ -10,10 +10,11 @@ module reimplements it:
   colors from a pluggable index-based generator.
 
 None of the above needs NumPy, so importing this package stays cheap for a base
-``luxonis-ml[utils]`` install. The one color tool that does need NumPy —
-`Gradient` (colormaps for scalar fields such as heatmaps) — lives in
-`luxonis_ml.utils.color.gradient` and is imported directly from there, not
-re-exported here, so the base import does not pull in NumPy.
+``luxonis-ml[utils]`` install. `Gradient` (colormaps for scalar fields such as
+heatmaps) lives in `luxonis_ml.utils.color.gradient` and is imported directly
+from there rather than re-exported here; it also imports without NumPy, and only
+its `Gradient.colorize` method — which takes a NumPy array in the first place —
+needs it. NumPy is therefore never a dependency of importing any of this.
 """
 
 from . import brand

--- a/luxonis_ml/utils/color/__init__.py
+++ b/luxonis_ml/utils/color/__init__.py
@@ -1,0 +1,42 @@
+"""Color management for ``luxonis-ml``: the primitive, brand, and class palette.
+
+This package is the single home for color handling across the stack, so no other
+module reimplements it:
+
+- `Color` — the immutable RGBA primitive with hex/name/HSL parsing and helpers.
+- `brand` — the Luxonis brand colors and the UI-chrome palette built from them,
+  for every non-label color (backgrounds, cards, dividers, verdict marks).
+- `Palette` / `GoldenRatioColors` / `SequenceColors` — distinct per-class label
+  colors from a pluggable index-based generator.
+
+None of the above needs NumPy, so importing this package stays cheap for a base
+``luxonis-ml[utils]`` install. The one color tool that does need NumPy —
+`Gradient` (colormaps for scalar fields such as heatmaps) — lives in
+`luxonis_ml.utils.color.gradient` and is imported directly from there, not
+re-exported here, so the base import does not pull in NumPy.
+"""
+
+from . import brand
+from .base import RGB, RGBA, Color, ColorLike
+from .palette import (
+    BRAND_COLORS,
+    DEFAULT_PALETTE,
+    ColorGenerator,
+    GoldenRatioColors,
+    Palette,
+    SequenceColors,
+)
+
+__all__ = [
+    "BRAND_COLORS",
+    "DEFAULT_PALETTE",
+    "RGB",
+    "RGBA",
+    "Color",
+    "ColorGenerator",
+    "ColorLike",
+    "GoldenRatioColors",
+    "Palette",
+    "SequenceColors",
+    "brand",
+]

--- a/luxonis_ml/utils/color/base.py
+++ b/luxonis_ml/utils/color/base.py
@@ -1,0 +1,342 @@
+"""Color parsing and manipulation.
+
+The `Color` class is the single color primitive shared across ``luxonis-ml`` —
+`luxonis_ml.vizlab` re-exports it, and other submodules (e.g. augmentation fill
+values) parse colors through it too, so no module reimplements color handling.
+
+Colors are normalized to an ``(r, g, b, a)`` tuple of 8-bit integers. `Color.parse`
+accepts the shapes users actually have on hand — hex strings, CSS color names, a
+single grayscale integer, RGB/RGBA tuples, or another `Color` — and exposes the
+HSL-space operations the palette and sub-label style derivation rely on.
+"""
+
+import colorsys
+from dataclasses import dataclass
+from typing import TypeAlias
+
+RGBA: TypeAlias = tuple[int, int, int, int]
+"""An ``(r, g, b, a)`` tuple of 8-bit integers (0-255)."""
+
+RGB: TypeAlias = tuple[int, int, int]
+"""An ``(r, g, b)`` tuple of 8-bit integers (0-255)."""
+
+#: A small dependency-free set of common color names, so the basics resolve
+#: without Pillow. Anything else falls back to Pillow's full CSS set when it is
+#: installed (see `Color._from_name`).
+_NAMED_COLORS: dict[str, RGB] = {
+    "black": (0, 0, 0),
+    "white": (255, 255, 255),
+    "red": (255, 0, 0),
+    "green": (0, 128, 0),
+    "lime": (0, 255, 0),
+    "blue": (0, 0, 255),
+    "yellow": (255, 255, 0),
+    "cyan": (0, 255, 255),
+    "aqua": (0, 255, 255),
+    "magenta": (255, 0, 255),
+    "fuchsia": (255, 0, 255),
+    "gray": (128, 128, 128),
+    "grey": (128, 128, 128),
+    "silver": (192, 192, 192),
+    "maroon": (128, 0, 0),
+    "olive": (128, 128, 0),
+    "navy": (0, 0, 128),
+    "purple": (128, 0, 128),
+    "teal": (0, 128, 128),
+    "orange": (255, 165, 0),
+}
+
+
+def _clamp8(value: float) -> int:
+    """Clamp a number to the inclusive 0-255 integer range.
+
+    Args:
+        value: The value to clamp.
+
+    Returns:
+        The value rounded and clamped to ``[0, 255]``.
+
+    """
+    return max(0, min(255, round(value)))
+
+
+@dataclass(frozen=True)
+class Color:
+    """An immutable RGBA color with HSL-space helpers.
+
+    Attributes:
+        r: Red channel, 0-255.
+        g: Green channel, 0-255.
+        b: Blue channel, 0-255.
+        a: Alpha channel, 0-255 (255 is opaque).
+
+    Examples:
+        >>> Color.parse("#4c8dff")
+        Color(r=76, g=141, b=255, a=255)
+        >>> Color.parse("#abc")
+        Color(r=170, g=187, b=204, a=255)
+        >>> Color.parse("white")
+        Color(r=255, g=255, b=255, a=255)
+        >>> Color.parse(128)
+        Color(r=128, g=128, b=128, a=255)
+        >>> Color.parse(300)  # out-of-range channels are clamped
+        Color(r=255, g=255, b=255, a=255)
+        >>> Color.parse((255, 0, 0))
+        Color(r=255, g=0, b=0, a=255)
+        >>> Color.parse("white").rgb
+        (255, 255, 255)
+        >>> Color(255, 0, 0).with_alpha(0.5)
+        Color(r=255, g=0, b=0, a=128)
+        >>> Color(1, 2, 3, 4).rgba
+        (1, 2, 3, 4)
+        >>> Color(255, 255, 255).readable_text_color()
+        Color(r=17, g=17, b=17, a=255)
+        >>> Color(0, 0, 0).readable_text_color()
+        Color(r=255, g=255, b=255, a=255)
+        >>> c = Color(120, 120, 120)
+        >>> c.lighten(0.5).hls[1] > c.hls[1]
+        True
+        >>> c.darken(0.5).hls[1] < c.hls[1]
+        True
+        >>> Color.parse("#12")
+        Traceback (most recent call last):
+            ...
+        ValueError: invalid hex color '#12'
+
+    """
+
+    r: int
+    g: int
+    b: int
+    a: int = 255
+
+    @classmethod
+    def parse(cls, value: object) -> "Color":
+        """Coerce a color-like value into a `Color`.
+
+        Args:
+            value: A hex string (``"#rgb"``, ``"#rrggbb"``, ``"#rrggbbaa"``, with
+                or without the leading ``#``), a CSS color name (``"red"``), a
+                single grayscale integer (``128`` → gray), an ``(r, g, b)`` or
+                ``(r, g, b, a)`` tuple, or an existing `Color`.
+
+        Returns:
+            The corresponding `Color`.
+
+        Raises:
+            ValueError: If the value cannot be interpreted as a color.
+
+        """
+        if isinstance(value, Color):
+            return value
+        if isinstance(value, int) and not isinstance(value, bool):
+            channel = _clamp8(value)
+            return cls(channel, channel, channel)
+        if isinstance(value, str):
+            return cls._from_str(value)
+        if isinstance(value, tuple):
+            if len(value) == 3:
+                r, g, b = value
+                return cls(_clamp8(r), _clamp8(g), _clamp8(b))
+            if len(value) == 4:
+                r, g, b, a = value
+                return cls(_clamp8(r), _clamp8(g), _clamp8(b), _clamp8(a))
+            raise ValueError(
+                f"color tuple must have 3 or 4 elements, got {len(value)}"
+            )
+        raise ValueError(f"cannot parse color from {value!r}")
+
+    @classmethod
+    def _from_str(cls, text: str) -> "Color":
+        """Parse a hex string or a color name.
+
+        A leading ``#`` forces hex parsing (so a bad hex reports as such);
+        otherwise hex is tried first, then a color name.
+        """
+        if text.startswith("#"):
+            return cls._from_hex(text)
+        try:
+            return cls._from_hex(text)
+        except ValueError:
+            return cls._from_name(text)
+
+    @classmethod
+    def _from_name(cls, text: str) -> "Color":
+        """Resolve a CSS color name to a `Color`.
+
+        Uses a small built-in table, then Pillow's full name set when it is
+        installed.
+
+        Args:
+            text: The color name.
+
+        Returns:
+            The named `Color`.
+
+        Raises:
+            ValueError: If the name is not recognized.
+
+        """
+        key = text.strip().lower()
+        if key in _NAMED_COLORS:
+            r, g, b = _NAMED_COLORS[key]
+            return cls(r, g, b)
+        try:
+            from PIL import ImageColor
+        except ImportError:
+            ImageColor = None
+        if ImageColor is not None:
+            try:
+                r, g, b = ImageColor.getrgb(text)[:3]
+            except ValueError:
+                pass
+            else:
+                return cls(r, g, b)
+        raise ValueError(f"invalid color name {text!r}")
+
+    @classmethod
+    def _from_hex(cls, text: str) -> "Color":
+        """Parse a hex color string.
+
+        Args:
+            text: A hex string with 3, 4, 6, or 8 digits, optional leading ``#``.
+
+        Returns:
+            The parsed `Color`.
+
+        Raises:
+            ValueError: If the string is not valid hex of a supported length.
+
+        """
+        s = text.lstrip("#")
+        if len(s) in (3, 4):
+            s = "".join(ch * 2 for ch in s)
+        if len(s) not in (6, 8):
+            raise ValueError(f"invalid hex color {text!r}")
+        try:
+            channels = [int(s[i : i + 2], 16) for i in range(0, len(s), 2)]
+        except ValueError as exc:
+            raise ValueError(f"invalid hex color {text!r}") from exc
+        if len(channels) == 3:
+            channels.append(255)
+        r, g, b, a = channels
+        return cls(r, g, b, a)
+
+    @classmethod
+    def from_hls(cls, h: float, ll: float, s: float, a: int = 255) -> "Color":
+        """Build a color from hue/lightness/saturation.
+
+        Args:
+            h: Hue in ``[0, 1]``.
+            ll: Lightness in ``[0, 1]``.
+            s: Saturation in ``[0, 1]``.
+            a: Alpha channel, 0-255.
+
+        Returns:
+            The corresponding `Color`.
+
+        """
+        r, g, b = colorsys.hls_to_rgb(
+            h % 1.0, max(0.0, min(1.0, ll)), max(0.0, min(1.0, s))
+        )
+        return cls(_clamp8(r * 255), _clamp8(g * 255), _clamp8(b * 255), a)
+
+    @property
+    def rgb(self) -> RGB:
+        """The color as an ``(r, g, b)`` tuple."""
+        return (self.r, self.g, self.b)
+
+    @property
+    def rgba(self) -> RGBA:
+        """The color as an ``(r, g, b, a)`` tuple."""
+        return (self.r, self.g, self.b, self.a)
+
+    @property
+    def hls(self) -> tuple[float, float, float]:
+        """The color as a ``(hue, lightness, saturation)`` tuple in ``[0, 1]``."""
+        return colorsys.rgb_to_hls(self.r / 255, self.g / 255, self.b / 255)
+
+    def with_alpha(self, a: float) -> "Color":
+        """Return a copy with a new alpha.
+
+        Args:
+            a: Alpha as an int (0-255) or a float in ``[0, 1]``.
+
+        Returns:
+            A new `Color` with the requested alpha.
+
+        """
+        alpha = _clamp8(a * 255) if isinstance(a, float) else _clamp8(a)
+        return Color(self.r, self.g, self.b, alpha)
+
+    def lighten(self, amount: float) -> "Color":
+        """Move the color toward white in HSL space.
+
+        Args:
+            amount: Fraction of the remaining lightness to add, in ``[0, 1]``.
+
+        Returns:
+            A lighter `Color`, alpha preserved.
+
+        """
+        h, ll, s = self.hls
+        return Color.from_hls(h, ll + (1.0 - ll) * amount, s, self.a)
+
+    def darken(self, amount: float) -> "Color":
+        """Move the color toward black in HSL space.
+
+        Args:
+            amount: Fraction of the current lightness to remove, in ``[0, 1]``.
+
+        Returns:
+            A darker `Color`, alpha preserved.
+
+        """
+        h, ll, s = self.hls
+        return Color.from_hls(h, ll * (1.0 - amount), s, self.a)
+
+    def saturate(self, amount: float) -> "Color":
+        """Increase (or, with a negative amount, decrease) saturation.
+
+        Args:
+            amount: Fraction of the remaining saturation to add, in ``[-1, 1]``.
+
+        Returns:
+            A `Color` with adjusted saturation, alpha preserved.
+
+        """
+        h, ll, s = self.hls
+        new_s = s + (1.0 - s) * amount if amount >= 0 else s * (1.0 + amount)
+        return Color.from_hls(h, ll, new_s, self.a)
+
+    def shift_hue(self, turns: float) -> "Color":
+        """Rotate the hue around the color wheel.
+
+        Args:
+            turns: Amount to rotate, in turns (``1.0`` is a full circle).
+
+        Returns:
+            A hue-rotated `Color`, alpha preserved.
+
+        """
+        h, ll, s = self.hls
+        return Color.from_hls(h + turns, ll, s, self.a)
+
+    def readable_text_color(self) -> "Color":
+        """Return black or white, whichever is more readable on this color.
+
+        Uses the standard relative-luminance threshold so label text placed on a
+        chip of this color stays legible.
+
+        Returns:
+            Opaque black or white as a `Color`.
+
+        """
+        r, g, b = self.r / 255, self.g / 255, self.b / 255
+        luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        return Color(17, 17, 17) if luminance > 0.55 else Color(255, 255, 255)
+
+
+ColorLike: TypeAlias = str | int | tuple[int, ...] | Color
+"""Anything `Color.parse` accepts: a hex string or color name, a grayscale int,
+an RGB/RGBA tuple, or a `Color`."""

--- a/luxonis_ml/utils/color/base.py
+++ b/luxonis_ml/utils/color/base.py
@@ -325,8 +325,10 @@ class Color:
     def readable_text_color(self) -> "Color":
         """Return black or white, whichever is more readable on this color.
 
-        Uses the standard relative-luminance threshold so label text placed on a
-        chip of this color stays legible.
+        Weights the channels the way WCAG relative luminance does, but leaves
+        them gamma-encoded rather than linearizing first — an approximation of
+        perceived brightness, which is all the black-or-white choice needs to
+        keep label text on a chip of this color legible.
 
         Returns:
             Opaque black or white as a `Color`.

--- a/luxonis_ml/utils/color/base.py
+++ b/luxonis_ml/utils/color/base.py
@@ -1,13 +1,14 @@
 """Color parsing and manipulation.
 
 The `Color` class is the single color primitive shared across ``luxonis-ml`` —
-`luxonis_ml.vizlab` re-exports it, and other submodules (e.g. augmentation fill
-values) parse colors through it too, so no module reimplements color handling.
+the visualization layer re-exports it, and other submodules (e.g. augmentation
+fill values) parse colors through it too, so no module reimplements color
+handling.
 
 Colors are normalized to an ``(r, g, b, a)`` tuple of 8-bit integers. `Color.parse`
 accepts the shapes users actually have on hand — hex strings, CSS color names, a
 single grayscale integer, RGB/RGBA tuples, or another `Color` — and exposes the
-HSL-space operations the palette and sub-label style derivation rely on.
+HSL-space operations the palette and style derivation rely on.
 """
 
 import colorsys
@@ -153,11 +154,11 @@ class Color:
         A leading ``#`` forces hex parsing (so a bad hex reports as such);
         otherwise hex is tried first, then a color name.
         """
-        if text.startswith("#"):
-            return cls._from_hex(text)
         try:
             return cls._from_hex(text)
         except ValueError:
+            if text.startswith("#"):
+                raise
             return cls._from_name(text)
 
     @classmethod
@@ -183,16 +184,11 @@ class Color:
             return cls(r, g, b)
         try:
             from PIL import ImageColor
-        except ImportError:
-            ImageColor = None
-        if ImageColor is not None:
-            try:
-                r, g, b = ImageColor.getrgb(text)[:3]
-            except ValueError:
-                pass
-            else:
-                return cls(r, g, b)
-        raise ValueError(f"invalid color name {text!r}")
+
+            r, g, b = ImageColor.getrgb(text)[:3]
+        except (ImportError, ValueError):
+            raise ValueError(f"invalid color name {text!r}") from None
+        return cls(r, g, b)
 
     @classmethod
     def _from_hex(cls, text: str) -> "Color":
@@ -223,13 +219,15 @@ class Color:
         return cls(r, g, b, a)
 
     @classmethod
-    def from_hls(cls, h: float, ll: float, s: float, a: int = 255) -> "Color":
+    def from_hls(
+        cls, hue: float, lightness: float, saturation: float, a: int = 255
+    ) -> "Color":
         """Build a color from hue/lightness/saturation.
 
         Args:
-            h: Hue in ``[0, 1]``.
-            ll: Lightness in ``[0, 1]``.
-            s: Saturation in ``[0, 1]``.
+            hue: Hue in ``[0, 1]``.
+            lightness: Lightness in ``[0, 1]``.
+            saturation: Saturation in ``[0, 1]``.
             a: Alpha channel, 0-255.
 
         Returns:
@@ -237,7 +235,9 @@ class Color:
 
         """
         r, g, b = colorsys.hls_to_rgb(
-            h % 1.0, max(0.0, min(1.0, ll)), max(0.0, min(1.0, s))
+            hue % 1.0,
+            max(0.0, min(1.0, lightness)),
+            max(0.0, min(1.0, saturation)),
         )
         return cls(_clamp8(r * 255), _clamp8(g * 255), _clamp8(b * 255), a)
 
@@ -279,8 +279,10 @@ class Color:
             A lighter `Color`, alpha preserved.
 
         """
-        h, ll, s = self.hls
-        return Color.from_hls(h, ll + (1.0 - ll) * amount, s, self.a)
+        hue, lightness, saturation = self.hls
+        return Color.from_hls(
+            hue, lightness + (1.0 - lightness) * amount, saturation, self.a
+        )
 
     def darken(self, amount: float) -> "Color":
         """Move the color toward black in HSL space.
@@ -292,8 +294,10 @@ class Color:
             A darker `Color`, alpha preserved.
 
         """
-        h, ll, s = self.hls
-        return Color.from_hls(h, ll * (1.0 - amount), s, self.a)
+        hue, lightness, saturation = self.hls
+        return Color.from_hls(
+            hue, lightness * (1.0 - amount), saturation, self.a
+        )
 
     def saturate(self, amount: float) -> "Color":
         """Increase (or, with a negative amount, decrease) saturation.
@@ -305,9 +309,12 @@ class Color:
             A `Color` with adjusted saturation, alpha preserved.
 
         """
-        h, ll, s = self.hls
-        new_s = s + (1.0 - s) * amount if amount >= 0 else s * (1.0 + amount)
-        return Color.from_hls(h, ll, new_s, self.a)
+        hue, lightness, saturation = self.hls
+        if amount >= 0:
+            new = saturation + (1.0 - saturation) * amount
+        else:
+            new = saturation * (1.0 + amount)
+        return Color.from_hls(hue, lightness, new, self.a)
 
     def shift_hue(self, turns: float) -> "Color":
         """Rotate the hue around the color wheel.
@@ -319,24 +326,29 @@ class Color:
             A hue-rotated `Color`, alpha preserved.
 
         """
-        h, ll, s = self.hls
-        return Color.from_hls(h + turns, ll, s, self.a)
+        hue, lightness, saturation = self.hls
+        return Color.from_hls(hue + turns, lightness, saturation, self.a)
 
-    def readable_text_color(self) -> "Color":
-        """Return black or white, whichever is more readable on this color.
+    @property
+    def is_light(self) -> bool:
+        """Whether this color is bright enough to need dark text on top.
 
         Weights the channels the way WCAG relative luminance does, but leaves
         them gamma-encoded rather than linearizing first — an approximation of
-        perceived brightness, which is all the black-or-white choice needs to
-        keep label text on a chip of this color legible.
-
-        Returns:
-            Opaque black or white as a `Color`.
-
+        perceived brightness, which is all a light/dark decision needs.
         """
         r, g, b = self.r / 255, self.g / 255, self.b / 255
-        luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b
-        return Color(17, 17, 17) if luminance > 0.55 else Color(255, 255, 255)
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b > 0.55
+
+    def readable_text_color(self) -> "Color":
+        """Return near-black or white, whichever is more readable on this color.
+
+        Returns:
+            Opaque `Color`: a soft near-black on light colors, white on dark
+            ones, so label text on a chip of this color stays legible.
+
+        """
+        return Color(17, 17, 17) if self.is_light else Color(255, 255, 255)
 
 
 ColorLike: TypeAlias = str | int | tuple[int, ...] | Color

--- a/luxonis_ml/utils/color/brand.py
+++ b/luxonis_ml/utils/color/brand.py
@@ -162,8 +162,4 @@ def chrome_for(background: Color) -> Chrome:
         True
 
     """
-    return (
-        LIGHT_CHROME
-        if background.readable_text_color().r < 128
-        else DARK_CHROME
-    )
+    return LIGHT_CHROME if background.is_light else DARK_CHROME

--- a/luxonis_ml/utils/color/brand.py
+++ b/luxonis_ml/utils/color/brand.py
@@ -1,0 +1,169 @@
+"""The Luxonis brand colors and the UI-chrome palette built from them.
+
+These are the company colors, taken from the Luxonis design tokens. They are the
+single home for every non-label color in the stack: visualization *chrome* —
+composite backgrounds, card fills, panel keys and titles, dividers, chart tracks,
+and verdict marks — is colored from here so the framing reads as on-brand out of
+the box. Per-class *label* colors deliberately do **not** come from here: they
+stay maximally distinct via the golden-ratio generator (see
+`luxonis_ml.utils.color.palette`), because a fixed brand set can't keep many
+classes apart. Reach for these constants when coloring anything that is not a
+class label.
+
+Examples:
+    >>> from luxonis_ml.utils.color import brand
+    >>> brand.PURPLE
+    Color(r=76, g=79, b=241, a=255)
+    >>> brand.CARD_KEY is brand.PERIWINKLE
+    True
+    >>> brand.chrome_for(brand.LIGHT_BACKGROUND).card_text is brand.PURPLE
+    True
+
+"""
+
+from dataclasses import dataclass
+
+from .base import Color
+
+# -- Core brand colors (the Luxonis design tokens) --------------------------
+PURPLE = Color(76, 79, 241)  # #4c4ff1 — the primary "Luxonis Purple"
+GREEN = Color(18, 183, 106)  # #12B76A
+ORANGE = Color(220, 104, 3)  # #DC6803
+RED = Color(240, 68, 56)  # #F04438
+
+PERIWINKLE = Color(141, 164, 244)  # #8da4f4 — light purple
+MINT = Color(108, 233, 166)  # #6CE9A6 — light green
+AMBER = Color(254, 200, 75)  # #FEC84B — light orange
+SALMON = Color(253, 162, 155)  # #FDA29B — light red
+
+#: A deep-indigo shade of :data:`PURPLE` (same hue) for light-mode titles and
+#: headings: a stronger, higher-contrast purple that outranks the regular
+#: brand purple used for body text (≈ 15:1 on white).
+PURPLE_TITLE = Color(22, 24, 112)  # #161870
+
+# Neutral "ink" ramp (brand grays), dark to light.
+INK = Color(29, 41, 57)  # #1D2939 — darkest neutral
+SLATE = Color(71, 84, 103)  # #475467 — muted mid neutral
+STEEL = Color(102, 112, 133)  # #667085 — light neutral
+
+# -- Chrome palette (semantic; used across the annotations) -----------------
+#: Deep navy composite background painted behind stacks, grids, and pad gaps.
+BACKGROUND = INK.darken(0.28)
+#: Light-mode composite background — a soft, cool lavender-gray (a hair of brand
+#: purple mixed into white). Deliberately *not* pure white so white cards and
+#: panels read as distinct surfaces on top of it.
+LIGHT_BACKGROUND = Color(237, 239, 248)  # #edeff8
+
+#: Card fill — a translucent navy sitting a touch lighter than ``BACKGROUND`` so
+#: stacked cards (legend, info card, distribution panel) read as one family.
+CARD_BG = INK.with_alpha(150)
+#: Caption chips use the same navy, more opaque for a single short line.
+CAPTION_BG = INK.with_alpha(235)
+#: Light-purple (periwinkle) body text — the dark-mode counterpart to the
+#: regular-purple body text on light surfaces, so both themes read as on-brand
+#: rather than plain white on dark.
+CARD_TEXT = PERIWINKLE
+#: A lighter lavender heading, brighter than the body so it outranks it on dark.
+CARD_TITLE = PERIWINKLE.lighten(0.4)  # ≈ #bbc8f8
+CARD_KEY = PERIWINKLE  # keys / secondary accents on cards
+DIVIDER = PERIWINKLE.with_alpha(40)  # subtle rule between image and panel
+MUTED = SLATE  # empty track fills and the "other" segment
+
+# -- Light-mode chrome (white cards + brand-purple text on the light surface) --
+#: Near-opaque white card fill, so panels pop against the lavender background.
+LIGHT_CARD_BG = Color(255, 255, 255, 236)
+#: Caption chips in light mode: opaque white for a single crisp line.
+LIGHT_CAPTION_BG = Color(255, 255, 255, 240)
+LIGHT_CARD_TEXT = PURPLE  # body text in the regular brand purple
+LIGHT_CARD_TITLE = PURPLE_TITLE  # deeper heading, to outrank the body text
+LIGHT_CARD_KEY = PURPLE  # keys / accents in the bright brand purple
+#: Hairline card border and image/panel rule, a translucent brand purple.
+LIGHT_CARD_BORDER = PURPLE.with_alpha(38)
+LIGHT_DIVIDER = PURPLE.with_alpha(46)
+
+# Semantic accents for chart chrome (not class labels).
+ACCENT = PURPLE  # primary highlight
+SUCCESS = GREEN  # a correct ✓ verdict
+WARNING = ORANGE
+ERROR = RED  # an incorrect ✗ verdict
+
+
+@dataclass(frozen=True)
+class Chrome:
+    """Resolved card/panel chrome for a given composite background.
+
+    Bundles the handful of non-label colors a stacked card or side panel needs —
+    fill, body/heading text, accent key, divider, and an optional hairline
+    border — so the framing adapts to a dark or light background as one set.
+    Resolve it with `chrome_for`; the dark and light presets are `DARK_CHROME`
+    and `LIGHT_CHROME`.
+
+    Attributes:
+        card_bg: Rounded-card fill.
+        caption_bg: Caption-chip fill (a more opaque variant of ``card_bg``).
+        card_text: Body/value text on a card.
+        card_title: Heading text on a card.
+        card_key: Key/accent color (labels of key/value rows, chart accents).
+        divider: Subtle rule between an image and its side panel.
+        border: Hairline card outline, or ``None`` to draw none (dark cards rely
+            on their shadow instead of a border).
+
+    """
+
+    card_bg: Color
+    caption_bg: Color
+    card_text: Color
+    card_title: Color
+    card_key: Color
+    divider: Color
+    border: Color | None = None
+
+
+DARK_CHROME = Chrome(
+    card_bg=CARD_BG,
+    caption_bg=CAPTION_BG,
+    card_text=CARD_TEXT,
+    card_title=CARD_TITLE,
+    card_key=CARD_KEY,
+    divider=DIVIDER,
+    border=None,
+)
+"""Chrome for dark composite backgrounds: navy cards, near-white text."""
+
+LIGHT_CHROME = Chrome(
+    card_bg=LIGHT_CARD_BG,
+    caption_bg=LIGHT_CAPTION_BG,
+    card_text=LIGHT_CARD_TEXT,
+    card_title=LIGHT_CARD_TITLE,
+    card_key=LIGHT_CARD_KEY,
+    divider=LIGHT_DIVIDER,
+    border=LIGHT_CARD_BORDER,
+)
+"""Chrome for light composite backgrounds: white cards, deep-purple text."""
+
+
+def chrome_for(background: Color) -> Chrome:
+    """Return the card/panel chrome that suits ``background``.
+
+    Picks `LIGHT_CHROME` for a light background (one that reads best with dark
+    text) and `DARK_CHROME` otherwise, so cards drawn on top stay legible and
+    on-brand either way.
+
+    Args:
+        background: The composite background the chrome will sit on.
+
+    Returns:
+        The matching `Chrome` preset.
+
+    Examples:
+        >>> chrome_for(BACKGROUND) is DARK_CHROME
+        True
+        >>> chrome_for(LIGHT_BACKGROUND) is LIGHT_CHROME
+        True
+
+    """
+    return (
+        LIGHT_CHROME
+        if background.readable_text_color().r < 128
+        else DARK_CHROME
+    )

--- a/luxonis_ml/utils/color/brand.py
+++ b/luxonis_ml/utils/color/brand.py
@@ -1,6 +1,8 @@
 """The Luxonis brand colors and the UI-chrome palette built from them.
 
-These are the company colors, taken from the Luxonis design tokens. They are the
+These are the company colors, transcribed from the shared Luxonis design tokens
+that the frontend renders from, so a chart or overlay produced here matches the
+web UI rather than drifting from it. They are the
 single home for every non-label color in the stack: visualization *chrome* —
 composite backgrounds, card fills, panel keys and titles, dividers, chart tracks,
 and verdict marks — is colored from here so the framing reads as on-brand out of
@@ -16,7 +18,7 @@ Examples:
     Color(r=76, g=79, b=241, a=255)
     >>> brand.CARD_KEY is brand.PERIWINKLE
     True
-    >>> brand.chrome_for(brand.LIGHT_BACKGROUND).card_text is brand.PURPLE
+    >>> brand.chrome_for(brand.LIGHT_BACKGROUND).card_text is brand.PURPLE_TEXT
     True
 
 """
@@ -25,26 +27,60 @@ from dataclasses import dataclass
 
 from .base import Color
 
-# -- Core brand colors (the Luxonis design tokens) --------------------------
-PURPLE = Color(76, 79, 241)  # #4c4ff1 — the primary "Luxonis Purple"
+# -- Core brand colors ------------------------------------------------------
+# The saturated fill of each semantic family, for filled surfaces rather than
+# for text (the `*_TEXT` ramp below is what labels and icons should use).
+PURPLE = Color(76, 79, 241)  # #4C4FF1 — the primary "Luxonis Purple"
 GREEN = Color(18, 183, 106)  # #12B76A
 ORANGE = Color(220, 104, 3)  # #DC6803
 RED = Color(240, 68, 56)  # #F04438
 
-PERIWINKLE = Color(141, 164, 244)  # #8da4f4 — light purple
+# The lighter "decoration" variant of each family, which the design system also
+# uses as that family's outline/border color.
+PERIWINKLE = Color(141, 164, 244)  # #8DA4F4 — light purple
 MINT = Color(108, 233, 166)  # #6CE9A6 — light green
 AMBER = Color(254, 200, 75)  # #FEC84B — light orange
 SALMON = Color(253, 162, 155)  # #FDA29B — light red
 
 #: A deep-indigo shade of :data:`PURPLE` (same hue) for light-mode titles and
-#: headings: a stronger, higher-contrast purple that outranks the regular
-#: brand purple used for body text (≈ 15:1 on white).
+#: headings: a stronger, higher-contrast purple that outranks :data:`PURPLE_TEXT`
+#: used for body text (≈ 15:1 on white). The design system has no heading token,
+#: so this one is ours.
 PURPLE_TITLE = Color(22, 24, 112)  # #161870
 
-# Neutral "ink" ramp (brand grays), dark to light.
+# Neutral "ink" ramp (brand grays), dark to light: body text, labels, and the
+# muted/disabled end of the scale.
 INK = Color(29, 41, 57)  # #1D2939 — darkest neutral
 SLATE = Color(71, 84, 103)  # #475467 — muted mid neutral
 STEEL = Color(102, 112, 133)  # #667085 — light neutral
+FAINT = Color(211, 211, 211)  # #D3D3D3 — disabled text and placeholders
+
+# -- Soft tints -------------------------------------------------------------
+# Pale fills for chips, badges, and callouts, one per family. The active tint is
+# a pale blue rather than a wash of the indigo brand purple; that is what the
+# design system specifies, not a transcription slip.
+PURPLE_SOFT = Color(220, 239, 252)  # #DCEFFC
+GRAY_SOFT = Color(242, 244, 247)  # #F2F4F7
+GREEN_SOFT = Color(236, 253, 243)  # #ECFDF3
+ORANGE_SOFT = Color(255, 250, 235)  # #FFFAEB
+RED_SOFT = Color(254, 243, 242)  # #FEF3F2
+
+# -- Foreground text colors -------------------------------------------------
+# Darkened per-family colors for text and icons, contrast-tuned to sit on the
+# soft tints above (or on white). Use these instead of the solids for anything
+# a reader has to actually read.
+PURPLE_TEXT = Color(87, 36, 232)  # #5724E8
+GRAY_TEXT = Color(52, 64, 84)  # #344054
+GREEN_TEXT = Color(2, 122, 72)  # #027A48
+ORANGE_TEXT = Color(181, 71, 8)  # #B54708
+RED_TEXT = Color(180, 35, 24)  # #B42318
+
+#: Neutral hairline border, for rules and outlines with no semantic color.
+GRAY_BORDER = Color(229, 229, 229)  # #E5E5E5
+
+#: The design system draws hover states as the base color at 85% alpha, so
+#: ``PURPLE.with_alpha(HOVER_ALPHA)`` is the hover fill for a purple surface.
+HOVER_ALPHA = 0xD9
 
 # -- Chrome palette (semantic; used across the annotations) -----------------
 #: Deep navy composite background painted behind stacks, grids, and pad gaps.
@@ -74,9 +110,9 @@ MUTED = SLATE  # empty track fills and the "other" segment
 LIGHT_CARD_BG = Color(255, 255, 255, 236)
 #: Caption chips in light mode: opaque white for a single crisp line.
 LIGHT_CAPTION_BG = Color(255, 255, 255, 240)
-LIGHT_CARD_TEXT = PURPLE  # body text in the regular brand purple
+LIGHT_CARD_TEXT = PURPLE_TEXT  # body text in the family's text purple
 LIGHT_CARD_TITLE = PURPLE_TITLE  # deeper heading, to outrank the body text
-LIGHT_CARD_KEY = PURPLE  # keys / accents in the bright brand purple
+LIGHT_CARD_KEY = PURPLE_TEXT  # keys / accents in the same text purple
 #: Hairline card border and image/panel rule, a translucent brand purple.
 LIGHT_CARD_BORDER = PURPLE.with_alpha(38)
 LIGHT_DIVIDER = PURPLE.with_alpha(46)

--- a/luxonis_ml/utils/color/gradient.py
+++ b/luxonis_ml/utils/color/gradient.py
@@ -1,0 +1,250 @@
+"""Color gradients (colormaps) for scalar fields such as heatmaps.
+
+A `Gradient` maps a scalar in ``[0, 1]`` to a `Color` by linearly interpolating
+between ordered color stops. It is the color model for `Heatmap`, kept separate
+from the class `Palette` because a heatmap colors a continuous magnitude, not a
+set of discrete classes.
+
+A handful of ready-made gradients are registered by name in :data:`GRADIENTS`
+(perceptually-uniform ones like ``"viridis"``/``"turbo"`` plus classics like
+``"jet"`` and ``"hot"``). Resolve a name or pass your own with
+`resolve_gradient`; build a custom one with `Gradient.from_colors`.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .base import Color, ColorLike
+
+
+@dataclass(frozen=True)
+class Gradient:
+    """A colormap: an ordered set of color stops interpolated in RGB.
+
+    A scalar ``t`` in ``[0, 1]`` is mapped to a color by piecewise-linear
+    interpolation between the surrounding stops. Values outside ``[0, 1]`` are
+    clamped.
+
+    Attributes:
+        stops: Ascending ``(position, color)`` pairs with positions in ``[0, 1]``;
+            the first should be at ``0.0`` and the last at ``1.0``.
+
+    Examples:
+        >>> g = Gradient.from_colors(["#000000", "#ff0000"])
+        >>> g.color_at(0.0)
+        Color(r=0, g=0, b=0, a=255)
+        >>> g.color_at(0.5)
+        Color(r=128, g=0, b=0, a=255)
+        >>> g.color_at(1.0)
+        Color(r=255, g=0, b=0, a=255)
+
+    """
+
+    stops: tuple[tuple[float, Color], ...]
+
+    @classmethod
+    def from_colors(
+        cls,
+        colors: "list[ColorLike]",
+        *,
+        positions: "list[float] | None" = None,
+    ) -> "Gradient":
+        """Build a gradient from colors, evenly spaced unless positions are given.
+
+        Args:
+            colors: Two or more colors (hex strings, tuples, or `Color`), from the
+                low end of the scale to the high end.
+            positions: Optional stop positions in ``[0, 1]``, one per color; when
+                ``None`` the colors are spread evenly from ``0`` to ``1``.
+
+        Returns:
+            The `Gradient`.
+
+        Raises:
+            ValueError: If fewer than two colors are given, or ``positions`` is
+                given with a different length than ``colors``.
+
+        """
+        parsed = [Color.parse(c) for c in colors]
+        if len(parsed) < 2:
+            raise ValueError("a gradient needs at least two colors")
+        if positions is None:
+            positions = list(np.linspace(0.0, 1.0, len(parsed)))
+        elif len(positions) != len(parsed):
+            raise ValueError("positions must have one entry per color")
+        stops = sorted(
+            ((float(p), c) for p, c in zip(positions, parsed, strict=True)),
+            key=lambda stop: stop[0],
+        )
+        return cls(tuple(stops))
+
+    def _channels(
+        self,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Return the stop positions and per-channel values as arrays."""
+        xp = np.array([p for p, _ in self.stops], dtype=np.float64)
+        rs = np.array([c.r for _, c in self.stops], dtype=np.float64)
+        gs = np.array([c.g for _, c in self.stops], dtype=np.float64)
+        bs = np.array([c.b for _, c in self.stops], dtype=np.float64)
+        return xp, rs, gs, bs
+
+    def color_at(self, t: float) -> Color:
+        """Return the color at scalar ``t`` in ``[0, 1]`` (clamped).
+
+        Args:
+            t: The position along the gradient.
+
+        Returns:
+            The interpolated `Color`.
+
+        """
+        xp, rs, gs, bs = self._channels()
+        clamped = min(1.0, max(0.0, t))
+        return Color(
+            round(float(np.interp(clamped, xp, rs))),
+            round(float(np.interp(clamped, xp, gs))),
+            round(float(np.interp(clamped, xp, bs))),
+        )
+
+    def colorize(self, field: np.ndarray) -> np.ndarray:
+        """Map a scalar field to RGB, interpolating each channel through the stops.
+
+        Args:
+            field: An array of scalars, expected in ``[0, 1]`` (values are
+                clamped). Any shape is accepted.
+
+        Returns:
+            A ``uint8`` array shaped ``(*field.shape, 3)`` in RGB order.
+
+        """
+        xp, rs, gs, bs = self._channels()
+        flat = np.clip(np.asarray(field, dtype=np.float64).ravel(), 0.0, 1.0)
+        rgb = np.stack(
+            [
+                np.interp(flat, xp, rs),
+                np.interp(flat, xp, gs),
+                np.interp(flat, xp, bs),
+            ],
+            axis=-1,
+        )
+        return np.round(rgb).astype(np.uint8).reshape(*field.shape, 3)
+
+
+# Preset colormaps. The perceptually-uniform families (viridis, magma, inferno,
+# plasma, turbo) are approximated with a handful of anchor colors sampled from
+# the matplotlib originals — close enough for visualization, without shipping a
+# 256-entry lookup table. Classics (jet, hot, coolwarm, grayscale) round it out.
+_PRESETS: dict[str, tuple[str, ...]] = {
+    "viridis": (
+        "#440154",
+        "#414487",
+        "#2a788e",
+        "#22a884",
+        "#7ad151",
+        "#fde725",
+    ),
+    "magma": (
+        "#000004",
+        "#180f3e",
+        "#451077",
+        "#721f81",
+        "#9f2f7f",
+        "#cd4071",
+        "#f1605d",
+        "#fd9567",
+        "#feca8d",
+        "#fcfdbf",
+    ),
+    "inferno": (
+        "#000004",
+        "#320a5a",
+        "#781c6d",
+        "#bb3754",
+        "#ed6925",
+        "#fbb61a",
+        "#fcffa4",
+    ),
+    "plasma": (
+        "#0d0887",
+        "#5402a3",
+        "#8b0aa5",
+        "#b83289",
+        "#db5c68",
+        "#f48849",
+        "#febd2a",
+        "#f0f921",
+    ),
+    "turbo": (
+        "#30123b",
+        "#4145ab",
+        "#4675ed",
+        "#39a2fc",
+        "#1bcfd4",
+        "#24eca6",
+        "#61fc6c",
+        "#a4fc3b",
+        "#d1e834",
+        "#f3c53a",
+        "#fe9b2d",
+        "#ec7014",
+        "#cb4149",
+        "#7a0403",
+    ),
+    "jet": ("#000080", "#0000ff", "#00ffff", "#ffff00", "#ff0000", "#800000"),
+    "hot": ("#000000", "#ff0000", "#ffff00", "#ffffff"),
+    "coolwarm": ("#3b4cc0", "#6f91f2", "#dddcdc", "#f6a385", "#b40426"),
+    "rdbu": ("#67001f", "#d6604d", "#f7f7f7", "#4393c3", "#053061"),
+    "seismic": ("#00004c", "#0000ff", "#ffffff", "#ff0000", "#800000"),
+    "grayscale": ("#000000", "#ffffff"),
+}
+
+GRADIENTS: dict[str, Gradient] = {
+    name: Gradient.from_colors(list(colors))
+    for name, colors in _PRESETS.items()
+}
+"""The preset gradients, keyed by name. See `resolve_gradient`."""
+
+DEFAULT_GRADIENT = "turbo"
+"""Name of the gradient used by `Heatmap` when none is given."""
+
+DIVERGING_GRADIENTS = frozenset({"coolwarm", "rdbu", "seismic"})
+"""Presets built around a neutral midpoint.
+
+Each has an odd number of evenly spaced stops with a near-white one in the
+middle, so pairing them with `Heatmap.center` puts that neutral color exactly on
+the center value. The sequential presets have no such anchor: centering them
+still balances the range, but no particular color marks the middle.
+"""
+
+DEFAULT_DIVERGING_GRADIENT = "coolwarm"
+"""Name of the gradient used for a signed field when none is given."""
+
+
+def resolve_gradient(gradient: "Gradient | str") -> Gradient:
+    """Resolve a gradient or a preset name to a `Gradient`.
+
+    Args:
+        gradient: A `Gradient`, or the name of a preset in :data:`GRADIENTS`.
+
+    Returns:
+        The `Gradient`.
+
+    Raises:
+        KeyError: If a name is given that is not a registered preset.
+
+    Examples:
+        >>> resolve_gradient("grayscale").color_at(1.0)
+        Color(r=255, g=255, b=255, a=255)
+
+    """
+    if isinstance(gradient, Gradient):
+        return gradient
+    try:
+        return GRADIENTS[gradient]
+    except KeyError:
+        names = ", ".join(sorted(GRADIENTS))
+        raise KeyError(
+            f"unknown gradient {gradient!r}; choose one of: {names}, "
+            "or pass a Gradient"
+        ) from None

--- a/luxonis_ml/utils/color/gradient.py
+++ b/luxonis_ml/utils/color/gradient.py
@@ -9,13 +9,19 @@ A handful of ready-made gradients are registered by name in :data:`GRADIENTS`
 (perceptually-uniform ones like ``"viridis"``/``"turbo"`` plus classics like
 ``"jet"`` and ``"hot"``). Resolve a name or pass your own with
 `resolve_gradient`; build a custom one with `Gradient.from_colors`.
+
+Only `Gradient.colorize` needs NumPy, and it imports it when called, so this
+module stays importable on a base ``luxonis-ml`` install that has no NumPy.
 """
 
 from dataclasses import dataclass
-
-import numpy as np
+from typing import TYPE_CHECKING
 
 from .base import Color, ColorLike
+
+if TYPE_CHECKING:
+    import numpy as np
+    import numpy.typing as npt
 
 
 @dataclass(frozen=True)
@@ -63,34 +69,41 @@ class Gradient:
 
         Raises:
             ValueError: If fewer than two colors are given, or ``positions`` is
-                given with a different length than ``colors``.
+                given with a different length than ``colors``, a position outside
+                ``[0, 1]``, or a repeated position.
 
         """
         parsed = [Color.parse(c) for c in colors]
         if len(parsed) < 2:
             raise ValueError("a gradient needs at least two colors")
         if positions is None:
-            positions = list(np.linspace(0.0, 1.0, len(parsed)))
+            last = len(parsed) - 1
+            positions = [i / last for i in range(len(parsed))]
         elif len(positions) != len(parsed):
             raise ValueError("positions must have one entry per color")
+        else:
+            outside = [p for p in positions if not 0.0 <= p <= 1.0]
+            if outside:
+                raise ValueError(
+                    f"positions must lie in [0, 1], got {outside}"
+                )
+            # Two stops at the same position leave the interpolation between
+            # them undefined, so the resulting color would depend on stop order.
+            if len(set(positions)) != len(positions):
+                raise ValueError(
+                    f"positions must be distinct, got {positions}"
+                )
         stops = sorted(
             ((float(p), c) for p, c in zip(positions, parsed, strict=True)),
             key=lambda stop: stop[0],
         )
         return cls(tuple(stops))
 
-    def _channels(
-        self,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """Return the stop positions and per-channel values as arrays."""
-        xp = np.array([p for p, _ in self.stops], dtype=np.float64)
-        rs = np.array([c.r for _, c in self.stops], dtype=np.float64)
-        gs = np.array([c.g for _, c in self.stops], dtype=np.float64)
-        bs = np.array([c.b for _, c in self.stops], dtype=np.float64)
-        return xp, rs, gs, bs
-
     def color_at(self, t: float) -> Color:
         """Return the color at scalar ``t`` in ``[0, 1]`` (clamped).
+
+        All four channels are interpolated, so a gradient between translucent
+        stops fades in alpha too.
 
         Args:
             t: The position along the gradient.
@@ -99,36 +112,53 @@ class Gradient:
             The interpolated `Color`.
 
         """
-        xp, rs, gs, bs = self._channels()
         clamped = min(1.0, max(0.0, t))
-        return Color(
-            round(float(np.interp(clamped, xp, rs))),
-            round(float(np.interp(clamped, xp, gs))),
-            round(float(np.interp(clamped, xp, bs))),
-        )
+        if clamped <= self.stops[0][0]:
+            return self.stops[0][1]
+        for (p0, low), (p1, high) in zip(
+            self.stops, self.stops[1:], strict=False
+        ):
+            if clamped <= p1:
+                # Slope first, then offset — the order ``np.interp`` uses, so a
+                # scalar lookup rounds exactly like the same value in `colorize`.
+                span, offset = p1 - p0, clamped - p0
+                return Color(
+                    round(low.r + (high.r - low.r) / span * offset),
+                    round(low.g + (high.g - low.g) / span * offset),
+                    round(low.b + (high.b - low.b) / span * offset),
+                    round(low.a + (high.a - low.a) / span * offset),
+                )
+        return self.stops[-1][1]
 
-    def colorize(self, field: np.ndarray) -> np.ndarray:
+    def colorize(self, field: "npt.ArrayLike") -> "np.ndarray":
         """Map a scalar field to RGB, interpolating each channel through the stops.
+
+        Only the color channels are mapped: the result is opaque RGB, so any
+        alpha on the stops is ignored. Use `color_at` when alpha matters.
 
         Args:
             field: An array of scalars, expected in ``[0, 1]`` (values are
-                clamped). Any shape is accepted.
+                clamped). Any shape is accepted, as is anything
+                ``numpy.asarray`` converts to a float array.
 
         Returns:
             A ``uint8`` array shaped ``(*field.shape, 3)`` in RGB order.
 
         """
-        xp, rs, gs, bs = self._channels()
-        flat = np.clip(np.asarray(field, dtype=np.float64).ravel(), 0.0, 1.0)
+        import numpy as np
+
+        values = np.asarray(field, dtype=np.float64)
+        xp = [p for p, _ in self.stops]
+        flat = np.clip(values.ravel(), 0.0, 1.0)
         rgb = np.stack(
             [
-                np.interp(flat, xp, rs),
-                np.interp(flat, xp, gs),
-                np.interp(flat, xp, bs),
+                np.interp(flat, xp, [c.r for _, c in self.stops]),
+                np.interp(flat, xp, [c.g for _, c in self.stops]),
+                np.interp(flat, xp, [c.b for _, c in self.stops]),
             ],
             axis=-1,
         )
-        return np.round(rgb).astype(np.uint8).reshape(*field.shape, 3)
+        return np.round(rgb).astype(np.uint8).reshape(*values.shape, 3)
 
 
 # Preset colormaps. The perceptually-uniform families (viridis, magma, inferno,

--- a/luxonis_ml/utils/color/gradient.py
+++ b/luxonis_ml/utils/color/gradient.py
@@ -1,7 +1,7 @@
 """Color gradients (colormaps) for scalar fields such as heatmaps.
 
 A `Gradient` maps a scalar in ``[0, 1]`` to a `Color` by linearly interpolating
-between ordered color stops. It is the color model for `Heatmap`, kept separate
+between ordered color stops. It is the color model for heatmaps, kept separate
 from the class `Palette` because a heatmap colors a continuous magnitude, not a
 set of discrete classes.
 
@@ -81,18 +81,13 @@ class Gradient:
             positions = [i / last for i in range(len(parsed))]
         elif len(positions) != len(parsed):
             raise ValueError("positions must have one entry per color")
-        else:
-            outside = [p for p in positions if not 0.0 <= p <= 1.0]
-            if outside:
-                raise ValueError(
-                    f"positions must lie in [0, 1], got {outside}"
-                )
-            # Two stops at the same position leave the interpolation between
-            # them undefined, so the resulting color would depend on stop order.
-            if len(set(positions)) != len(positions):
-                raise ValueError(
-                    f"positions must be distinct, got {positions}"
-                )
+
+        outside = [p for p in positions if not 0.0 <= p <= 1.0]
+        if outside:
+            raise ValueError(f"positions must lie in [0, 1], got {outside}")
+        # Two stops at one position leave the color between them undefined.
+        if len(set(positions)) != len(positions):
+            raise ValueError(f"positions must be distinct, got {positions}")
         stops = sorted(
             ((float(p), c) for p, c in zip(positions, parsed, strict=True)),
             key=lambda stop: stop[0],
@@ -148,8 +143,8 @@ class Gradient:
         import numpy as np
 
         values = np.asarray(field, dtype=np.float64)
-        xp = [p for p, _ in self.stops]
         flat = np.clip(values.ravel(), 0.0, 1.0)
+        xp = [p for p, _ in self.stops]
         rgb = np.stack(
             [
                 np.interp(flat, xp, [c.r for _, c in self.stops]),
@@ -236,14 +231,14 @@ GRADIENTS: dict[str, Gradient] = {
 """The preset gradients, keyed by name. See `resolve_gradient`."""
 
 DEFAULT_GRADIENT = "turbo"
-"""Name of the gradient used by `Heatmap` when none is given."""
+"""Name of the gradient used for an unsigned field when none is given."""
 
 DIVERGING_GRADIENTS = frozenset({"coolwarm", "rdbu", "seismic"})
 """Presets built around a neutral midpoint.
 
 Each has an odd number of evenly spaced stops with a near-white one in the
-middle, so pairing them with `Heatmap.center` puts that neutral color exactly on
-the center value. The sequential presets have no such anchor: centering them
+middle, so centering a heatmap puts that neutral color exactly on the center
+value. The sequential presets have no such anchor: centering them
 still balances the range, but no particular color marks the middle.
 """
 

--- a/luxonis_ml/utils/color/palette.py
+++ b/luxonis_ml/utils/color/palette.py
@@ -24,6 +24,7 @@ the same order, but not across arbitrary reorderings. Pin a color explicitly wit
 map to one exact color forever.
 """
 
+import threading
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 
@@ -201,6 +202,9 @@ class Palette:
         """
         self._generator: ColorGenerator = generator or GoldenRatioColors()
         self._colors: dict[str, Color] = {}
+        # Assigning a color is a read-modify-write of `_colors`, and
+        # `DEFAULT_PALETTE` is shared process-wide, so serialize that step.
+        self._lock = threading.Lock()
         self._pins: dict[str, Color] = {
             name: Color.parse(value) for name, value in (colors or {}).items()
         }
@@ -228,7 +232,9 @@ class Palette:
         """Return the color assigned to ``key``, assigning a new one if unseen.
 
         The first time a key is seen it takes the next color in the sequence; every
-        later call for that key returns the same color.
+        later call for that key returns the same color. Two threads racing to
+        register different keys get different colors: only the assignment is
+        locked, so the common case of an already-colored key stays lock-free.
 
         Args:
             key: The label (or any string identity) to color.
@@ -242,8 +248,11 @@ class Palette:
             return pinned
         color = self._colors.get(key)
         if color is None:
-            color = self._generator(len(self._colors))
-            self._colors[key] = color
+            with self._lock:
+                color = self._colors.get(key)
+                if color is None:
+                    color = self._generator(len(self._colors))
+                    self._colors[key] = color
         return color
 
     def pin(self, key: str, color: ColorLike) -> "Palette":

--- a/luxonis_ml/utils/color/palette.py
+++ b/luxonis_ml/utils/color/palette.py
@@ -1,0 +1,293 @@
+"""Distinct class colors from a pluggable, index-based generator.
+
+A `Palette` hands each new class the next color from a **color generator**:
+a callable ``int -> Color`` that maps a sequence position to a color. The default
+generator, `GoldenRatioColors`, offsets each hue from the last by the golden
+angle (~137.5°) so no two classes land on a near-identical hue — the failure mode a
+fixed palette (or a hash into one) can't avoid once the class count approaches the
+palette size. Class labels stay on this distinct-hue scheme on purpose; the
+Luxonis brand colors are reserved for chrome (see
+`luxonis_ml.utils.color.brand`), though `SequenceColors` lets a caller anchor a
+palette to the brand :data:`BRAND_COLORS` when they want to.
+
+Swapping the whole color scheme is a single argument — ``Palette(generator=...)`` —
+so the strategy lives in exactly one place and callers (``BBox`` and friends) only
+ever touch `Palette.color_for`.
+
+Because the spacing guarantee only holds for *sequential* indices, colors are
+assigned in order of first appearance and memoized: within a process, a class keeps
+its color across every image (the module-level :data:`DEFAULT_PALETTE` is shared).
+The trade-off is that a class's color depends on the order classes are first seen,
+not on its name alone — stable within a run and across runs that request classes in
+the same order, but not across arbitrary reorderings. Pin a color explicitly with
+``BBox(color=...)`` or by pre-registering classes in a fixed order when a name must
+map to one exact color forever.
+"""
+
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+
+from .base import Color, ColorLike
+from .brand import AMBER, GREEN, MINT, ORANGE, PERIWINKLE, PURPLE, RED, SALMON
+
+ColorGenerator = Callable[[int], Color]
+"""A callable mapping a zero-based sequence index to a `Color`."""
+
+# The Luxonis brand colors in a distinct-hue order: the four solid hues first,
+# then their lighter "decoration" variants, interleaving hues so adjacent
+# entries stay easy to tell apart. Reserved for callers that explicitly want a
+# brand-anchored palette (via `SequenceColors`); the default palette does not
+# use them (see the module docstring).
+BRAND_COLORS: tuple[Color, ...] = (
+    PURPLE,
+    GREEN,
+    ORANGE,
+    RED,
+    PERIWINKLE,
+    MINT,
+    AMBER,
+    SALMON,
+)
+"""The Luxonis brand color sequence, for use with `SequenceColors`."""
+
+# (sqrt(5) - 1) / 2 — the golden ratio's conjugate. Stepping the hue by this each
+# time is the classic low-discrepancy way to spread points around a circle.
+_GOLDEN_CONJUGATE = 0.6180339887498949
+
+# A second, unrelated irrational step used to vary lightness, so that even the rare
+# pair of hue-neighbors (at large class counts) still differ in brightness.
+_LIGHTNESS_STEP = 0.7548776662466927
+
+
+@dataclass(frozen=True)
+class GoldenRatioColors:
+    """Maps a sequence index to a distinct color via golden-ratio hue spacing.
+
+    This is the default :data:`ColorGenerator`. Every knob that shapes the look
+    lives here, so restyling the whole palette means constructing one of these (or
+    any other ``int -> Color`` callable) and passing it to `Palette`.
+
+    Attributes:
+        hue0: Hue of index 0, in ``[0, 1]`` turns (default a blue).
+        saturation: Fixed saturation of every color, in ``[0, 1]``.
+        lightness: Base lightness of every color, in ``[0, 1]``.
+        lightness_jitter: Peak lightness deviation from ``lightness``, applied via a
+            second low-discrepancy sequence so brightness varies subtly (which keeps
+            colors apart even when hues get crowded at high class counts).
+
+    Examples:
+        >>> gen = GoldenRatioColors()
+        >>> gen(0) == gen(0)
+        True
+        >>> gen(0) == gen(1)
+        False
+
+    """
+
+    hue0: float = 0.6
+    saturation: float = 0.7
+    lightness: float = 0.62
+    lightness_jitter: float = 0.12
+
+    def __call__(self, index: int) -> Color:
+        """Generate the color for sequence position ``index``.
+
+        Args:
+            index: The zero-based position in the sequence.
+
+        Returns:
+            The generated `Color`.
+
+        """
+        hue = (self.hue0 + index * _GOLDEN_CONJUGATE) % 1.0
+        jitter = 2.0 * ((index * _LIGHTNESS_STEP) % 1.0) - 1.0
+        lightness = self.lightness + self.lightness_jitter * jitter
+        return Color.from_hls(hue, lightness, self.saturation)
+
+
+@dataclass(frozen=True)
+class SequenceColors:
+    """Hand out a fixed list of colors first, then fall back to a generator.
+
+    Wraps a list of ``anchors`` (e.g. the Luxonis :data:`BRAND_COLORS`) so the
+    first classes seen get those exact colors, in order. Once the anchors run
+    out, index ``n`` continues through ``overflow`` (a `GoldenRatioColors`
+    generator by default, queried with an index that restarts at the first
+    post-anchor class), so any number of classes still receive distinct colors.
+
+    Attributes:
+        anchors: Colors handed out for indices ``0 .. len(anchors) - 1``.
+        overflow: Generator used once the anchors are exhausted.
+
+    Examples:
+        >>> from luxonis_ml.vizlab.color import Color
+        >>> gen = SequenceColors((Color(255, 0, 0), Color(0, 255, 0)))
+        >>> gen(0)
+        Color(r=255, g=0, b=0, a=255)
+        >>> gen(1)
+        Color(r=0, g=255, b=0, a=255)
+        >>> gen(2) == gen(2)  # overflow is deterministic
+        True
+
+    """
+
+    anchors: tuple[Color, ...]
+    overflow: ColorGenerator = field(default_factory=GoldenRatioColors)
+
+    def __call__(self, index: int) -> Color:
+        """Return the color for sequence position ``index``.
+
+        Args:
+            index: The zero-based position in the sequence.
+
+        Returns:
+            The anchor color at ``index``, or the overflow generator's color for
+            the position past the anchors.
+
+        """
+        if 0 <= index < len(self.anchors):
+            return self.anchors[index]
+        return self.overflow(index - len(self.anchors))
+
+
+class Palette:
+    """Assigns colors to classes in order of first use, from a color generator.
+
+    Examples:
+        A class keeps its color; different classes get different colors:
+
+        >>> p = Palette()
+        >>> p.color_for("car") == p.color_for("car")
+        True
+        >>> p.color_for("car") == p.color_for("bus")
+        False
+        >>> len(p)
+        2
+
+        Two fresh palettes agree as long as classes are requested in the same order
+        (``"car"`` is index 0 in both) ...
+
+        >>> Palette().color_for("car") == Palette().color_for("car")
+        True
+
+        ... but the color follows first-seen order, not the name, so reordering
+        changes it:
+
+        >>> Palette(["a", "b"]).color_for("b") == Palette(
+        ...     ["b", "a"]
+        ... ).color_for("b")
+        False
+
+    """
+
+    def __init__(
+        self,
+        classes: Iterable[str] | None = None,
+        *,
+        generator: ColorGenerator | None = None,
+        colors: Mapping[str, ColorLike] | None = None,
+    ) -> None:
+        """Create a palette, optionally pinning class order and exact colors.
+
+        Args:
+            classes: Class names to register up front, in the order that fixes their
+                colors. Any class not listed is assigned on first use.
+            generator: The ``int -> Color`` strategy; defaults to
+                `GoldenRatioColors`.
+            colors: Explicit ``{class_name: color}`` pins. A pinned class always
+                gets exactly that color and never consumes a generator slot, so
+                pins do not shift the sequence colors of the other classes.
+
+        """
+        self._generator: ColorGenerator = generator or GoldenRatioColors()
+        self._colors: dict[str, Color] = {}
+        self._pins: dict[str, Color] = {
+            name: Color.parse(value) for name, value in (colors or {}).items()
+        }
+        if classes is not None:
+            for name in classes:
+                self.color_for(name)
+
+    def __len__(self) -> int:
+        """Return the number of classes assigned a color so far."""
+        return len(self._colors)
+
+    def at(self, index: int) -> Color:
+        """Return the color for sequence position ``index`` (without registering it).
+
+        Args:
+            index: The zero-based position in the generator's sequence.
+
+        Returns:
+            The generated `Color`.
+
+        """
+        return self._generator(index)
+
+    def color_for(self, key: str) -> Color:
+        """Return the color assigned to ``key``, assigning a new one if unseen.
+
+        The first time a key is seen it takes the next color in the sequence; every
+        later call for that key returns the same color.
+
+        Args:
+            key: The label (or any string identity) to color.
+
+        Returns:
+            The assigned `Color`.
+
+        """
+        pinned = self._pins.get(key)
+        if pinned is not None:
+            return pinned
+        color = self._colors.get(key)
+        if color is None:
+            color = self._generator(len(self._colors))
+            self._colors[key] = color
+        return color
+
+    def pin(self, key: str, color: ColorLike) -> "Palette":
+        """Pin ``key`` to exactly ``color`` and return ``self`` for chaining.
+
+        A pinned class always gets this color from `color_for`, overriding any
+        generated one, and never consumes a generator slot.
+
+        Args:
+            key: The class name (or string identity) to pin.
+            color: The exact color for ``key`` (any :data:`ColorLike`).
+
+        Returns:
+            This palette, to allow fluent chaining.
+
+        """
+        self._pins[key] = Color.parse(color)
+        return self
+
+    def with_colors(self, colors: Mapping[str, ColorLike]) -> "Palette":
+        """Return a copy of this palette with additional class-color pins.
+
+        The copy shares the generator and inherits already-assigned colors and
+        pins; ``colors`` are merged on top. The original is not mutated, so a
+        shared palette can be specialized per render without side effects.
+
+        Args:
+            colors: Extra ``{class_name: color}`` pins to add.
+
+        Returns:
+            A new `Palette` with the merged pins.
+
+        """
+        clone = Palette(generator=self._generator)
+        clone._colors = dict(self._colors)
+        clone._pins = {
+            **self._pins,
+            **{name: Color.parse(value) for name, value in colors.items()},
+        }
+        return clone
+
+
+DEFAULT_PALETTE = Palette()
+"""The process-wide default `Palette`, shared so a class keeps its color.
+
+Uses the distinct-hue `GoldenRatioColors` generator: label colors are chosen to
+stay far apart, not to match the brand (which is reserved for chrome)."""

--- a/luxonis_ml/utils/color/palette.py
+++ b/luxonis_ml/utils/color/palette.py
@@ -11,8 +11,8 @@ Luxonis brand colors are reserved for chrome (see
 palette to the brand :data:`BRAND_COLORS` when they want to.
 
 Swapping the whole color scheme is a single argument — ``Palette(generator=...)`` —
-so the strategy lives in exactly one place and callers (``BBox`` and friends) only
-ever touch `Palette.color_for`.
+so the strategy lives in exactly one place and callers only ever touch
+`Palette.color_for`.
 
 Because the spacing guarantee only holds for *sequential* indices, colors are
 assigned in order of first appearance and memoized: within a process, a class keeps
@@ -20,8 +20,8 @@ its color across every image (the module-level :data:`DEFAULT_PALETTE` is shared
 The trade-off is that a class's color depends on the order classes are first seen,
 not on its name alone — stable within a run and across runs that request classes in
 the same order, but not across arbitrary reorderings. Pin a color explicitly with
-``BBox(color=...)`` or by pre-registering classes in a fixed order when a name must
-map to one exact color forever.
+`Palette.pin` or by pre-registering classes in a fixed order when a name must map
+to one exact color forever.
 """
 
 import threading

--- a/luxonis_ml/utils/color/palette.py
+++ b/luxonis_ml/utils/color/palette.py
@@ -120,7 +120,7 @@ class SequenceColors:
         overflow: Generator used once the anchors are exhausted.
 
     Examples:
-        >>> from luxonis_ml.vizlab.color import Color
+        >>> from luxonis_ml.utils.color import Color
         >>> gen = SequenceColors((Color(255, 0, 0), Color(0, 255, 0)))
         >>> gen(0)
         Color(r=255, g=0, b=0, a=255)

--- a/tests/test_utils/test_color.py
+++ b/tests/test_utils/test_color.py
@@ -166,12 +166,7 @@ def test_with_colors_returns_a_specialized_copy():
 
 
 def test_two_threads_registering_at_once_get_different_colors():
-    """An unguarded `color_for` gives two racing threads the same color.
-
-    Assigning reads the class count and then writes it back, so the two steps
-    have to be atomic for concurrent first uses to land on different slots.
-
-    """
+    """Concurrent first uses must not land on the same generator slot."""
 
     def slow_generator(index: int) -> Color:
         # Widen the read-then-write window so the race is hit every run.
@@ -256,16 +251,9 @@ def test_colorize_accepts_any_array_like():
 def test_gradient_module_imports_without_numpy(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Importing this module must not need NumPy.
-
-    NumPy is not among the base dependencies in ``utils/requirements.txt``, so
-    only `Gradient.colorize` — which is handed a NumPy array anyway — may need
-    it.
-
-    """
-    monkeypatch.setitem(
-        sys.modules, "numpy", None
-    )  # makes `import numpy` fail
+    """NumPy is not a base dependency; this module must import without it."""
+    # A None entry makes `import numpy` fail.
+    monkeypatch.setitem(sys.modules, "numpy", None)
 
     # Load a second copy from source, so the real module stays untouched. The
     # package name keeps its relative imports resolvable.

--- a/tests/test_utils/test_color.py
+++ b/tests/test_utils/test_color.py
@@ -1,0 +1,108 @@
+"""The shared Color primitive parses every color-like input shape."""
+
+import pytest
+
+from luxonis_ml.utils.color import Color
+
+
+def test_parse_hex_with_and_without_hash():
+    assert Color.parse("#4c8dff") == Color(76, 141, 255)
+    assert Color.parse("4c8dff") == Color(76, 141, 255)
+    assert Color.parse("#abc") == Color(170, 187, 204)
+
+
+def test_parse_named_basics_without_pillow():
+    # The common names resolve from the built-in table (no Pillow needed).
+    assert Color.parse("black").rgb == (0, 0, 0)
+    assert Color.parse("white").rgb == (255, 255, 255)
+    assert Color.parse("Gray").rgb == (128, 128, 128)
+    assert Color.parse("grey").rgb == (128, 128, 128)
+
+
+def test_parse_named_extended_via_pillow():
+    pytest.importorskip("PIL")
+    assert Color.parse("royalblue").rgb == (65, 105, 225)
+
+
+def test_parse_grayscale_int():
+    assert Color.parse(0).rgb == (0, 0, 0)
+    assert Color.parse(128).rgb == (128, 128, 128)
+    assert Color.parse(255).rgb == (255, 255, 255)
+
+
+def test_parse_tuples():
+    assert Color.parse((1, 2, 3)) == Color(1, 2, 3, 255)
+    assert Color.parse((1, 2, 3, 4)) == Color(1, 2, 3, 4)
+
+
+def test_out_of_range_channels_are_clamped():
+    # Color clamps rather than raising (its consistent policy).
+    assert Color.parse(300).rgb == (255, 255, 255)
+    assert Color.parse(-5).rgb == (0, 0, 0)
+    assert Color.parse((1, 2, 300)).rgb == (1, 2, 255)
+
+
+def test_rgb_and_rgba_properties():
+    assert Color(1, 2, 3, 4).rgb == (1, 2, 3)
+    assert Color(1, 2, 3, 4).rgba == (1, 2, 3, 4)
+
+
+def test_parse_color_passthrough():
+    color = Color(10, 20, 30)
+    assert Color.parse(color) is color
+
+
+def test_invalid_hex_reports_as_hex():
+    with pytest.raises(ValueError, match="invalid hex color"):
+        Color.parse("#12")
+
+
+def test_invalid_name_raises():
+    with pytest.raises(ValueError, match="invalid color name"):
+        Color.parse("not_a_real_color")
+
+
+def test_bool_is_rejected():
+    with pytest.raises(ValueError, match="cannot parse color"):
+        Color.parse(True)
+
+
+def test_chrome_for_picks_by_background_lightness():
+    """A light background resolves the white/purple chrome; a dark one the navy."""
+    from luxonis_ml.utils.color import brand
+
+    light = brand.chrome_for(brand.LIGHT_BACKGROUND)
+    dark = brand.chrome_for(brand.BACKGROUND)
+    assert light is brand.LIGHT_CHROME
+    assert dark is brand.DARK_CHROME
+    # Light chrome: white card, brand-purple body text, deeper purple titles,
+    # and a hairline border.
+    assert light.card_bg.r > 240
+    assert light.card_bg.g > 240
+    assert light.card_text is brand.PURPLE
+    assert light.card_title is brand.PURPLE_TITLE
+    assert light.border is not None
+    # Dark chrome: navy card, light-purple (periwinkle) text — on-brand, not
+    # plain white — and no border (it relies on its shadow instead).
+    assert dark.card_text is brand.PERIWINKLE
+    assert dark.card_text.b > dark.card_text.r  # blue-purple, not white
+    assert dark.border is None
+
+
+def test_light_title_is_deeper_than_body_purple():
+    """The light-mode heading outranks the regular-purple body text."""
+    from luxonis_ml.utils.color import brand
+
+    # Same blue-purple family, but the title is clearly darker than the body.
+    assert brand.PURPLE_TITLE.b > brand.PURPLE_TITLE.r
+    assert sum(brand.PURPLE_TITLE.rgb) < sum(brand.PURPLE.rgb)
+
+
+def test_dark_title_is_lighter_than_body_on_dark():
+    """The dark-mode heading is a brighter lavender than the periwinkle body."""
+    from luxonis_ml.utils.color import brand
+
+    dark = brand.chrome_for(brand.BACKGROUND)
+    # Same purple family, but the title is clearly lighter (stronger on dark).
+    assert dark.card_title.b > dark.card_title.r
+    assert sum(dark.card_title.rgb) > sum(dark.card_text.rgb)

--- a/tests/test_utils/test_color.py
+++ b/tests/test_utils/test_color.py
@@ -91,7 +91,7 @@ def test_chrome_for_picks_by_background_lightness():
     # and a hairline border.
     assert light.card_bg.r > 240
     assert light.card_bg.g > 240
-    assert light.card_text is brand.PURPLE
+    assert light.card_text is brand.PURPLE_TEXT
     assert light.card_title is brand.PURPLE_TITLE
     assert light.border is not None
     # Dark chrome: navy card, light-purple (periwinkle) text — on-brand, not
@@ -107,7 +107,7 @@ def test_light_title_is_deeper_than_body_purple():
 
     # Same blue-purple family, but the title is clearly darker than the body.
     assert brand.PURPLE_TITLE.b > brand.PURPLE_TITLE.r
-    assert sum(brand.PURPLE_TITLE.rgb) < sum(brand.PURPLE.rgb)
+    assert sum(brand.PURPLE_TITLE.rgb) < sum(brand.PURPLE_TEXT.rgb)
 
 
 def test_dark_title_is_lighter_than_body_on_dark():
@@ -118,6 +118,25 @@ def test_dark_title_is_lighter_than_body_on_dark():
     # Same purple family, but the title is clearly lighter (stronger on dark).
     assert dark.card_title.b > dark.card_title.r
     assert sum(dark.card_title.rgb) > sum(dark.card_text.rgb)
+
+
+def test_each_family_reads_as_dark_text_on_its_own_soft_tint():
+    """A swapped soft/text pair is still two valid brand colors, so only the
+    contrast relationship between them catches a bad transcription.
+    """
+    from luxonis_ml.utils.color import brand
+
+    families = [
+        (brand.PURPLE, brand.PURPLE_SOFT, brand.PURPLE_TEXT),
+        (brand.GREEN, brand.GREEN_SOFT, brand.GREEN_TEXT),
+        (brand.ORANGE, brand.ORANGE_SOFT, brand.ORANGE_TEXT),
+        (brand.RED, brand.RED_SOFT, brand.RED_TEXT),
+    ]
+    for solid, soft, text in families:
+        assert soft.is_light  # a pale chip fill ...
+        assert not text.is_light  # ... that its label reads as dark on
+        # The text color is the darkened variant of the family, not the solid.
+        assert sum(text.rgb) < sum(solid.rgb)
 
 
 def test_parse_rejects_a_tuple_that_is_not_rgb_or_rgba():

--- a/tests/test_utils/test_color.py
+++ b/tests/test_utils/test_color.py
@@ -1,9 +1,15 @@
 """The shared Color primitive parses every color-like input shape."""
 
+import importlib.util
+import sys
+import time
+from threading import Thread
+
 import numpy as np
 import pytest
 
 from luxonis_ml.utils.color import Color, Palette
+from luxonis_ml.utils.color import gradient as gradient_module
 from luxonis_ml.utils.color.gradient import (
     GRADIENTS,
     Gradient,
@@ -159,6 +165,35 @@ def test_with_colors_returns_a_specialized_copy():
     assert shared.color_for("person") != Color(0, 255, 0)
 
 
+def test_two_threads_registering_at_once_get_different_colors():
+    """An unguarded `color_for` gives two racing threads the same color.
+
+    Assigning reads the class count and then writes it back, so the two steps
+    have to be atomic for concurrent first uses to land on different slots.
+
+    """
+
+    def slow_generator(index: int) -> Color:
+        # Widen the read-then-write window so the race is hit every run.
+        time.sleep(0.05)
+        return Color(index, index, index)
+
+    palette = Palette(generator=slow_generator)
+    assigned: dict[str, Color] = {}
+
+    def register(key: str) -> None:
+        assigned[key] = palette.color_for(key)
+
+    threads = [Thread(target=register, args=(key,)) for key in ("car", "bus")]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert assigned["car"] != assigned["bus"]
+    assert {c.r for c in assigned.values()} == {0, 1}
+
+
 def test_gradient_needs_at_least_two_colors():
     with pytest.raises(ValueError, match="at least two colors"):
         Gradient.from_colors(["red"])
@@ -187,6 +222,68 @@ def test_colorize_maps_a_field_to_rgb_and_clamps():
     assert rgb[0, 0].tolist() == [0, 0, 0]
     assert rgb[1, 0].tolist() == [0, 0, 0]
     assert rgb[1, 1].tolist() == [255, 255, 255]
+
+
+def test_gradient_rejects_positions_outside_the_unit_range():
+    with pytest.raises(ValueError, match=r"must lie in \[0, 1\]"):
+        Gradient.from_colors(["black", "white"], positions=[0.0, 1.5])
+
+
+def test_gradient_rejects_repeated_positions():
+    # Two stops at the same spot make the color between them order-dependent.
+    with pytest.raises(ValueError, match="must be distinct"):
+        Gradient.from_colors(
+            ["black", "white", "red"], positions=[0.0, 0.5, 0.5]
+        )
+
+
+def test_color_at_interpolates_alpha_with_the_color_channels():
+    gradient = Gradient.from_colors([Color(0, 0, 0, 0), Color(0, 0, 0, 200)])
+    assert gradient.color_at(0.0).a == 0
+    assert gradient.color_at(0.5).a == 100
+    assert gradient.color_at(1.0).a == 200
+
+
+def test_colorize_accepts_any_array_like():
+    # The field is converted with np.asarray, so nested lists work too.
+    rgb = Gradient.from_colors(["black", "white"]).colorize([[0.0, 1.0]])
+
+    assert rgb.shape == (1, 2, 3)
+    assert rgb[0, 0].tolist() == [0, 0, 0]
+    assert rgb[0, 1].tolist() == [255, 255, 255]
+
+
+def test_gradient_module_imports_without_numpy(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Importing this module must not need NumPy.
+
+    NumPy is not among the base dependencies in ``utils/requirements.txt``, so
+    only `Gradient.colorize` — which is handed a NumPy array anyway — may need
+    it.
+
+    """
+    monkeypatch.setitem(
+        sys.modules, "numpy", None
+    )  # makes `import numpy` fail
+
+    # Load a second copy from source, so the real module stays untouched. The
+    # package name keeps its relative imports resolvable.
+    spec = importlib.util.spec_from_file_location(
+        "luxonis_ml.utils.color._gradient_probe", gradient_module.__file__
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    probe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(probe)
+
+    assert probe.Gradient.from_colors(["black", "white"]).color_at(
+        0.5
+    ).rgb == (
+        128,
+        128,
+        128,
+    )
 
 
 def test_resolve_gradient_accepts_a_name_or_an_instance():

--- a/tests/test_utils/test_color.py
+++ b/tests/test_utils/test_color.py
@@ -1,8 +1,14 @@
 """The shared Color primitive parses every color-like input shape."""
 
+import numpy as np
 import pytest
 
-from luxonis_ml.utils.color import Color
+from luxonis_ml.utils.color import Color, Palette
+from luxonis_ml.utils.color.gradient import (
+    GRADIENTS,
+    Gradient,
+    resolve_gradient,
+)
 
 
 def test_parse_hex_with_and_without_hash():
@@ -106,3 +112,90 @@ def test_dark_title_is_lighter_than_body_on_dark():
     # Same purple family, but the title is clearly lighter (stronger on dark).
     assert dark.card_title.b > dark.card_title.r
     assert sum(dark.card_title.rgb) > sum(dark.card_text.rgb)
+
+
+def test_parse_rejects_a_tuple_that_is_not_rgb_or_rgba():
+    with pytest.raises(ValueError, match="3 or 4 elements"):
+        Color.parse((1, 2))  # type: ignore[arg-type]
+
+
+def test_saturate_moves_toward_and_away_from_gray():
+    muted = Color(140, 120, 120)
+    assert muted.saturate(1.0).hls[2] == pytest.approx(1.0)
+    assert muted.saturate(-1.0).hls[2] == pytest.approx(0.0)
+    assert muted.saturate(0.5).a == muted.a  # alpha is preserved
+
+
+def test_shift_hue_is_a_full_circle_at_one_turn():
+    color = Color(200, 60, 40)
+    assert color.shift_hue(1.0).rgb == color.rgb
+    # Half a turn lands on the opposing hue, so the channels really move.
+    assert color.shift_hue(0.5).rgb != color.rgb
+
+
+def test_palette_at_does_not_register_the_class():
+    palette = Palette()
+    first = palette.at(0)
+    assert len(palette) == 0  # peeking must not consume a slot
+    assert palette.color_for("car") == first
+    assert len(palette) == 1
+
+
+def test_pinned_class_keeps_its_color_and_consumes_no_slot():
+    palette = Palette().pin("car", "#ff0000")
+    assert palette.color_for("car") == Color(255, 0, 0)
+    # The pin sits outside the sequence, so the next class still gets slot 0.
+    assert palette.color_for("person") == palette.at(0)
+
+
+def test_with_colors_returns_a_specialized_copy():
+    shared = Palette(classes=["car"])
+    car = shared.color_for("car")
+    special = shared.with_colors({"person": "#00ff00"})
+
+    assert special.color_for("person") == Color(0, 255, 0)
+    assert special.color_for("car") == car  # inherits what was assigned
+    # The original is untouched, so a shared palette survives specialization.
+    assert shared.color_for("person") != Color(0, 255, 0)
+
+
+def test_gradient_needs_at_least_two_colors():
+    with pytest.raises(ValueError, match="at least two colors"):
+        Gradient.from_colors(["red"])
+
+
+def test_gradient_positions_must_match_the_colors():
+    with pytest.raises(ValueError, match="one entry per color"):
+        Gradient.from_colors(["black", "white"], positions=[0.0, 0.5, 1.0])
+
+
+def test_gradient_honors_explicit_stop_positions():
+    # White arrives at 0.25, so the midpoint is already past it.
+    gradient = Gradient.from_colors(["black", "white"], positions=[0.0, 0.25])
+    assert gradient.color_at(0.25) == Color(255, 255, 255)
+    assert gradient.color_at(0.5) == Color(255, 255, 255)
+    assert gradient.color_at(0.125).rgb == (128, 128, 128)
+
+
+def test_colorize_maps_a_field_to_rgb_and_clamps():
+    field = np.array([[0.0, 1.0], [-5.0, 5.0]])
+    rgb = Gradient.from_colors(["black", "white"]).colorize(field)
+
+    assert rgb.shape == (2, 2, 3)
+    assert rgb.dtype == np.uint8
+    # Out-of-range scalars clamp to the end stops rather than wrapping.
+    assert rgb[0, 0].tolist() == [0, 0, 0]
+    assert rgb[1, 0].tolist() == [0, 0, 0]
+    assert rgb[1, 1].tolist() == [255, 255, 255]
+
+
+def test_resolve_gradient_accepts_a_name_or_an_instance():
+    assert resolve_gradient("grayscale") is GRADIENTS["grayscale"]
+    custom = Gradient.from_colors(["black", "white"])
+    assert resolve_gradient(custom) is custom
+
+
+def test_resolve_gradient_names_the_alternatives_when_unknown():
+    with pytest.raises(KeyError, match="unknown gradient") as excinfo:
+        resolve_gradient("not-a-gradient")
+    assert "grayscale" in str(excinfo.value)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
There was no first-class way to handle colors in the ecosystem. The only color parser available was matplotlib's, which returns floats in `[0, 1]` and drags a plotting dependency into code that just wants an RGB triple (see the letterbox bug in the follow-up PR). Anything that draws — augmentations, dataset health charts, visualization — needs one shared, dependency-free color model.

Split out of the `feat/vizlab` branch, which had grown to 81 commits; this is one of eight self-contained pieces that do not belong to vizlab itself.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
New `luxonis_ml.utils.color` package, re-exported as `luxonis_ml.utils.Color`:
- `base.py` — the `Color` model and `ColorLike` alias: parsing from names, hex, grayscale ints and RGB(A) tuples, with 0-255 channels and clamping.
- `brand.py` — the Luxonis brand colors and background-aware chrome.
- `gradient.py` — named gradients and interpolation.
- `palette.py` — stable, visually distinct per-label color assignment.

Purely additive: no existing module changes behavior in this PR.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
No new third-party dependencies — the package is pure Python and stdlib only. Additive API, so nothing breaks. Later PRs in this series build on it.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
`tests/test_utils/test_color.py` — 14 tests covering parsing, clamping, conversion, gradients and palette stability. `ruff`, `pyright` and the pydoctor build are clean.

## AI Usage
<!--
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Claude:claude-fable-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive color utilities for parsing, validation, transformations, and readable text color selection.
  * Added brand colors, light/dark visualization palettes, semantic accents, and adaptive display styling.
  * Added customizable palettes with deterministic generation, pinned colors, and class-based assignment.
  * Added gradient generation, interpolation, preset gradients, and field colorization support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->