### PR TITLE
Dataset inspection query helpers

### DIFF
--- a/luxonis_ml/data/utils/inspection.py
+++ b/luxonis_ml/data/utils/inspection.py
@@ -65,9 +65,20 @@ class SampleFilterConfig:
 
     @property
     def task_filter(self) -> frozenset[str] | None:
-        """Deduplicated task scope, or ``None`` when every task is selected."""
+        """Deduplicated task scope, or ``None`` when every task is selected.
+
+        The set alone does not say whether the named tasks are wanted or
+        rejected. Use `accepts_task` to apply ``task_name_mode``.
+        """
         names = tuple(dict.fromkeys(self.task_name or []))
         return frozenset(names) if names else None
+
+    def accepts_task(self, task_name: str) -> bool:
+        """Whether one task passes the include or exclude task filter."""
+        names = self.task_filter
+        if names is None:
+            return True
+        return (task_name in names) == (self.task_name_mode == "include")
 
     def validate(
         self,
@@ -88,7 +99,7 @@ class SampleFilterConfig:
             )
 
         classes = frozenset(name.strip() for name in available_classes)
-        requested_classes = tuple(dict.fromkeys(self.class_name or []))
+        requested_classes = self._requested_classes()
         unknown_classes = [
             name for name in requested_classes if name not in classes
         ]
