### PR TITLE
Added workflow to check if docs are generated correctly

### DIFF
--- a/.github/workflows/export-pydoctor-reference.yaml
+++ b/.github/workflows/export-pydoctor-reference.yaml
@@ -1,0 +1,85 @@
+name: Export pydoctor reference
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  export:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (startsWith(github.head_ref, 'release/') &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout LuxonisML
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout pydoctor reference tools
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: luxonis/docs-content
+          ref: main
+          path: docs-content
+          sparse-checkout: tools/pydoctor_reference
+          persist-credentials: false
+          ssh-key: ${{ secrets.DOCS_CONTENT_SSH_KEY }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: docs-content/tools/pydoctor_reference/requirements.txt
+
+      - name: Install exporter dependencies
+        run: >-
+          python -m pip install
+          -r docs-content/tools/pydoctor_reference/requirements.txt
+
+      - name: Resolve source metadata
+        id: source
+        shell: bash
+        run: |
+          echo "ref=${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Export API reference
+        run: |
+          python docs-content/tools/pydoctor_reference/workflow.py export \
+            --manifest docs-content/tools/pydoctor_reference/packages.toml \
+            --package-id luxonis-ml \
+            --source-root "$GITHUB_WORKSPACE" \
+            --output-dir "$RUNNER_TEMP/luxonis-ml-reference" \
+            --source-ref "${{ steps.source.outputs.ref }}" \
+            --source-sha "${{ steps.source.outputs.sha }}"
+
+      - name: Upload API reference
+        id: artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: luxonis-ml-api-reference
+          path: ${{ runner.temp }}/luxonis-ml-reference
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Add artifact link to job summary
+        env:
+          ARTIFACT_URL: ${{ steps.artifact.outputs.artifact-url }}
+        run: |
+          {
+            echo "### Generated API reference"
+            echo
+            echo "[Download luxonis-ml-api-reference]($ARTIFACT_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/luxonis_ml/data/augmentations/custom/mosaic.py
+++ b/luxonis_ml/data/augmentations/custom/mosaic.py
@@ -33,7 +33,7 @@ class Mosaic4(BatchTransform):
     needed with the specified fill values.
 
     .. figure::
-       https://github.com/luxonis/luxonis-ml/blob/58fb10adc38a393640b9dc889fdefd1db81f9900/luxonis_ml/data/augmentations/media/mosaic4.png
+       https://raw.githubusercontent.com/luxonis/luxonis-ml/58fb10adc38a393640b9dc889fdefd1db81f9900/luxonis_ml/data/augmentations/media/mosaic4.png
        :height: 300px
        :width: 400px
        :loading: embed


### PR DESCRIPTION
## Purpose
<!-- Clearly describe why this change is needed and what problem it solves. -->

- Add a GitHub Actions workflow to export the LuxonisML pydoctor API reference for internal `release/*` PRs targeting `main`, or on manual dispatch.
- Fetch the current `main` branch of `luxonis/docs-content` securely via the `DOCS_CONTENT_SSH_KEY` deploy-key secret.
- Use the docs-content `packages.toml` configuration and the same strict export command used by docs-content.
- Upload the generated API reference as a seven-day workflow artifact and add a direct download link to the job summary.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Mosaic4 documentation image link to display the correct image directly.

* **Chores**
  * Added an automated workflow to generate and export the LuxonisML API reference for release pull requests or manual runs.
  * API reference exports are available as temporary downloadable artifacts with links included in the workflow summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->