### PR TITLE
Fix letterbox padding with named and hex fill colors

### DIFF
--- a/luxonis_ml/data/augmentations/custom/letterbox_resize.py
+++ b/luxonis_ml/data/augmentations/custom/letterbox_resize.py
@@ -6,35 +6,7 @@ import numpy as np
 from typing_extensions import override
 
 from luxonis_ml.typing import RGB
-from luxonis_ml.typing import Color as ColorLike
-from luxonis_ml.utils.color import Color
-
-
-def _fill_color(value: ColorLike, name: str) -> RGB:
-    """Resolve a user-supplied padding value to an ``(r, g, b)`` triple.
-
-    `Color.parse` clamps channels into ``[0, 255]``. A fill value outside that
-    range is a config mistake rather than something to round off, so it is
-    rejected here instead of silently padding with a different color.
-
-    Args:
-        value: A color name, hex string, grayscale int, or ``(r, g, b)`` tuple.
-        name: The parameter name, used in the error message.
-
-    Returns:
-        The resolved RGB triple.
-
-    Raises:
-        ValueError: If any channel falls outside ``[0, 255]``.
-
-    """
-    channels = value if isinstance(value, tuple) else (value,)
-    for channel in channels:
-        if isinstance(channel, int) and not 0 <= channel <= 255:
-            raise ValueError(
-                f"{name} value {channel} is out of range [0, 255]"
-            )
-    return Color.parse(value).rgb
+from luxonis_ml.utils.color import Color, ColorLike
 
 
 class LetterboxResize(A.DualTransform):
@@ -63,8 +35,8 @@ class LetterboxResize(A.DualTransform):
             width: The desired width of the output image
             interpolation: ``cv2`` flag to specify interpolation used
                 when resizing. Defaults to ``cv2.INTER_LINEAR``.
-            image_fill_value: Padding value for images.
-                Can be a string color name or an RGB tuple.
+            image_fill_value: Padding value for images. Can be a color name,
+                a hex string, a grayscale integer, or an RGB tuple.
                 Defaults to ``"black"``.
             mask_fill_value: Padding value for masks. Must be an integer
                 representing a class label. Defaults to ``0`` (background).
@@ -78,10 +50,12 @@ class LetterboxResize(A.DualTransform):
         self.width = width
 
         self._interpolation = interpolation