@@ -104,7 +115,7 @@ class SampleFilterConfig:
         """Build the immutable matcher consumed by inspect and compare."""
         search = self.search.strip() if self.search else ""
         return InspectionQuery(
-            class_names=frozenset(dict.fromkeys(self.class_name or [])),
+            class_names=frozenset(self._requested_classes()),
             class_name_mode=self.class_name_mode,
             annotation_types=frozenset(self.annotation_type or []),
             metadata=tuple(
@@ -116,6 +127,12 @@ class SampleFilterConfig:
             max_instances=self.max_instances,
             unlabeled_only=self.unlabeled_only,
             search=search or None,
+        )
+
+    def _requested_classes(self) -> tuple[str, ...]:
+        """Deduplicated class names, trimmed the way stored names are."""
+        return tuple(
+            dict.fromkeys(name.strip() for name in self.class_name or [])
         )
 
 

--- a/luxonis_ml/data/utils/inspection.py
+++ b/luxonis_ml/data/utils/inspection.py
@@ -1,0 +1,438 @@
+"""Typed sample-selection rules shared by dataset visualization commands."""
+
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Literal, TypeAlias
+
+from luxonis_ml.ldf import DatasetRecord, Detection
+from luxonis_ml.typing import Params, ParamValue, PrimitiveType
+
+InspectionAnnotationType: TypeAlias = Literal[
+    "array",
+    "boundingbox",
+    "classification",
+    "instance_segmentation",
+    "keypoints",
+    "metadata",
+    "segmentation",
+]
+"""Annotation families accepted by the inspector's type filter."""
+
+NameFilterMode: TypeAlias = Literal["include", "exclude"]
+"""Whether named tasks or classes are required or rejected."""
+
+
+@dataclass(frozen=True, slots=True)
+class SampleFilterConfig:
+    """Shared flat CLI options for selecting dataset samples.
+
+    Repeated task, class, and annotation-type values are alternatives within
+    their category. Different categories and repeated metadata expressions are
+    combined with ``and``. A selected sample retains all matching-task
+    annotations for visual context.
+
+    Attributes:
+        task_name: Complete task names to include or exclude.
+        task_name_mode: Include only or exclude the named tasks.
+        class_name: Class names to include or exclude when selecting samples.
+        class_name_mode: Include samples containing a named class or exclude
+            samples containing any named class.
+        annotation_type: Annotation families of which at least one must occur.
+        metadata_filter: Exact metadata predicates. Each occurrence takes
+            separate ``path value`` tokens; dotted paths address nested sample
+            metadata.
+        min_confidence: Minimum numeric ``score`` or ``confidence`` metadata on
+            at least one detection.
+        min_instances: Minimum number of spatial instances.
+        max_instances: Maximum number of spatial instances.
+        unlabeled_only: Select samples without annotations.
+        search: Case-insensitive substring matched against filenames, task and
+            class names, and sample or detection metadata.
+
+    """
+
+    task_name: list[str] | None = None
+    task_name_mode: NameFilterMode = "include"
+    class_name: list[str] | None = None
+    class_name_mode: NameFilterMode = "include"
+    annotation_type: list[InspectionAnnotationType] | None = None
+    metadata_filter: list[tuple[str, str]] | None = None
+    min_confidence: float | None = None
+    min_instances: int | None = None
+    max_instances: int | None = None
+    unlabeled_only: bool = False
+    search: str | None = None
+
+    @property
+    def task_filter(self) -> frozenset[str] | None:
+        """Deduplicated task scope, or ``None`` when every task is selected."""
+        names = tuple(dict.fromkeys(self.task_name or []))
+        return frozenset(names) if names else None
+
+    def validate(
+        self,
+        *,
+        available_tasks: Iterable[str] = (),
+        available_classes: Iterable[str] = (),
+    ) -> None:
+        """Reject requested task or class names absent from the supplied scope."""
+        tasks = tuple(dict.fromkeys(available_tasks))
+        requested_tasks = tuple(dict.fromkeys(self.task_name or []))
+        unknown_tasks = [task for task in requested_tasks if task not in tasks]
+        if unknown_tasks:
+            unknown = ", ".join(repr(task) for task in unknown_tasks)
+            available = ", ".join(repr(task) for task in tasks)
+            raise ValueError(
+                f"Unknown task name(s): {unknown}. "
+                f"Available task names: {available or '(none)'}."
+            )
+
+        classes = frozenset(name.strip() for name in available_classes)
+        requested_classes = tuple(dict.fromkeys(self.class_name or []))
+        unknown_classes = [
+            name for name in requested_classes if name not in classes
+        ]
+        if unknown_classes:
+            unknown = ", ".join(repr(name) for name in unknown_classes)
+            available = ", ".join(repr(name) for name in sorted(classes))
+            raise ValueError(
+                f"Unknown class name(s): {unknown}. "
+                f"Available class names: {available or '(none)'}."
+            )
+
+    def query(self) -> "InspectionQuery":
+        """Build the immutable matcher consumed by inspect and compare."""
+        search = self.search.strip() if self.search else ""
+        return InspectionQuery(
+            class_names=frozenset(dict.fromkeys(self.class_name or [])),
+            class_name_mode=self.class_name_mode,
+            annotation_types=frozenset(self.annotation_type or []),
+            metadata=tuple(
+                MetadataPredicate.from_pair(path, expected)
+                for path, expected in self.metadata_filter or []
+            ),
+            min_confidence=self.min_confidence,
+            min_instances=self.min_instances,
+            max_instances=self.max_instances,
+            unlabeled_only=self.unlabeled_only,
+            search=search or None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataPredicate:
+    """One exact metadata comparison supplied as separate path and value tokens.
+
+    Dotted paths address nested sample metadata. A single-segment path also
+    matches per-detection metadata, including nested sub-detections.
+    """
+
+    path: tuple[str, ...]
+    expected: str
+
+    @classmethod
+    def from_pair(cls, path: str, expected: str) -> "MetadataPredicate":
+        """Build a predicate from the CLI's separate path and value tokens."""
+        parts = tuple(part.strip() for part in path.split(".") if part.strip())
+        if not parts:
+            raise ValueError("Metadata filter paths cannot be empty.")
+        return cls(path=parts, expected=expected.strip())
+
+    def matches(
+        self,
+        sample_metadata: Params,
+        detections: Sequence[Detection],
+    ) -> bool:
+        """Whether sample or detection metadata contains the expected value."""
+        found, value = _metadata_path(sample_metadata, self.path)
+        if found and _metadata_equal(value, self.expected):
+            return True
+        if len(self.path) != 1:
+            return False
+        key = self.path[0]
+        return any(
+            key in detection.metadata
+            and _metadata_equal(detection.metadata[key], self.expected)
+            for detection in detections
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InspectionQuery:
+    """Conjunctive sample filters for dataset inspection and comparison.
+
+    Repeated class names and annotation types are alternatives within their
+    category; different categories are combined with ``and``. Filters select
+    whole samples rather than pruning matching detections from a selected
+    sample, preserving visual context.
+    """
+
+    class_names: frozenset[str] = field(default_factory=frozenset)
+    class_name_mode: NameFilterMode = "include"
+    annotation_types: frozenset[InspectionAnnotationType] = field(
+        default_factory=frozenset
+    )
+    metadata: tuple[MetadataPredicate, ...] = ()
+    min_confidence: float | None = None
+    min_instances: int | None = None
+    max_instances: int | None = None
+    unlabeled_only: bool = False
+    search: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate bounds and incompatible filters."""
+        if self.min_confidence is not None and not (
+            0.0 <= self.min_confidence <= 1.0
+        ):
+            raise ValueError("--min-confidence must be between 0 and 1.")
+        for name, value in (
+            ("--min-instances", self.min_instances),
+            ("--max-instances", self.max_instances),
+        ):
+            if value is not None and value < 0:
+                raise ValueError(f"{name} must be non-negative.")
+        if (
+            self.min_instances is not None
+            and self.max_instances is not None
+            and self.min_instances > self.max_instances
+        ):
+            raise ValueError(
+                "--min-instances cannot be greater than --max-instances."
+            )
+        if self.unlabeled_only and (
+            (self.class_names and self.class_name_mode == "include")
+            or self.annotation_types
+            or self.min_confidence is not None
+            or (self.min_instances is not None and self.min_instances > 0)
+        ):
+            raise ValueError(
+                "--unlabeled-only cannot be combined with an inclusive class "
+                "filter, annotation type, confidence, or a positive "
+                "minimum-instance filter."
+            )
+
+    @property
+    def active(self) -> bool:
+        """Whether the query contains at least one sample-level filter."""
+        return bool(
+            self.class_names
+            or self.annotation_types
+            or self.metadata
+            or self.min_confidence is not None
+            or self.min_instances is not None
+            or self.max_instances is not None
+            or self.unlabeled_only
+            or self.search
+        )
+
+    def matches(
+        self,
+        records: Mapping[str, DatasetRecord],
+        sample_metadata: Params,
+        *,
+        extra_annotation_types: frozenset[
+            InspectionAnnotationType
+        ] = frozenset(),
+    ) -> bool:
+        """Return whether one converted loader sample satisfies this query."""
+        detections = list(_record_detections(records.values()))
+        if self.unlabeled_only and (
+            extra_annotation_types or _has_annotations(detections)
+        ):
+            return False
+        if self.class_names:
+            matches_classes = _matches_classes(detections, self.class_names)
+            if matches_classes != (self.class_name_mode == "include"):
+                return False
+        if self.annotation_types and not _matches_annotation_types(
+            detections,
+            self.annotation_types,
+            extra_annotation_types,
+        ):
+            return False
+        if not _matches_instance_bounds(
+            detections, self.min_instances, self.max_instances
+        ):
+            return False
+        if self.min_confidence is not None and not _matches_confidence(
+            detections, self.min_confidence
+        ):
+            return False
+        if any(
+            not predicate.matches(sample_metadata, detections)
+            for predicate in self.metadata
+        ):
+            return False
+        return not self.search or _matches_search(
+            self.search, records, detections, sample_metadata
+        )
+
+
+def _record_detections(
+    records: Iterable[DatasetRecord],
+) -> Iterator[Detection]:
+    """Yield every top-level and nested detection from a record collection."""
+    for record in records:
+        if record.annotation is not None:
+            yield from _detection_tree(record.annotation)
+
+
+def _detection_tree(detection: Detection) -> Iterator[Detection]:
+    """Yield a detection followed by all nested sub-detections."""
+    yield detection
+    for child in detection.sub_detections.values():
+        yield from _detection_tree(child)
+
+
+def _has_annotations(detections: Sequence[Detection]) -> bool:
+    """Whether any detection carries a label, array, or metadata value."""
+    return any(detection.get_task_types() for detection in detections)
+
+
+def _matches_classes(
+    detections: Sequence[Detection], requested: frozenset[str]
+) -> bool:
+    """Whether any detection belongs to a requested class."""
+    return any(
+        detection.class_name is not None
+        and detection.class_name.strip() in requested
+        for detection in detections
+    )
+
+
+def _matches_annotation_types(
+    detections: Sequence[Detection],
+    requested: frozenset[InspectionAnnotationType],
+    extra: frozenset[InspectionAnnotationType],
+) -> bool:
+    """Whether any detection carries a requested annotation family."""
+    present = {
+        task_type
+        for detection in detections
+        for task_type in detection.get_task_types()
+    }
+    present.update(extra)
+    return any(
+        (
+            any(task_type.startswith("metadata/") for task_type in present)
+            if requested_type == "metadata"
+            else requested_type in present
+        )
+        for requested_type in requested
+    )
+
+
+def _matches_instance_bounds(
+    detections: Sequence[Detection],
+    minimum: int | None,
+    maximum: int | None,
+) -> bool:
+    """Whether the number of spatial instances falls within both bounds."""
+    count = sum(
+        detection.boundingbox is not None
+        or detection.keypoints is not None
+        or detection.instance_segmentation is not None
+        for detection in detections
+    )
+    return (minimum is None or count >= minimum) and (
+        maximum is None or count <= maximum
+    )
+
+
+def _matches_confidence(
+    detections: Sequence[Detection], minimum: float
+) -> bool:
+    """Whether any detection has ``score``/``confidence`` metadata above cutoff."""
+    return any(
+        confidence is not None and confidence >= minimum
+        for detection in detections
+        for confidence in (_detection_confidence(detection),)
+    )
+
+
+def _detection_confidence(detection: Detection) -> float | None:
+    """Read a numeric confidence from conventional detection metadata keys."""
+    for key in ("score", "confidence"):
+        value = detection.metadata.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return None
+
+
+def _matches_search(
+    query: str,
+    records: Mapping[str, DatasetRecord],
+    detections: Sequence[Detection],
+    sample_metadata: Params,
+) -> bool:
+    """Case-insensitive substring search over identity, labels, and metadata."""
+    needle = query.casefold()
+    values = [*records]
+    values.extend(
+        detection.class_name
+        for detection in detections
+        if detection.class_name is not None
+    )
+    values.extend(_params_strings(sample_metadata))
+    for detection in detections:
+        values.extend(str(key) for key in detection.metadata)
+        values.extend(str(value) for value in detection.metadata.values())
+    return any(needle in value.casefold() for value in values)
+
+
+def _params_strings(params: Params) -> Iterator[str]:
+    """Flatten a top-level metadata mapping into searchable text."""
+    for key, value in params.items():
+        yield key
+        yield from _metadata_strings(value)
+
+
+def _metadata_strings(value: ParamValue) -> Iterator[str]:
+    """Flatten recursive metadata keys and scalar values into search text."""
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            yield str(key)
+            yield from _metadata_strings(child)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        for child in value:
+            yield from _metadata_strings(child)
+        return
+    yield str(value)
+
+
+def _metadata_path(
+    metadata: Params, path: tuple[str, ...]
+) -> tuple[bool, ParamValue]:
+    """Resolve a dotted path without conflating a missing value with ``None``."""
+    current: Mapping[str, ParamValue] | Mapping[PrimitiveType, ParamValue] = (
+        metadata
+    )
+    value: ParamValue = None
+    for index, part in enumerate(path):
+        if not isinstance(current, Mapping) or part not in current:
+            return False, None
+        value = current[part]
+        if index == len(path) - 1:
+            return True, value
+        if not isinstance(value, Mapping):
+            return False, None
+        current = value
+    return False, None
+
+
+def _metadata_equal(value: ParamValue, expected: str) -> bool:
+    """Compare a scalar metadata value to its command-line representation."""
+    if isinstance(value, Mapping) or (
+        isinstance(value, Sequence) and not isinstance(value, str)
+    ):
+        return False
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        # Numbers must compare numerically, not by repr: a stored 0.5 has to
+        # match ``--metadata-filter score 0.50``, and a stored 1.0 has to match
+        # ``... count 1``.
+        try:
+            return float(value) == float(expected)
+        except ValueError:
+            return False
+    return str(value).casefold() == expected.casefold()

--- a/luxonis_ml/data/utils/inspection.py
+++ b/luxonis_ml/data/utils/inspection.py
@@ -1,22 +1,17 @@
-"""Typed sample-selection rules shared by dataset visualization commands."""
+"""Sample-selection rules shared by the dataset visualization commands."""
 
 from collections.abc import Iterable, Iterator, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
 from luxonis_ml.ldf import DatasetRecord, Detection
-from luxonis_ml.typing import Params, ParamValue
+from luxonis_ml.typing import Params, ParamValue, TaskType
 
-InspectionAnnotationType: TypeAlias = Literal[
-    "array",
-    "boundingbox",
-    "classification",
-    "instance_segmentation",
-    "keypoints",
-    "metadata",
-    "segmentation",
-]
-"""Annotation families accepted by the inspector's type filter."""
+InspectionAnnotationType: TypeAlias = TaskType | Literal["metadata"]
+"""Annotation families accepted by the inspector's type filter.
+
+Every `TaskType`, plus ``"metadata"`` for the whole ``metadata/<key>`` family.
+"""
 
 NameFilterMode: TypeAlias = Literal["include", "exclude"]
 """Whether named tasks or classes are required or rejected."""
@@ -70,8 +65,7 @@ class SampleFilterConfig:
         The set alone does not say whether the named tasks are wanted or
         rejected. Use `accepts_task` to apply ``task_name_mode``.
         """
-        names = tuple(dict.fromkeys(self.task_name or []))
-        return frozenset(names) if names else None
+        return frozenset(self.task_name) if self.task_name else None
 
     def accepts_task(self, task_name: str) -> bool:
         """Whether one task passes the include or exclude task filter."""
@@ -86,30 +80,15 @@ class SampleFilterConfig:
         available_tasks: Iterable[str] = (),
         available_classes: Iterable[str] = (),
     ) -> None:
-        """Reject requested task or class names absent from the supplied scope."""
-        tasks = tuple(dict.fromkeys(available_tasks))
-        requested_tasks = tuple(dict.fromkeys(self.task_name or []))
-        unknown_tasks = [task for task in requested_tasks if task not in tasks]
-        if unknown_tasks:
-            unknown = ", ".join(repr(task) for task in unknown_tasks)
-            available = ", ".join(repr(task) for task in tasks)
-            raise ValueError(
-                f"Unknown task name(s): {unknown}. "
-                f"Available task names: {available or '(none)'}."
-            )
-
-        classes = frozenset(name.strip() for name in available_classes)
-        requested_classes = self._requested_classes()
-        unknown_classes = [
-            name for name in requested_classes if name not in classes
-        ]
-        if unknown_classes:
-            unknown = ", ".join(repr(name) for name in unknown_classes)
-            available = ", ".join(repr(name) for name in sorted(classes))
-            raise ValueError(
-                f"Unknown class name(s): {unknown}. "
-                f"Available class names: {available or '(none)'}."
-            )
+        """Reject requested task or class names outside the given scope."""
+        _reject_unknown_names(
+            "task name", self.task_name or (), available_tasks
+        )
+        _reject_unknown_names(
+            "class name",
+            self._requested_classes(),
+            (name.strip() for name in available_classes),
+        )
 
     def query(self) -> "InspectionQuery":
         """Build the immutable matcher consumed by inspect and compare."""
@@ -130,10 +109,8 @@ class SampleFilterConfig:
         )
 
     def _requested_classes(self) -> tuple[str, ...]:
-        """Deduplicated class names, trimmed the way stored names are."""
-        return tuple(
-            dict.fromkeys(name.strip() for name in self.class_name or [])
-        )
+        """Class names trimmed the way stored class names are."""
+        return tuple(name.strip() for name in self.class_name or [])
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,11 +161,9 @@ class InspectionQuery:
     so the visual context stays complete.
     """
 
-    class_names: frozenset[str] = field(default_factory=frozenset)
+    class_names: frozenset[str] = frozenset()
     class_name_mode: NameFilterMode = "include"
-    annotation_types: frozenset[InspectionAnnotationType] = field(
-        default_factory=frozenset
-    )
+    annotation_types: frozenset[InspectionAnnotationType] = frozenset()
     metadata: tuple[MetadataPredicate, ...] = ()
     min_confidence: float | None = None
     min_instances: int | None = None
@@ -202,12 +177,10 @@ class InspectionQuery:
             0.0 <= self.min_confidence <= 1.0
         ):
             raise ValueError("--min-confidence must be between 0 and 1.")
-        for name, value in (
-            ("--min-instances", self.min_instances),
-            ("--max-instances", self.max_instances),
-        ):
-            if value is not None and value < 0:
-                raise ValueError(f"{name} must be non-negative.")
+        if self.min_instances is not None and self.min_instances < 0:
+            raise ValueError("--min-instances must be non-negative.")
+        if self.max_instances is not None and self.max_instances < 0:
+            raise ValueError("--max-instances must be non-negative.")
         if (
             self.min_instances is not None
             and self.max_instances is not None
@@ -285,31 +258,43 @@ class InspectionQuery:
         )
 
 
+def _reject_unknown_names(
+    kind: str, requested: Iterable[str], available: Iterable[str]
+) -> None:
+    known = frozenset(available)
+    unknown = [name for name in dict.fromkeys(requested) if name not in known]
+    if not unknown:
+        return
+    missing = ", ".join(repr(name) for name in unknown)
+    scope = ", ".join(repr(name) for name in sorted(known)) or "(none)"
+    raise ValueError(
+        f"Unknown {kind}(s): {missing}. Available {kind}s: {scope}."
+    )
+
+
 def _record_detections(
     records: Iterable[DatasetRecord],
 ) -> Iterator[Detection]:
-    """Yield every top-level and nested detection from a record collection."""
+    """Yield every top-level and nested detection of a record collection."""
     for record in records:
         if record.annotation is not None:
             yield from _detection_tree(record.annotation)
 
 
 def _detection_tree(detection: Detection) -> Iterator[Detection]:
-    """Yield a detection followed by all nested sub-detections."""
+    """Yield a detection followed by all of its nested sub-detections."""
     yield detection
     for child in detection.sub_detections.values():
         yield from _detection_tree(child)
 
 
 def _has_annotations(detections: Sequence[Detection]) -> bool:
-    """Whether any detection carries a label, array, or metadata value."""
     return any(detection.get_task_types() for detection in detections)
 
 
 def _matches_classes(
     detections: Sequence[Detection], requested: frozenset[str]
 ) -> bool:
-    """Whether any detection belongs to a requested class."""
     return any(
         detection.class_name is not None
         and detection.class_name.strip() in requested
@@ -322,20 +307,21 @@ def _matches_annotation_types(
     requested: frozenset[InspectionAnnotationType],
     extra: frozenset[InspectionAnnotationType],
 ) -> bool:
-    """Whether any detection carries a requested annotation family."""
+    """Whether any detection carries a requested annotation family.
+
+    ``"metadata"`` stands for the whole family, because
+    `Detection.get_task_types` reports one ``metadata/<key>`` type per key.
+    """
     present = {
         task_type
         for detection in detections
         for task_type in detection.get_task_types()
     }
     present.update(extra)
-    return any(
-        (
-            any(task_type.startswith("metadata/") for task_type in present)
-            if requested_type == "metadata"
-            else requested_type in present
-        )
-        for requested_type in requested
+    if present & (requested - {"metadata"}):
+        return True
+    return "metadata" in requested and any(
+        task_type.startswith("metadata/") for task_type in present
     )
 
 
@@ -344,7 +330,6 @@ def _matches_instance_bounds(
     minimum: int | None,
     maximum: int | None,
 ) -> bool:
-    """Whether the number of spatial instances falls within both bounds."""
     count = sum(
         detection.boundingbox is not None
         or detection.keypoints is not None
@@ -359,20 +344,15 @@ def _matches_instance_bounds(
 def _matches_confidence(
     detections: Sequence[Detection], minimum: float
 ) -> bool:
-    """Whether any detection has ``score``/``confidence`` metadata above cutoff."""
-    for detection in detections:
-        confidence = _detection_confidence(detection)
-        if confidence is not None and confidence >= minimum:
-            return True
-    return False
+    scores = (_detection_confidence(detection) for detection in detections)
+    return any(score is not None and score >= minimum for score in scores)
 
 
 def _detection_confidence(detection: Detection) -> float | None:
-    """Read a numeric confidence from conventional detection metadata keys."""
     for key in ("score", "confidence"):
-        value = detection.metadata.get(key)
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            return float(value)
+        score = _as_number(detection.metadata.get(key))
+        if score is not None:
+            return score
     return None
 
 
@@ -382,19 +362,27 @@ def _matches_search(
     detections: Sequence[Detection],
     sample_metadata: Params,
 ) -> bool:
-    """Case-insensitive substring search over identity, labels, and metadata."""
     needle = query.casefold()
-    values = [*records]
-    values.extend(
-        detection.class_name
-        for detection in detections
-        if detection.class_name is not None
+    return any(
+        needle in text.casefold()
+        for text in _searchable_text(records, detections, sample_metadata)
     )
-    values.extend(_metadata_strings(sample_metadata))
+
+
+def _searchable_text(
+    records: Mapping[str, DatasetRecord],
+    detections: Sequence[Detection],
+    sample_metadata: Params,
+) -> Iterator[str]:
+    """Yield the task names, class names, and metadata the search covers."""
+    yield from records
+    yield from _metadata_strings(sample_metadata)
     for detection in detections:
-        values.extend(str(key) for key in detection.metadata)
-        values.extend(str(value) for value in detection.metadata.values())
-    return any(needle in value.casefold() for value in values)
+        if detection.class_name is not None:
+            yield detection.class_name
+        for key, value in detection.metadata.items():
+            yield key
+            yield str(value)
 
 
 def _metadata_strings(value: ParamValue) -> Iterator[str]:
@@ -429,12 +417,24 @@ def _metadata_equal(value: ParamValue, expected: str) -> bool:
         isinstance(value, Sequence) and not isinstance(value, str)
     ):
         return False
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
-        # Numbers must compare numerically, not by repr: a stored 0.5 has to
-        # match ``--metadata-filter score 0.50``, and a stored 1.0 has to match
-        # ``... count 1``.
-        try:
-            return float(value) == float(expected)
-        except ValueError:
-            return False
-    return str(value).casefold() == expected.casefold()
+    number = _as_number(value)
+    if number is None:
+        return str(value).casefold() == expected.casefold()
+    # Numbers must compare numerically, not by repr: a stored 0.5 has to match
+    # ``--metadata-filter score 0.50``, and a stored 1.0 has to match
+    # ``... count 1``.
+    try:
+        return number == float(expected)
+    except ValueError:
+        return False
+
+
+def _as_number(value: ParamValue) -> float | None:
+    """Read a metadata value as a number, refusing ``bool``.
+
+    ``bool`` subclasses ``int``, but a filter compares ``True`` to the word
+    "true", never to the number 1.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)

--- a/luxonis_ml/data/utils/inspection.py
+++ b/luxonis_ml/data/utils/inspection.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import Literal, TypeAlias
 
 from luxonis_ml.ldf import DatasetRecord, Detection
-from luxonis_ml.typing import Params, ParamValue, PrimitiveType
+from luxonis_ml.typing import Params, ParamValue
 
 InspectionAnnotationType: TypeAlias = Literal[
     "array",
@@ -179,9 +179,9 @@ class InspectionQuery:
     """Conjunctive sample filters for dataset inspection and comparison.
 
     Repeated class names and annotation types are alternatives within their
-    category; different categories are combined with ``and``. Filters select
-    whole samples rather than pruning matching detections from a selected
-    sample, preserving visual context.
+    category; different categories are combined with ``and``. A filter selects
+    a whole sample. It does not remove the other detections from that sample,
+    so the visual context stays complete.
     """
 
     class_names: frozenset[str] = field(default_factory=frozenset)
@@ -360,11 +360,11 @@ def _matches_confidence(
     detections: Sequence[Detection], minimum: float
 ) -> bool:
     """Whether any detection has ``score``/``confidence`` metadata above cutoff."""
-    return any(
-        confidence is not None and confidence >= minimum
-        for detection in detections
-        for confidence in (_detection_confidence(detection),)
-    )
+    for detection in detections:
+        confidence = _detection_confidence(detection)
+        if confidence is not None and confidence >= minimum:
+            return True
+    return False
 
 
 def _detection_confidence(detection: Detection) -> float | None:
@@ -390,18 +390,11 @@ def _matches_search(
         for detection in detections
         if detection.class_name is not None
     )
-    values.extend(_params_strings(sample_metadata))
+    values.extend(_metadata_strings(sample_metadata))
     for detection in detections:
         values.extend(str(key) for key in detection.metadata)
         values.extend(str(value) for value in detection.metadata.values())
     return any(needle in value.casefold() for value in values)
-
-
-def _params_strings(params: Params) -> Iterator[str]:
-    """Flatten a top-level metadata mapping into searchable text."""
-    for key, value in params.items():
-        yield key
-        yield from _metadata_strings(value)
 
 
 def _metadata_strings(value: ParamValue) -> Iterator[str]:
@@ -422,20 +415,12 @@ def _metadata_path(
     metadata: Params, path: tuple[str, ...]
 ) -> tuple[bool, ParamValue]:
     """Resolve a dotted path without conflating a missing value with ``None``."""
-    current: Mapping[str, ParamValue] | Mapping[PrimitiveType, ParamValue] = (
-        metadata
-    )
-    value: ParamValue = None
-    for index, part in enumerate(path):
+    current: ParamValue = metadata
+    for part in path:
         if not isinstance(current, Mapping) or part not in current:
             return False, None
-        value = current[part]
-        if index == len(path) - 1:
-            return True, value
-        if not isinstance(value, Mapping):
-            return False, None
-        current = value
-    return False, None
+        current = current[part]
+    return True, current
 
 
 def _metadata_equal(value: ParamValue, expected: str) -> bool:

--- a/tests/test_data/test_inspection_query.py
+++ b/tests/test_data/test_inspection_query.py
@@ -8,6 +8,7 @@ from luxonis_ml.data.utils.inspection import (
     InspectionAnnotationType,
     InspectionQuery,
     MetadataPredicate,
+    NameFilterMode,
     SampleFilterConfig,
     _metadata_equal,
 )
@@ -58,6 +59,32 @@ def test_sample_filter_config_validates_and_builds_query() -> None:
             "camera": {"side": "left"},
         },
     )
+
+
+@pytest.mark.parametrize(
+    ("mode", "accepted", "rejected"),
+    [("include", "objects", "other"), ("exclude", "other", "objects")],
+)
+def test_task_name_mode_decides_which_tasks_pass(
+    mode: NameFilterMode, accepted: str, rejected: str
+) -> None:
+    """`task_filter` alone loses the mode, so `accepts_task` applies it."""
+    config = SampleFilterConfig(task_name=["objects"], task_name_mode=mode)
+    assert config.accepts_task(accepted)
+    assert not config.accepts_task(rejected)
+
+
+def test_task_filter_accepts_everything_when_unset() -> None:
+    config = SampleFilterConfig()
+    assert config.task_filter is None
+    assert config.accepts_task("anything")
+
+
+def test_requested_class_names_are_trimmed() -> None:
+    """Available and stored class names are trimmed, so requests must be too."""
+    config = SampleFilterConfig(class_name=["  car  "])
+    config.validate(available_classes=["car"])
+    assert config.query().class_names == frozenset({"car"})
 
 
 @pytest.mark.parametrize(

--- a/tests/test_data/test_inspection_query.py
+++ b/tests/test_data/test_inspection_query.py
@@ -1,0 +1,219 @@
+"""Focused tests for typed dataset-inspection sample filters."""
+
+from pathlib import Path
+
+import pytest
+
+from luxonis_ml.data.utils.inspection import (
+    InspectionAnnotationType,
+    InspectionQuery,
+    MetadataPredicate,
+    SampleFilterConfig,
+    _metadata_equal,
+)
+from luxonis_ml.ldf import BBoxAnnotation, DatasetRecord, Detection
+from luxonis_ml.typing import Params
+
+
+def _records() -> dict[str, DatasetRecord]:
+    child = Detection(class_name="plate", metadata={"text": "ABC-123"})
+    detection = Detection(
+        class_name="car",
+        instance_id=7,
+        boundingbox=BBoxAnnotation(x=0.1, y=0.2, w=0.3, h=0.4),
+        metadata={"confidence": 0.86, "quality": "approved"},
+        sub_detections={"plate": child},
+    )
+    return {
+        "objects": DatasetRecord.model_construct(
+            files={"image": Path("frame.jpg")},
+            annotation=detection,
+            task_name="objects",
+        )
+    }
+
+
+def test_sample_filter_config_validates_and_builds_query() -> None:
+    config = SampleFilterConfig(
+        task_name=["objects", "objects"],
+        class_name=["car"],
+        annotation_type=["boundingbox"],
+        metadata_filter=[("camera.side", "left")],
+        min_confidence=0.8,
+        min_instances=1,
+        max_instances=2,
+        search="  FRAME_0042  ",
+    )
+
+    config.validate(
+        available_tasks=["objects"],
+        available_classes=["car", "person"],
+    )
+
+    assert config.task_filter == frozenset({"objects"})
+    assert config.query().matches(
+        _records(),
+        {
+            "filenames": {"image": "frame_0042.jpg"},
+            "camera": {"side": "left"},
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        InspectionQuery(class_names=frozenset({"car"})),
+        InspectionQuery(annotation_types=frozenset({"boundingbox"})),
+        InspectionQuery(annotation_types=frozenset({"metadata"})),
+        InspectionQuery(min_confidence=0.8),
+        InspectionQuery(min_instances=1, max_instances=1),
+        InspectionQuery(
+            metadata=(MetadataPredicate.from_pair("camera.side", "left"),)
+        ),
+        InspectionQuery(
+            metadata=(MetadataPredicate.from_pair("quality", "approved"),)
+        ),
+        InspectionQuery(
+            class_names=frozenset({"person"}),
+            class_name_mode="exclude",
+        ),
+        InspectionQuery(search="abc-123"),
+        InspectionQuery(search="FRAME_0042"),
+    ],
+)
+def test_query_matches_supported_sample_filters(
+    query: InspectionQuery,
+) -> None:
+    metadata: Params = {
+        "filenames": {"image": "frame_0042.jpg"},
+        "camera": {"side": "left"},
+    }
+    assert query.matches(_records(), metadata)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        InspectionQuery(class_names=frozenset({"person"})),
+        InspectionQuery(annotation_types=frozenset({"segmentation"})),
+        InspectionQuery(min_confidence=0.9),
+        InspectionQuery(min_instances=2),
+        InspectionQuery(max_instances=0),
+        InspectionQuery(
+            metadata=(MetadataPredicate.from_pair("camera.side", "right"),)
+        ),
+        InspectionQuery(
+            class_names=frozenset({"car"}),
+            class_name_mode="exclude",
+        ),
+        InspectionQuery(search="missing"),
+        InspectionQuery(unlabeled_only=True),
+    ],
+)
+def test_query_rejects_nonmatching_samples(query: InspectionQuery) -> None:
+    metadata: Params = {
+        "filenames": {"image": "frame_0042.jpg"},
+        "camera": {"side": "left"},
+    }
+    assert not query.matches(_records(), metadata)
+
+
+def test_unlabeled_query_accepts_an_empty_sample() -> None:
+    assert InspectionQuery(unlabeled_only=True).matches({}, {})
+
+
+def test_array_filter_uses_loader_only_annotation_type() -> None:
+    array_type: frozenset[InspectionAnnotationType] = frozenset({"array"})
+    assert InspectionQuery(annotation_types=array_type).matches(
+        {}, {}, extra_annotation_types=array_type
+    )
+    assert not InspectionQuery(unlabeled_only=True).matches(
+        {},
+        {},
+        extra_annotation_types=array_type,
+    )
+
+
+def test_repeated_metadata_predicates_are_conjunctive() -> None:
+    query = InspectionQuery(
+        metadata=(
+            MetadataPredicate.from_pair("camera.side", "left"),
+            MetadataPredicate.from_pair("quality", "rejected"),
+        )
+    )
+    assert not query.matches(_records(), {"camera": {"side": "left"}})
+
+
+@pytest.mark.parametrize("path", ["", ".", " . "])
+def test_metadata_predicate_rejects_empty_path(path: str) -> None:
+    with pytest.raises(ValueError, match="paths cannot be empty"):
+        MetadataPredicate.from_pair(path, "value")
+
+
+def test_query_rejects_invalid_filter_combinations() -> None:
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        InspectionQuery(min_confidence=1.1)
+    with pytest.raises(ValueError, match="--min-instances"):
+        InspectionQuery(min_instances=-1)
+    with pytest.raises(ValueError, match="--max-instances"):
+        InspectionQuery(max_instances=-1)
+    with pytest.raises(ValueError, match="cannot be greater"):
+        InspectionQuery(min_instances=2, max_instances=1)
+    with pytest.raises(ValueError, match="--unlabeled-only"):
+        InspectionQuery(
+            class_names=frozenset({"car"}),
+            unlabeled_only=True,
+        )
+    assert InspectionQuery(
+        class_names=frozenset({"car"}),
+        class_name_mode="exclude",
+        unlabeled_only=True,
+    ).matches({}, {})
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (0.5, "0.50"),  # trailing zero: not in the float's repr
+        (0.5, "0.5"),
+        (1.0, "1"),  # stored as a float, typed as an int
+        (1, "1.0"),  # and the other way around
+        (12, "12"),
+    ],
+)
+def test_numeric_metadata_filters_compare_numerically(
+    stored: float, expected: str
+) -> None:
+    """Numbers match by value, not by their Python repr.
+
+    Detection metadata decodes to `float`, so a `str()` comparison made
+    ``--metadata-filter score 0.50`` silently match nothing.
+    """
+    assert _metadata_equal(stored, expected)
+
+
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        (0.5, "0.6"),
+        (0.5, "not-a-number"),
+        (1, "2"),
+    ],
+)
+def test_numeric_metadata_filters_still_reject_other_values(
+    stored: float, expected: str
+) -> None:
+    assert not _metadata_equal(stored, expected)
+
+
+def test_bool_metadata_still_matches_by_name_not_by_number() -> None:
+    # `bool` is an `int` subclass; it must keep comparing as "true"/"false".
+    assert _metadata_equal(True, "true")
+    assert _metadata_equal(False, "FALSE")
+    assert not _metadata_equal(True, "1")
+
+
+def test_string_metadata_still_compares_case_insensitively() -> None:
+    assert _metadata_equal("Approved", "approved")
+    assert not _metadata_equal("approved", "rejected")

--- a/tests/test_data/test_inspection_query.py
+++ b/tests/test_data/test_inspection_query.py
@@ -1,5 +1,6 @@
-"""Focused tests for typed dataset-inspection sample filters."""
+"""Tests for the dataset-inspection sample filters."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -15,23 +16,10 @@ from luxonis_ml.data.utils.inspection import (
 from luxonis_ml.ldf import BBoxAnnotation, DatasetRecord, Detection
 from luxonis_ml.typing import Params
 
-
-def _records() -> dict[str, DatasetRecord]:
-    child = Detection(class_name="plate", metadata={"text": "ABC-123"})
-    detection = Detection(
-        class_name="car",
-        instance_id=7,
-        boundingbox=BBoxAnnotation(x=0.1, y=0.2, w=0.3, h=0.4),
-        metadata={"confidence": 0.86, "quality": "approved"},
-        sub_detections={"plate": child},
-    )
-    return {
-        "objects": DatasetRecord.model_construct(
-            files={"image": Path("frame.jpg")},
-            annotation=detection,
-            task_name="objects",
-        )
-    }
+SAMPLE_METADATA: Params = {
+    "filenames": {"image": "frame_0042.jpg"},
+    "camera": {"side": "left"},
+}
 
 
 def test_sample_filter_config_validates_and_builds_query() -> None:
@@ -52,13 +40,7 @@ def test_sample_filter_config_validates_and_builds_query() -> None:
     )
 
     assert config.task_filter == frozenset({"objects"})
-    assert config.query().matches(
-        _records(),
-        {
-            "filenames": {"image": "frame_0042.jpg"},
-            "camera": {"side": "left"},
-        },
-    )
+    assert config.query().matches(_records(), SAMPLE_METADATA)
 
 
 @pytest.mark.parametrize(
@@ -88,6 +70,31 @@ def test_requested_class_names_are_trimmed() -> None:
 
 
 @pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (
+            SampleFilterConfig(task_name=["missing"]),
+            "Unknown task name(s): 'missing'. "
+            "Available task names: 'objects', 'seg'.",
+        ),
+        (
+            SampleFilterConfig(class_name=["missing"]),
+            "Unknown class name(s): 'missing'. "
+            "Available class names: 'car', 'person'.",
+        ),
+    ],
+)
+def test_validate_lists_the_unknown_name_and_the_available_scope(
+    config: SampleFilterConfig, message: str
+) -> None:
+    with pytest.raises(ValueError, match=re.escape(message)):
+        config.validate(
+            available_tasks=["seg", "objects"],
+            available_classes=["person", "car"],
+        )
+
+
+@pytest.mark.parametrize(
     "query",
     [
         InspectionQuery(class_names=frozenset({"car"})),
@@ -107,16 +114,13 @@ def test_requested_class_names_are_trimmed() -> None:
         ),
         InspectionQuery(search="abc-123"),
         InspectionQuery(search="FRAME_0042"),
+        InspectionQuery(search="objects"),
     ],
 )
 def test_query_matches_supported_sample_filters(
     query: InspectionQuery,
 ) -> None:
-    metadata: Params = {
-        "filenames": {"image": "frame_0042.jpg"},
-        "camera": {"side": "left"},
-    }
-    assert query.matches(_records(), metadata)
+    assert query.matches(_records(), SAMPLE_METADATA)
 
 
 @pytest.mark.parametrize(
@@ -139,11 +143,36 @@ def test_query_matches_supported_sample_filters(
     ],
 )
 def test_query_rejects_nonmatching_samples(query: InspectionQuery) -> None:
-    metadata: Params = {
-        "filenames": {"image": "frame_0042.jpg"},
-        "camera": {"side": "left"},
-    }
-    assert not query.matches(_records(), metadata)
+    assert not query.matches(_records(), SAMPLE_METADATA)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        InspectionQuery(class_names=frozenset({"car"})),
+        InspectionQuery(annotation_types=frozenset({"boundingbox"})),
+        InspectionQuery(
+            metadata=(MetadataPredicate.from_pair("quality", "approved"),)
+        ),
+        InspectionQuery(min_confidence=0.5),
+        InspectionQuery(min_instances=0),  # a bound of zero still filters
+        InspectionQuery(max_instances=0),
+        InspectionQuery(unlabeled_only=True),
+        InspectionQuery(search="car"),
+    ],
+)
+def test_a_single_filter_makes_the_query_active(
+    query: InspectionQuery,
+) -> None:
+    assert query.active
+
+
+@pytest.mark.parametrize(
+    "query",
+    [InspectionQuery(), InspectionQuery(class_name_mode="exclude")],
+)
+def test_a_query_without_filters_is_inactive(query: InspectionQuery) -> None:
+    assert not query.active
 
 
 def test_unlabeled_query_accepts_an_empty_sample() -> None:
@@ -192,11 +221,16 @@ def test_query_rejects_invalid_filter_combinations() -> None:
             class_names=frozenset({"car"}),
             unlabeled_only=True,
         )
