### PR TITLE
Resolve every annotation path in the native exported format

### DIFF
--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -9,6 +9,36 @@ from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
+#: Annotation fields holding a path to a companion file, as ``(field, key)``.
+#: These are written relative to ``annotations.json`` so a dataset directory
+#: stays portable, and have to be resolved before the record is validated.
+_ANNOTATION_PATHS: tuple[tuple[str, str], ...] = (
+    ("segmentation", "mask"),
+    ("instance_segmentation", "mask"),
+    ("array", "path"),
+)
+
+
+def _resolve_annotation_paths(
+    annotation: dict[str, Any], base_dir: Path
+) -> None:
+    """Rewrite one detection's companion-file paths in place.
+
+    Args:
+        annotation: A detection, as read from the manifest.
+        base_dir: Directory that relative paths are resolved against.
+
+    """
+    for field, key in _ANNOTATION_PATHS:
+        value = annotation.get(field)
+        if isinstance(value, dict) and isinstance(value.get(key), PathType):
+            value[key] = resolve_manifest_path(base_dir, value[key])
+    sub_detections = annotation.get("sub_detections")
+    if isinstance(sub_detections, dict):
+        for sub_detection in sub_detections.values():
+            if isinstance(sub_detection, dict):
+                _resolve_annotation_paths(sub_detection, base_dir)
+
 
 class NativeParser(BaseParser):
     """Parse a directory with native LDF annotations.
@@ -105,15 +135,16 @@ class NativeParser(BaseParser):
                                 record["files"][key] = resolve_manifest_path(
                                     annotation_path.parent, value
                                 )
-                for mask_type in ["segmentation", "instance_segmentation"]:
-                    with suppress(KeyError):
-                        mask = record["annotation"][mask_type]["mask"]
-                        if isinstance(mask, PathType):
-                            record["annotation"][mask_type]["mask"] = (
-                                resolve_manifest_path(
-                                    annotation_path.parent, mask
-                                )
-                            )
+                annotation = record.get("annotation")
+                for detection in (
+                    annotation
+                    if isinstance(annotation, list)
+                    else [annotation]
+                ):
+                    if isinstance(detection, dict):
+                        _resolve_annotation_paths(
+                            detection, annotation_path.parent
+                        )
                 yield record
 
         added_images = self._get_added_images(generator())

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -93,3 +93,96 @@ def test_yolov4_parser_keeps_unlabeled_image_with_duplicate_basename(
 
     assert annotated_image.resolve() in files
     assert unlabeled_image.resolve() in files
+
+
+def test_native_parser_resolves_array_annotation_paths(tempdir: Path):
+    # An array annotation points at a companion .npy the same way a mask points
+    # at a companion image. Before this was resolved against the manifest, a
+    # relative path was validated against the process's CWD instead, so any
+    # portable dataset carrying arrays failed to parse at all.
+    import numpy as np
+
+    image_path = create_image(0, tempdir)
+    split_dir = tempdir / "train"
+    (split_dir / "images").mkdir(parents=True)
+    (split_dir / "arrays").mkdir(parents=True)
+    copied_image = split_dir / "images" / image_path.name
+    copied_image.write_bytes(image_path.read_bytes())
+    array_path = split_dir / "arrays" / "0.npy"
+    np.save(array_path, np.zeros((4, 5), dtype=np.float32))
+
+    annotations_path = split_dir / "annotations.json"
+    annotations_path.write_text(
+        json.dumps(
+            [
+                {
+                    "file": f"images/{image_path.name}",
+                    "task_name": "stereo",
+                    "annotation": {
+                        "class": "disparity",
+                        "array": {"path": "arrays/0.npy"},
+                    },
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    generator, _, _ = NativeParser(
+        dataset=None,  # type: ignore[arg-type]
+        dataset_type=DatasetType.NATIVE,
+        task_name=None,
+    ).from_split(annotation_path=annotations_path)
+
+    record = next(iter(generator))
+    assert isinstance(record, dict)  # the parser yields raw manifest records
+    assert record["annotation"]["array"]["path"] == array_path.resolve()
+
+
+def test_native_parser_resolves_paths_for_a_list_of_annotations(
+    tempdir: Path,
+):
+    # `annotation` may be a single detection or a list of them. Indexing the
+    # list as if it were a detection used to raise TypeError, which the
+    # surrounding suppress(KeyError) did not catch.
+    image_path = create_image(0, tempdir)
+    split_dir = tempdir / "train"
+    (split_dir / "images").mkdir(parents=True)
+    (split_dir / "masks").mkdir(parents=True)
+    copied_image = split_dir / "images" / image_path.name
+    copied_image.write_bytes(image_path.read_bytes())
+    mask_path = split_dir / "masks" / "0.png"
+    mask_path.write_bytes(image_path.read_bytes())
+
+    annotations_path = split_dir / "annotations.json"
+    annotations_path.write_text(
+        json.dumps(
+            [
+                {
+                    "file": f"images/{image_path.name}",
+                    "task_name": "task",
+                    "annotation": [
+                        {
+                            "class": "class0",
+                            "segmentation": {"mask": "masks/0.png"},
+                        },
+                        {"class": "class1"},
+                    ],
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    generator, _, _ = NativeParser(
+        dataset=None,  # type: ignore[arg-type]
+        dataset_type=DatasetType.NATIVE,
+        task_name=None,
+    ).from_split(annotation_path=annotations_path)
+
+    record = next(iter(generator))
+    assert isinstance(record, dict)  # the parser yields raw manifest records
+    resolved = record["annotation"][0]["segmentation"]["mask"]
+    assert resolved == mask_path.resolve()

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -96,10 +96,6 @@ def test_yolov4_parser_keeps_unlabeled_image_with_duplicate_basename(
 
 
 def test_native_parser_resolves_array_annotation_paths(tempdir: Path):
-    # An array annotation points at a companion .npy the same way a mask points
-    # at a companion image. Before this was resolved against the manifest, a
-    # relative path was validated against the process's CWD instead, so any
-    # portable dataset carrying arrays failed to parse at all.
     import numpy as np
 
     image_path = create_image(0, tempdir)
@@ -136,16 +132,13 @@ def test_native_parser_resolves_array_annotation_paths(tempdir: Path):
     ).from_split(annotation_path=annotations_path)
 
     record = next(iter(generator))
-    assert isinstance(record, dict)  # the parser yields raw manifest records
+    assert isinstance(record, dict)
     assert record["annotation"]["array"]["path"] == array_path.resolve()
 
 
 def test_native_parser_resolves_paths_for_a_list_of_annotations(
     tempdir: Path,
 ):
-    # `annotation` may be a single detection or a list of them. Indexing the
-    # list as if it were a detection used to raise TypeError, which the
-    # surrounding suppress(KeyError) did not catch.
     image_path = create_image(0, tempdir)
     split_dir = tempdir / "train"
     (split_dir / "images").mkdir(parents=True)
@@ -183,15 +176,12 @@ def test_native_parser_resolves_paths_for_a_list_of_annotations(
     ).from_split(annotation_path=annotations_path)
 
     record = next(iter(generator))
-    assert isinstance(record, dict)  # the parser yields raw manifest records
+    assert isinstance(record, dict)
     resolved = record["annotation"][0]["segmentation"]["mask"]
     assert resolved == mask_path.resolve()
 
 
 def test_native_parser_resolves_paths_inside_sub_detections(tempdir: Path):
-    # A nested detection carries companion files exactly like a top-level one,
-    # so its paths are written relative to the manifest too and have to be
-    # resolved with the same recursion.
     image_path = create_image(0, tempdir)
     split_dir = tempdir / "train"
     (split_dir / "images").mkdir(parents=True)
@@ -233,6 +223,6 @@ def test_native_parser_resolves_paths_inside_sub_detections(tempdir: Path):
     ).from_split(annotation_path=annotations_path)
 
     record = next(iter(generator))
-    assert isinstance(record, dict)  # the parser yields raw manifest records
+    assert isinstance(record, dict)
     nested = record["annotation"]["sub_detections"]["head"]
     assert nested["instance_segmentation"]["mask"] == mask_path.resolve()

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -186,3 +186,53 @@ def test_native_parser_resolves_paths_for_a_list_of_annotations(
     assert isinstance(record, dict)  # the parser yields raw manifest records
     resolved = record["annotation"][0]["segmentation"]["mask"]
     assert resolved == mask_path.resolve()
+
+
+def test_native_parser_resolves_paths_inside_sub_detections(tempdir: Path):
+    # A nested detection carries companion files exactly like a top-level one,
+    # so its paths are written relative to the manifest too and have to be
+    # resolved with the same recursion.
+    image_path = create_image(0, tempdir)
+    split_dir = tempdir / "train"
+    (split_dir / "images").mkdir(parents=True)
+    (split_dir / "masks").mkdir(parents=True)
+    copied_image = split_dir / "images" / image_path.name
+    copied_image.write_bytes(image_path.read_bytes())
+    mask_path = split_dir / "masks" / "head.png"
+    mask_path.write_bytes(image_path.read_bytes())
+
+    annotations_path = split_dir / "annotations.json"
+    annotations_path.write_text(
+        json.dumps(
+            [
+                {
+                    "file": f"images/{image_path.name}",
+                    "task_name": "person",
+                    "annotation": {
+                        "class": "person",
+                        "sub_detections": {
+                            "head": {
+                                "class": "head",
+                                "instance_segmentation": {
+                                    "mask": "masks/head.png"
+                                },
+                            }
+                        },
+                    },
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    generator, _, _ = NativeParser(
+        dataset=None,  # type: ignore[arg-type]
+        dataset_type=DatasetType.NATIVE,
+        task_name=None,
+    ).from_split(annotation_path=annotations_path)
+
+    record = next(iter(generator))
+    assert isinstance(record, dict)  # the parser yields raw manifest records
+    nested = record["annotation"]["sub_detections"]["head"]
+    assert nested["instance_segmentation"]["mask"] == mask_path.resolve()


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->
The native parser resolved only `segmentation` and `instance_segmentation` mask paths relative to `annotations.json`. A relative `array` path was therefore validated against the process working directory instead, so the same manifest parsed or failed depending on where you ran it from. Paths inside `sub_detections` were not resolved at all.

Split out of the `feat/vizlab` branch, which had grown to 81 commits; this is one of eight self-contained pieces that do not belong to vizlab itself.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Resolve all path-bearing annotations from one table instead of two hard-coded cases, recurse into `sub_detections`, and tolerate a record whose `annotation` is a list (which would previously raise `TypeError` on subscripting).

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
Fixes manifests that previously failed to parse; a manifest that already worked resolves to the same paths.

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
`tests/test_data/test_native_paths.py` — new coverage for array-path resolution and for a list-valued `annotation`, alongside the pre-existing Windows-path and duplicate-basename tests. 4 tests, all passing.

## AI Usage
<!--
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: Claude:claude-fable-5