-        self._image_fill_value = _fill_color(
+        self._image_fill_value = self._fill_color(
             image_fill_value, "image_fill_value"
         )
-        self._mask_fill_value = _fill_color(mask_fill_value, "mask_fill_value")
+        self._mask_fill_value = self._fill_color(
+            mask_fill_value, "mask_fill_value"
+        )
 
     @property
     @override
@@ -372,6 +346,21 @@ class LetterboxResize(A.DualTransform):
             padded_img = padded_img[..., None]
 
         return padded_img
+
+    @staticmethod
+    def _fill_color(value: ColorLike, name: str) -> RGB:
+        """Resolve a padding value to RGB, rejecting out-of-range channels.
+
+        `Color.parse` clamps rather than raising, which for a fill value would
+        silently pad with a color the config never asked for.
+        """
+        channels = value if isinstance(value, tuple) else (value,)
+        for channel in channels:
+            if isinstance(channel, int) and not 0 <= channel <= 255:
+                raise ValueError(
+                    f"{name} value {channel} is out of range [0, 255]"
+                )
+        return Color.parse(value).rgb
 
 
 def create_letterbox_or_resize(

--- a/luxonis_ml/data/augmentations/custom/letterbox_resize.py
+++ b/luxonis_ml/data/augmentations/custom/letterbox_resize.py
@@ -5,8 +5,36 @@ import cv2
 import numpy as np
 from typing_extensions import override
 
-from luxonis_ml.data.utils.visualizations import resolve_color
-from luxonis_ml.typing import RGB, Color
+from luxonis_ml.typing import RGB
+from luxonis_ml.typing import Color as ColorLike
+from luxonis_ml.utils.color import Color
+
+
+def _fill_color(value: ColorLike, name: str) -> RGB:
+    """Resolve a user-supplied padding value to an ``(r, g, b)`` triple.
+
+    `Color.parse` clamps channels into ``[0, 255]``. A fill value outside that
+    range is a config mistake rather than something to round off, so it is
+    rejected here instead of silently padding with a different color.
+
+    Args:
+        value: A color name, hex string, grayscale int, or ``(r, g, b)`` tuple.
+        name: The parameter name, used in the error message.
+
+    Returns:
+        The resolved RGB triple.
+
+    Raises:
+        ValueError: If any channel falls outside ``[0, 255]``.
+
+    """
+    channels = value if isinstance(value, tuple) else (value,)
+    for channel in channels:
+        if isinstance(channel, int) and not 0 <= channel <= 255:
+            raise ValueError(
+                f"{name} value {channel} is out of range [0, 255]"
+            )
+    return Color.parse(value).rgb
 
 
 class LetterboxResize(A.DualTransform):
@@ -24,7 +52,7 @@ class LetterboxResize(A.DualTransform):
         height: int,
         width: int,
         interpolation: int = cv2.INTER_LINEAR,
-        image_fill_value: Color = "black",
+        image_fill_value: ColorLike = "black",
         mask_fill_value: int = 0,
         p: float = 1.0,
     ):
@@ -50,8 +78,10 @@ class LetterboxResize(A.DualTransform):
         self.width = width
 
         self._interpolation = interpolation
-        self._image_fill_value = resolve_color(image_fill_value)
-        self._mask_fill_value = resolve_color(mask_fill_value)
+        self._image_fill_value = _fill_color(
+            image_fill_value, "image_fill_value"
+        )
+        self._mask_fill_value = _fill_color(mask_fill_value, "mask_fill_value")
 
     @property
     @override

--- a/tests/test_data/test_augmentations/test_letterbox.py
+++ b/tests/test_data/test_augmentations/test_letterbox.py
@@ -18,15 +18,27 @@ def test_letterbox():
     assert x["image"].shape == (HEIGHT, WIDTH, 3)
 
 
-def test_letterbox_fill_values_resolve_to_rgb():
-    # Fill colors resolve through the shared Color to proper 0-255 RGB.
-    assert LetterboxResize(HEIGHT, WIDTH)._image_fill_value == (0, 0, 0)
-    assert LetterboxResize(
-        HEIGHT, WIDTH, image_fill_value="white"
-    )._image_fill_value == (255, 255, 255)
-    assert LetterboxResize(
-        HEIGHT, WIDTH, image_fill_value=(10, 20, 30)
-    )._image_fill_value == (10, 20, 30)
+@pytest.mark.parametrize(
+    ("fill", "expected"),
+    [
+        ("white", (255, 255, 255)),
+        ("red", (255, 0, 0)),
+        ("#0000ff", (0, 0, 255)),
+        (128, (128, 128, 128)),
+        ((0, 128, 255), (0, 128, 255)),
+    ],
+)
+def test_letterbox_pads_with_the_requested_color(
+    fill: str | int | tuple[int, int, int],
+    expected: tuple[int, int, int],
+):
+    """Fill colors used to resolve to 0-1 floats, padding with near-black."""
+    img = np.zeros((100, 100, 3), dtype=np.uint8)
+    letterbox = LetterboxResize(HEIGHT, WIDTH, image_fill_value=fill)
+    padded = letterbox(image=img, labels={})["image"]
+    # A square image in a 4:3 frame is padded on the left and right only.
+    assert (padded[:, 0] == expected).all()
+    assert (padded[:, -1] == expected).all()
 
 
 @pytest.mark.parametrize(
@@ -34,25 +46,12 @@ def test_letterbox_fill_values_resolve_to_rgb():
 )
 def test_letterbox_rejects_out_of_range_fill_values(
     fill: int | tuple[int, int, int],
-) -> None:
-    """A fill value outside [0, 255] is a config error, not something to clamp.
-
-    The shared `Color.parse` clamps, which would silently pad every letterboxed
-    image with a different color than the config asked for.
-    """
+):
+    """`Color.parse` clamps, which would pad with a color nobody asked for."""
     with pytest.raises(ValueError, match=r"out of range \[0, 255\]"):
         LetterboxResize(HEIGHT, WIDTH, image_fill_value=fill)
 
 
-def test_letterbox_rejects_out_of_range_mask_fill_value() -> None:
+def test_letterbox_rejects_out_of_range_mask_fill_value():
     with pytest.raises(ValueError, match="mask_fill_value"):
         LetterboxResize(HEIGHT, WIDTH, mask_fill_value=999)