-    assert InspectionQuery(
+
+
+def test_unlabeled_only_allows_an_exclusive_class_filter() -> None:
+    """Excluding a class narrows unlabeled samples instead of contradicting."""
+    query = InspectionQuery(
         class_names=frozenset({"car"}),
         class_name_mode="exclude",
         unlabeled_only=True,
-    ).matches({}, {})
+    )
+    assert query.matches({}, {})
 
 
 @pytest.mark.parametrize(
@@ -244,3 +278,21 @@ def test_bool_metadata_still_matches_by_name_not_by_number() -> None:
 def test_string_metadata_still_compares_case_insensitively() -> None:
     assert _metadata_equal("Approved", "approved")
     assert not _metadata_equal("approved", "rejected")
+
+
+def _records() -> dict[str, DatasetRecord]:
+    child = Detection(class_name="plate", metadata={"text": "ABC-123"})
+    detection = Detection(
+        class_name="car",
+        instance_id=7,
+        boundingbox=BBoxAnnotation(x=0.1, y=0.2, w=0.3, h=0.4),
+        metadata={"confidence": 0.86, "quality": "approved"},
+        sub_detections={"plate": child},
+    )
+    return {
+        "objects": DatasetRecord.model_construct(
+            files={"image": Path("frame.jpg")},
+            annotation=detection,
+            task_name="objects",
+        )
+    }


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
Inspecting a dataset means finding the interesting samples — a class, a metadata value, a count — and there was no shared way to express that; callers filtered by hand.

Split out of the `feat/vizlab` branch, which had grown to 81 commits; this is one of eight self-contained pieces that do not belong to vizlab itself.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
New `luxonis_ml.data.utils.inspection`: parses filter expressions and evaluates them against a record's detections and sample metadata, so any caller (CLI, notebook, scripts) can select samples with the same syntax.

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
Additive — new module, no existing behavior changes.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
`tests/test_data/test_inspection_query.py` — 37 tests covering parsing, matching and error cases.

## AI Usage
<!--
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Claude:claude-fable-5

---

> **Stacked on #469** (`feat/record-multiple-annotations`). Based on that branch so the diff shows only this feature; GitHub retargets it to `main` once #469 merges.