-
-
-def test_letterbox_accepts_the_full_valid_range() -> None:
-    assert LetterboxResize(
-        HEIGHT, WIDTH, image_fill_value=(0, 128, 255)
-    )._image_fill_value == (0, 128, 255)
-    assert LetterboxResize(
-        HEIGHT, WIDTH, image_fill_value=255
-    )._image_fill_value == (255, 255, 255)

--- a/tests/test_data/test_augmentations/test_letterbox.py
+++ b/tests/test_data/test_augmentations/test_letterbox.py
@@ -1,6 +1,7 @@
 from typing import Final
 
 import numpy as np
+import pytest
 
 from luxonis_ml.data.augmentations.custom.letterbox_resize import (
     LetterboxResize,
@@ -15,3 +16,43 @@ def test_letterbox():
     letterbox = LetterboxResize(HEIGHT, WIDTH, p=1.0)
     x = letterbox(image=img, labels={})
     assert x["image"].shape == (HEIGHT, WIDTH, 3)
+
+
+def test_letterbox_fill_values_resolve_to_rgb():
+    # Fill colors resolve through the shared Color to proper 0-255 RGB.
+    assert LetterboxResize(HEIGHT, WIDTH)._image_fill_value == (0, 0, 0)
+    assert LetterboxResize(
+        HEIGHT, WIDTH, image_fill_value="white"
+    )._image_fill_value == (255, 255, 255)
+    assert LetterboxResize(
+        HEIGHT, WIDTH, image_fill_value=(10, 20, 30)
+    )._image_fill_value == (10, 20, 30)
+
+
+@pytest.mark.parametrize(
+    "fill", [300, -1, (300, 20, 30), (10, 20, -5), (0, 0, 256)]
+)
+def test_letterbox_rejects_out_of_range_fill_values(
+    fill: int | tuple[int, int, int],
+) -> None:
+    """A fill value outside [0, 255] is a config error, not something to clamp.
+
+    The shared `Color.parse` clamps, which would silently pad every letterboxed
+    image with a different color than the config asked for.
+    """
+    with pytest.raises(ValueError, match=r"out of range \[0, 255\]"):
+        LetterboxResize(HEIGHT, WIDTH, image_fill_value=fill)
+
+
+def test_letterbox_rejects_out_of_range_mask_fill_value() -> None:
+    with pytest.raises(ValueError, match="mask_fill_value"):
+        LetterboxResize(HEIGHT, WIDTH, mask_fill_value=999)
+
+
+def test_letterbox_accepts_the_full_valid_range() -> None:
+    assert LetterboxResize(
+        HEIGHT, WIDTH, image_fill_value=(0, 128, 255)
+    )._image_fill_value == (0, 128, 255)
+    assert LetterboxResize(
+        HEIGHT, WIDTH, image_fill_value=255
+    )._image_fill_value == (255, 255, 255)


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
`LetterboxResize` resolved its fill colors through `luxonis_ml.data.utils.visualizations.resolve_color`, which delegated string colors to `matplotlib.colors.to_rgb` — that returns floats in `[0, 1]`. So `image_fill_value="white"` padded images with `(1, 1, 1)` on a uint8 image, i.e. effectively black, silently producing the opposite of what was asked for.

Split out of the `feat/vizlab` branch, which had grown to 81 commits; this is one of eight self-contained pieces that do not belong to vizlab itself.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Resolve fill values through `luxonis_ml.utils.color.Color`, which yields proper 0-255 channels, via a small `_fill_color()` helper.

`Color.parse` clamps out-of-range channels, whereas `resolve_color` raised. A fill value outside `[0, 255]` is a config mistake rather than something to round off, so `_fill_color` keeps rejecting it — and now names the offending parameter in the message. `mask_fill_value` goes through the same path.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
Behavior change, and an intentional one: a named or hex `image_fill_value` now pads with the requested color instead of black. Anyone who compensated for the old behavior by passing an explicit tuple is unaffected. Also removes the last non-vizlab consumer of `data.utils.visualizations`, which the vizlab work deletes.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
`tests/test_data/test_augmentations/test_letterbox.py` — 4 new tests (9 total in the file, all passing): named/tuple/default fills resolve to the right RGB, out-of-range values are rejected for both fill parameters, and the full valid range is accepted. The first is a direct regression test for the bug above.

## AI Usage
<!--
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Claude:claude-fable-5

---

> **Stacked on #466** (`feat/color-utils`). Based on that branch so the diff shows only this feature; GitHub retargets it to `main` once #466 merges.
