### PR TITLE
Native export targeting older LDF versions

### DIFF
--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -443,6 +443,7 @@ def export(
         Parameter(alias="-m"),
     ] = None,
     zip: bool = True,
+    ldf_version: str | None = None,
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
     """Export a Luxonis dataset to disk.
@@ -460,6 +461,10 @@ def export(
         zip: If ``True``, the exported dataset will be zipped into a
             single archive. If ``False``, the dataset will be exported as a
             directory with the specified structure.
+        ldf_version: LDF version to write, such as ``2.0``, so the export
+            can be read by an older luxonis-ml. Only valid with
+            ``--type native``. Downgrading is lossy and warns about what
+            it drops.
         bucket_storage: Storage type of the dataset.
 
     """
@@ -467,7 +472,13 @@ def export(
     if delete_existing and Path(save_dir).exists():
         shutil.rmtree(save_dir)
     dataset = LuxonisDataset(name, bucket_storage=bucket_storage)
-    dataset.export(save_dir, dataset_type, max_partition_size_gb, zip)
+    dataset.export(
+        save_dir,
+        dataset_type=dataset_type,
+        max_partition_size_gb=max_partition_size_gb,
+        zip_output=zip,
+        ldf_version=ldf_version,
+    )
 
 
 @app.command

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -43,6 +43,7 @@ from luxonis_ml.data.exporters.exporter_utils import (
     ExporterSpec,
     create_zip_output,
 )
+from luxonis_ml.data.exporters.ldf_downgrade import resolve_export_version
 from luxonis_ml.data.utils import (
     BucketStorage,
     BucketType,
@@ -1752,6 +1753,7 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
         dataset_type: DatasetType = DatasetType.NATIVE,
         max_partition_size_gb: float | None = None,
         zip_output: bool = False,
+        ldf_version: str | None = None,
     ) -> Path | list[Path]:
         """Export the dataset into one of the supported formats.
 
@@ -1763,6 +1765,10 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                 ``{dataset_name}_part{partition_number}``.
             zip_output: Whether to zip the exported dataset or each
                 partition after export.
+            ldf_version: LDF version to write, for example ``"2.0"``, so
+                the export can be read by an older luxonis-ml. Native
+                format only. Defaults to the version this installation
+                writes. Downgrading is lossy and warns about what it drops.
 
         Returns:
             Export directory, or ZIP archive paths when ``zip_output`` is
@@ -1770,11 +1776,22 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
 
         Raises:
             NotImplementedError: If the specified export format is not supported.
-            ValueError: If the output path already exists.
+            ValueError: If the output path already exists, or if
+                ``ldf_version`` is set for a non-native format or names a
+                version this installation cannot write.
 
         """
+        if ldf_version is not None and dataset_type != DatasetType.NATIVE:
+            raise ValueError(
+                f"'ldf_version' only applies to the native format, "
+                f"not '{dataset_type}'."
+            )
+        target_version = resolve_export_version(ldf_version)
+
         EXPORTER_MAP: dict[DatasetType, ExporterSpec] = {
-            DatasetType.NATIVE: ExporterSpec(NativeExporter, {}),
+            DatasetType.NATIVE: ExporterSpec(
+                NativeExporter, {"ldf_version": target_version}
+            ),
             DatasetType.COCO: ExporterSpec(
                 CocoExporter,
                 {

--- a/luxonis_ml/data/exporters/__init__.py
+++ b/luxonis_ml/data/exporters/__init__.py
@@ -34,7 +34,9 @@ metadata, and media paths used by concrete exporters.
      - Native LDF and Ultralytics NDJSON interchange formats.
 
 `NativeExporter` preserves **record-level metadata** by writing
-``sample_metadata`` objects into native LDF ``annotations.json`` files.
+``sample_metadata`` objects into native LDF ``annotations.json`` files. It
+can also target an older LDF version, so an export stays readable by an
+older luxonis-ml -- see `luxonis_ml.data.exporters.ldf_downgrade`.
 """
 
 from .base_exporter import BaseExporter

--- a/luxonis_ml/data/exporters/ldf_downgrade.py
+++ b/luxonis_ml/data/exporters/ldf_downgrade.py
@@ -1,0 +1,112 @@
+"""Rewriting exported native records to older LDF versions.
+
+`DatasetRecord` forbids extra fields, so a record written by a newer
+luxonis-ml fails to validate on an older install -- LDF 2.1 added
+``sample_metadata``, which nothing older accepts. Exporting to an older
+version therefore drops every field introduced above it.
+"""
+
+from collections import Counter
+from typing import Any, Final
+
+from loguru import logger
+from semver.version import Version
+
+from luxonis_ml.data.utils.constants import LDF_VERSION
+
+
+def _parse(version: str) -> Version:
+    return Version.parse(version, optional_minor_and_patch=True)
+
+
+#: Record fields keyed by the LDF version that introduced them. Add an
+#: entry when a new version adds a field to `DatasetRecord`.
+_ADDED_FIELDS: Final[dict[str, Version]] = {
+    "sample_metadata": _parse("2.1"),
+}
+
+#: LDF versions the native exporter can write, newest first.
+SUPPORTED_EXPORT_VERSIONS: Final[tuple[Version, ...]] = (
+    LDF_VERSION,
+    _parse("2.0"),
+)
+
+
+def resolve_export_version(version: str | Version | None) -> Version:
+    """Resolve and validate a requested native export version.
+
+    Args:
+        version: Requested LDF version. Minor and patch parts are
+            optional, so both ``"2.0"`` and ``"2.0.0"`` are accepted.
+            ``None`` selects the current `LDF_VERSION`.
+
+    Returns:
+        The resolved version.
+
+    Raises:
+        ValueError: If the version is malformed, is newer than this
+            installation writes, or is not one the native exporter can
+            produce.
+
+    """
+    if version is None:
+        return LDF_VERSION
+
+    supported = ", ".join(str(v) for v in SUPPORTED_EXPORT_VERSIONS)
+    invalid = (
+        f"Invalid LDF version '{version}'. Supported versions: {supported}."
+    )
+
+    try:
+        resolved = _parse(str(version))
+    except ValueError as e:
+        raise ValueError(invalid) from e
+
+    if resolved > LDF_VERSION:
+        raise ValueError(
+            f"Cannot export LDF {resolved}: this installation of luxonis-ml "
+            f"writes LDF {LDF_VERSION} at the newest."
+        )
+    if resolved not in SUPPORTED_EXPORT_VERSIONS:
+        raise ValueError(invalid)
+    return resolved
+
+
+class LDFDowngrader:
+    """Strips exported native records down to an older LDF version.
+
+    Records are built at the current `LDF_VERSION` and passed through a
+    downgrader on their way out, which keeps version-specific knowledge in
+    one place and lets discarded data be counted as it goes.
+
+    Attributes:
+        target_version: LDF version the records are rewritten to.
+
+    """
+
+    def __init__(self, target_version: Version):
+        self.target_version = target_version
+        self._to_drop = [
+            field
+            for field, added_in in _ADDED_FIELDS.items()
+            if added_in > target_version
+        ]
+        self._dropped: Counter[str] = Counter()
+        self._n_records = 0
+
+    def __call__(self, record: dict[str, Any]) -> dict[str, Any]:
+        """Rewrite one exported record in place and return it."""
+        self._n_records += 1
+        for field in self._to_drop:
+            # An empty value is no loss, so drop it but do not report it.
+            if record.pop(field, None):
+                self._dropped[field] += 1
+        return record
+
+    def log_summary(self) -> None:
+        """Warn about populated data the downgrade discarded."""
+        for field, n_dropped in self._dropped.items():
+            logger.warning(
+                f"Exporting to LDF {self.target_version} drops '{field}' "
+                f"from {n_dropped} of {self._n_records} records."
+            )

--- a/luxonis_ml/data/exporters/native_exporter.py
+++ b/luxonis_ml/data/exporters/native_exporter.py
@@ -5,12 +5,15 @@ from pathlib import Path
 from typing import Any
 
 import polars as pl
+from semver.version import Version
 
 from luxonis_ml.data.exporters.base_exporter import BaseExporter
 from luxonis_ml.data.exporters.exporter_utils import (
     PreparedLDF,
     split_of_group,
 )
+from luxonis_ml.data.exporters.ldf_downgrade import LDFDowngrader
+from luxonis_ml.data.utils.constants import LDF_VERSION
 from luxonis_ml.enums import DatasetType
 from luxonis_ml.ldf import DatasetRecord
 from luxonis_ml.utils.path import path_to_posix
@@ -25,6 +28,14 @@ class NativeExporter(BaseExporter):
 
     ``sample_metadata`` is exported as a JSON object next to ``file`` or
     ``files``. It is **record-level metadata**, not an annotation label.
+
+    The export root also holds a ``metadata.json`` version stamp, such as
+    ``{"ldf_version": "2.1.0"}``. It is not the full `Metadata` model a
+    dataset keeps in its own storage.
+
+    Passing an older ``ldf_version`` strips the fields that version does
+    not know -- exporting LDF 2.0 omits ``sample_metadata``. See
+    `LDFDowngrader`.
 
     Example:
         .. code-block:: json
@@ -52,6 +63,20 @@ class NativeExporter(BaseExporter):
             }
 
     """
+
+    def __init__(
+        self,
+        dataset_identifier: str,
+        output_path: Path,
+        max_partition_size_gb: float | None,
+        *,
+        ldf_version: Version | None = None,
+    ):
+        super().__init__(
+            dataset_identifier, output_path, max_partition_size_gb
+        )
+        self.ldf_version = ldf_version or LDF_VERSION
+        self._downgrade = LDFDowngrader(self.ldf_version)
 
     @staticmethod
     def get_split_names() -> dict[str, str]:
@@ -107,6 +132,7 @@ class NativeExporter(BaseExporter):
             annotation_splits[split].extend(records)
 
         self._dump_annotations(annotation_splits, self.output_path, self.part)
+        self._downgrade.log_summary()
 
     def _maybe_roll_partition(
         self,
@@ -176,7 +202,7 @@ class NativeExporter(BaseExporter):
                 ann["metadata"] = {task_type[9:]: data}
             record["annotation"] = ann
 
-        return record
+        return self._downgrade(record)
 
     def _dump_annotations(
         self,
@@ -184,25 +210,32 @@ class NativeExporter(BaseExporter):
         output_path: Path,
         part: int | None = None,
     ) -> None:
+        base = self._base_path(output_path, part)
+        base.mkdir(parents=True, exist_ok=True)
+        # Called once per partition, so every part carries its own stamp.
+        (base / "metadata.json").write_text(
+            json.dumps({"ldf_version": str(self.ldf_version)}, indent=4),
+            encoding="utf-8",
+        )
+
         for split_name, items in annotation_splits.items():
             save_name = self.get_split_names().get(split_name, split_name)
-            base = (
-                output_path / f"{self.dataset_identifier}_part{part}"
-                if part is not None
-                else output_path / self.dataset_identifier
-            )
             split_path = base / save_name
             split_path.mkdir(parents=True, exist_ok=True)
             (split_path / "annotations.json").write_text(
                 json.dumps(items, indent=4), encoding="utf-8"
             )
 
+    def _base_path(self, output_path: Path, part: int | None) -> Path:
+        """Return the export root of a partition."""
+        name = (
+            self.dataset_identifier
+            if part is None
+            else f"{self.dataset_identifier}_part{part}"
+        )
+        return output_path / name
+
     def _get_data_path(
         self, output_path: Path, split: str, part: int | None = None
     ) -> Path:
-        base = (
-            output_path / f"{self.dataset_identifier}_part{part}"
-            if part is not None
-            else output_path / self.dataset_identifier
-        )
-        return base / split / "images"
+        return self._base_path(output_path, part) / split / "images"

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -3,7 +3,11 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+from semver.version import Version
+
 from luxonis_ml.data import DatasetIterator
+from luxonis_ml.data.utils.constants import LDF_VERSION
 from luxonis_ml.typing import PathType
 from luxonis_ml.utils.path import resolve_manifest_path
 
@@ -40,16 +44,41 @@ def _resolve_annotation_paths(
                 _resolve_annotation_paths(sub_detection, base_dir)
 
 
+def _warn_on_newer_export(annotation_path: Path) -> None:
+    """Warn when the export was written by a newer LDF version.
+
+    An older export is a strict subset of what this version accepts, so
+    only a newer one is worth reporting. The stamp is best-effort: exports
+    predating it have none, and a damaged one must not break the parse.
+    """
+    stamp = annotation_path.parent.parent / "metadata.json"
+    with suppress(OSError, ValueError, TypeError, KeyError):
+        version = Version.parse(
+            json.loads(stamp.read_text())["ldf_version"],
+            optional_minor_and_patch=True,
+        )
+        if version.major > LDF_VERSION.major:
+            logger.warning(
+                f"'{stamp}' declares LDF {version}, but this luxonis-ml "
+                f"reads LDF {LDF_VERSION}. Upgrade it if parsing fails."
+            )
+
+
 class NativeParser(BaseParser):
     """Parse a directory with native LDF annotations.
 
     Expected format::
 
         dataset_dir/
+        ├── metadata.json  (optional; names the LDF version written)
         ├── train/
         │   └── annotations.json
         ├── val/
         └── test/
+
+    ``metadata.json`` is a version stamp written by `NativeExporter`. It is
+    never required, and is read only to warn about exports from a *newer*
+    LDF version.
 
     The annotations are stored in a single JSON file as a list of dictionaries
     in the same format as the output of the generator function used by
@@ -120,6 +149,7 @@ class NativeParser(BaseParser):
             and added images.
 
         """
+        _warn_on_newer_export(annotation_path)
         data = json.loads(annotation_path.read_text())
 
         def generator() -> DatasetIterator:

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -13,55 +13,14 @@ from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
 
-#: Annotation fields holding a path to a companion file, as ``(field, key)``.
-#: These are written relative to ``annotations.json`` so a dataset directory
-#: stays portable, and have to be resolved before the record is validated.
+# Annotation fields holding a path to a companion file, as ``(field, key)``.
+# These are written relative to ``annotations.json`` so a dataset directory
+# stays portable, and have to be resolved before the record is validated.
 _ANNOTATION_PATHS: tuple[tuple[str, str], ...] = (
     ("segmentation", "mask"),
     ("instance_segmentation", "mask"),
     ("array", "path"),
 )
-
-
-def _resolve_annotation_paths(
-    annotation: dict[str, Any], base_dir: Path
-) -> None:
-    """Rewrite one detection's companion-file paths in place.
-
-    Args:
-        annotation: A detection, as read from the manifest.
-        base_dir: Directory that relative paths are resolved against.
-
-    """
-    for field, key in _ANNOTATION_PATHS:
-        value = annotation.get(field)
-        if isinstance(value, dict) and isinstance(value.get(key), PathType):
-            value[key] = resolve_manifest_path(base_dir, value[key])
-    sub_detections = annotation.get("sub_detections")
-    if isinstance(sub_detections, dict):
-        for sub_detection in sub_detections.values():
-            if isinstance(sub_detection, dict):
-                _resolve_annotation_paths(sub_detection, base_dir)
-
-
-def _warn_on_newer_export(annotation_path: Path) -> None:
-    """Warn when the export was written by a newer LDF version.
-
-    An older export is a strict subset of what this version accepts, so
-    only a newer one is worth reporting. The stamp is best-effort: exports
-    predating it have none, and a damaged one must not break the parse.
-    """
-    stamp = annotation_path.parent.parent / "metadata.json"
-    with suppress(OSError, ValueError, TypeError, KeyError):
-        version = Version.parse(
-            json.loads(stamp.read_text())["ldf_version"],
-            optional_minor_and_patch=True,
-        )
-        if version.major > LDF_VERSION.major:
-            logger.warning(
-                f"'{stamp}' declares LDF {version}, but this luxonis-ml "
-                f"reads LDF {LDF_VERSION}. Upgrade it if parsing fails."
-            )
 
 
 class NativeParser(BaseParser):
@@ -117,6 +76,10 @@ class NativeParser(BaseParser):
 
     _SPLIT_NAMES: tuple[str, ...] = ("train", "val", "test")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._checked_stamps: set[Path] = set()
+
     @staticmethod
     def validate_split(split_path: Path) -> dict[str, Any] | None:
         annotation_path = split_path / "annotations.json"
@@ -149,7 +112,7 @@ class NativeParser(BaseParser):
             and added images.
 
         """
-        _warn_on_newer_export(annotation_path)
+        self._warn_on_newer_export(annotation_path)
         data = json.loads(annotation_path.read_text())
 
         def generator() -> DatasetIterator:
@@ -180,3 +143,50 @@ class NativeParser(BaseParser):
         added_images = self._get_added_images(generator())
 
         return generator(), {}, added_images
+
+    def _warn_on_newer_export(self, annotation_path: Path) -> None:
+        """Warn when the export was written by a newer LDF version.
+
+        An older export is a strict subset of what this version accepts,
+        so only a newer one is worth reporting. Comparing the whole
+        version matters: ``sample_metadata`` arrived in a minor bump, so
+        a same-major export can be just as unreadable.
+
+        The stamp is best-effort: exports predating it have none, and a
+        damaged one must not break the parse.
+        """
+        stamp = annotation_path.parent.parent / "metadata.json"
+        if stamp in self._checked_stamps:
+            return
+        self._checked_stamps.add(stamp)
+        with suppress(OSError, ValueError, TypeError, KeyError):
+            version = Version.parse(
+                json.loads(stamp.read_text())["ldf_version"],
+                optional_minor_and_patch=True,
+            )
+            if version > LDF_VERSION:
+                logger.warning(
+                    f"'{stamp}' declares LDF {version}, but this luxonis-ml "
+                    f"reads LDF {LDF_VERSION}. Upgrade it if parsing fails."
+                )
+
+
+def _resolve_annotation_paths(
+    annotation: dict[str, Any], base_dir: Path
+) -> None:
+    """Rewrite one detection's companion-file paths in place.
+
+    Args:
+        annotation: A detection, as read from the manifest.
+        base_dir: Directory that relative paths are resolved against.
+
+    """
+    for field, key in _ANNOTATION_PATHS:
+        value = annotation.get(field)
+        if isinstance(value, dict) and isinstance(value.get(key), PathType):
+            value[key] = resolve_manifest_path(base_dir, value[key])
+    sub_detections = annotation.get("sub_detections")
+    if isinstance(sub_detections, dict):
+        for sub_detection in sub_detections.values():
+            if isinstance(sub_detection, dict):
+                _resolve_annotation_paths(sub_detection, base_dir)

--- a/tests/test_data/test_export_ldf_version.py
+++ b/tests/test_data/test_export_ldf_version.py
@@ -1,0 +1,254 @@
+"""Exporting the native format at an older LDF version.
+
+`DatasetRecord` forbids extra fields, so LDF 2.1 adding ``sample_metadata``
+made every 2.1 export unreadable by an older luxonis-ml.
+"""
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from loguru import logger
+from semver.version import Version
+
+from luxonis_ml.data import LuxonisDataset, LuxonisLoader, LuxonisParser
+from luxonis_ml.data.datasets.base_dataset import DatasetIterator
+from luxonis_ml.data.exporters.ldf_downgrade import (
+    _ADDED_FIELDS,
+    LDFDowngrader,
+    resolve_export_version,
+)
+from luxonis_ml.data.utils.constants import LDF_VERSION
+from luxonis_ml.enums.enums import DatasetType
+from luxonis_ml.ldf import DatasetRecord
+
+from .utils import create_dataset, create_image
+
+#: Fields a pre-2.1 `DatasetRecord` accepts. Anything else trips
+#: ``extra="forbid"`` on an older install.
+LDF_2_0_RECORD_FIELDS = {"file", "files", "task_name", "annotation"}
+
+
+@pytest.fixture
+def warnings_log() -> Iterator[list[str]]:
+    """Collect loguru warnings, which pytest's caplog does not see."""
+    messages: list[str] = []
+    handler = logger.add(messages.append, level="WARNING", format="{message}")
+    yield messages
+    logger.remove(handler)
+
+
+def _generator(tempdir: Path, with_metadata: bool = True) -> DatasetIterator:
+    for i in range(2):
+        record = {
+            "file": create_image(i, tempdir),
+            "annotation": {
+                "class": "person",
+                "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
+                "instance_id": i,
+            },
+        }
+        if with_metadata:
+            record["sample_metadata"] = {"record_id": i, "origin": "test"}
+        yield record
+
+
+def _read_records(export_root: Path) -> list[dict]:
+    """Read every annotation record an export directory holds."""
+    return [
+        record
+        for path in sorted(export_root.rglob("annotations.json"))
+        for record in json.loads(path.read_text())
+    ]
+
+
+def _read_stamp(export_root: Path) -> str:
+    return json.loads((export_root / "metadata.json").read_text())[
+        "ldf_version"
+    ]
+
+
+def _export(
+    dataset: LuxonisDataset, tempdir: Path, name: str, **kwargs
+) -> Path:
+    """Export to a fresh subdirectory and return the dataset root."""
+    dataset.export(tempdir / name, **kwargs)
+    return tempdir / name / dataset.identifier
+
+
+@pytest.mark.parametrize("version", ["2.0", "2.0.0"])
+def test_resolve_accepts_short_and_full_versions(version: str):
+    assert resolve_export_version(version) == Version.parse("2.0.0")
+
+
+def test_resolve_defaults_to_current_version():
+    assert resolve_export_version(None) == LDF_VERSION
+
+
+@pytest.mark.parametrize("version", ["banana", "", "v2.0", "2.0.0.0"])
+def test_resolve_rejects_malformed_versions(version: str):
+    with pytest.raises(ValueError, match="Invalid LDF version"):
+        resolve_export_version(version)
+
+
+@pytest.mark.parametrize("version", ["3.0", "2.9"])
+def test_resolve_rejects_newer_than_installed(version: str):
+    with pytest.raises(ValueError, match="at the newest"):
+        resolve_export_version(version)
+
+
+@pytest.mark.parametrize("version", ["1.0", "2.0.1"])
+def test_resolve_rejects_unsupported_versions(version: str):
+    with pytest.raises(ValueError, match="Supported versions"):
+        resolve_export_version(version)
+
+
+def test_every_record_field_has_a_known_ldf_version():
+    """Adding a `DatasetRecord` field must register the version it arrived in.
+
+    Otherwise an export targeting an older version silently keeps the new
+    field, and the install it was made for rejects the whole record.
+    """
+    known = LDF_2_0_RECORD_FIELDS | set(_ADDED_FIELDS)
+    assert set(DatasetRecord.model_fields) <= known
+
+
+def test_downgrade_removes_the_key_rather_than_emptying_it():
+    """``sample_metadata: {}`` still fails ``extra="forbid"``."""
+    downgraded = LDFDowngrader(Version.parse("2.0.0"))(
+        {"file": "a.jpg", "task_name": "t", "sample_metadata": {"x": 1}}
+    )
+    assert "sample_metadata" not in downgraded
+
+
+def test_downgrade_to_current_version_is_a_passthrough():
+    record = {"file": "a.jpg", "sample_metadata": {"x": 1}}
+    assert LDFDowngrader(LDF_VERSION)(dict(record)) == record
+
+
+def test_export_2_0_omits_sample_metadata(dataset_name: str, tempdir: Path):
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    root = _export(
+        dataset,
+        tempdir,
+        "v20",
+        dataset_type=DatasetType.NATIVE,
+        ldf_version="2.0",
+    )
+
+    records = _read_records(root)
+    assert records
+    for record in records:
+        assert set(record) <= LDF_2_0_RECORD_FIELDS
+    assert _read_stamp(root) == "2.0.0"
+
+
+def test_export_defaults_to_current_version(dataset_name: str, tempdir: Path):
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    root = _export(dataset, tempdir, "default")
+
+    records = _read_records(root)
+    assert records
+    assert all("sample_metadata" in record for record in records)
+    assert _read_stamp(root) == str(LDF_VERSION)
+
+
+def test_export_2_0_round_trips(dataset_name: str, tempdir: Path):
+    """A 2.0 export re-imports cleanly, minus the dropped metadata."""
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    root = _export(dataset, tempdir, "v20", ldf_version="2.0")
+
+    imported = LuxonisParser(
+        str(root),
+        dataset_type=DatasetType.NATIVE,
+        dataset_name=f"{dataset_name}_imported",
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+    imported.make_splits((1, 0, 0), replace_old_splits=True)
+
+    outputs = list(LuxonisLoader(imported))
+    assert len(outputs) == 2
+    # The loader always autopopulates `filenames`, so the record-level
+    # metadata is never empty; what must be gone are the exported keys.
+    for output in outputs:
+        assert "record_id" not in output.metadata
+        assert "origin" not in output.metadata
+
+
+def test_export_2_0_warns_about_dropped_metadata(
+    dataset_name: str, tempdir: Path, warnings_log: list[str]
+):
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    root = _export(dataset, tempdir, "v20", ldf_version="2.0")
+
+    # One record per annotation row, so the count is not the image count.
+    n_records = len(_read_records(root))
+    dropped = [msg for msg in warnings_log if "sample_metadata" in msg]
+    assert len(dropped) == 1
+    assert f"{n_records} of {n_records} records" in dropped[0]
+
+
+def test_export_2_0_is_quiet_when_nothing_is_dropped(
+    dataset_name: str, tempdir: Path, warnings_log: list[str]
+):
+    """An empty `sample_metadata` is no loss, so it must not warn."""
+    dataset = create_dataset(
+        dataset_name,
+        _generator(tempdir, with_metadata=False),
+        splits=(1, 0, 0),
+    )
+    _export(dataset, tempdir, "v20", ldf_version="2.0")
+
+    assert not [msg for msg in warnings_log if "sample_metadata" in msg]
+
+
+def test_export_2_0_stamps_every_partition(dataset_name: str, tempdir: Path):
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    out = tempdir / "parts"
+    dataset.export(out, max_partition_size_gb=1e-7, ldf_version="2.0")
+
+    parts = sorted(out.glob(f"{dataset.identifier}_part*"))
+    assert len(parts) > 1
+    for part in parts:
+        assert _read_stamp(part) == "2.0.0"
+    for record in _read_records(out):
+        assert "sample_metadata" not in record
+
+
+# `DatasetType` mixes in `str`, so the bare string is a real calling
+# convention and must reach the same error as the enum.
+@pytest.mark.parametrize("dataset_type", [DatasetType.COCO, "coco"])
+def test_ldf_version_rejected_for_non_native(
+    dataset_name: str, tempdir: Path, dataset_type: DatasetType
+):
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    out = tempdir / "coco"
+    with pytest.raises(ValueError, match="only applies to the native format"):
+        dataset.export(out, dataset_type=dataset_type, ldf_version="2.0")
+    assert not out.exists(), "must fail before creating the output directory"
+
+
+def test_invalid_version_leaves_no_output_directory(
+    dataset_name: str, tempdir: Path
+):
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    out = tempdir / "bad"
+    with pytest.raises(ValueError, match="Invalid LDF version"):
+        dataset.export(out, ldf_version="banana")
+    assert not out.exists(), "must fail before creating the output directory"

--- a/tests/test_data/test_export_ldf_version.py
+++ b/tests/test_data/test_export_ldf_version.py
@@ -227,6 +227,104 @@ def test_export_2_0_stamps_every_partition(dataset_name: str, tempdir: Path):
         assert "sample_metadata" not in record
 
 
+def _stamp(export_root: Path, version: str) -> None:
+    """Overwrite an export's version stamp, faking another install."""
+    (export_root / "metadata.json").write_text(
+        json.dumps({"ldf_version": version})
+    )
+
+
+def _import(export_root: Path, dataset_name: str, tempdir: Path) -> None:
+    LuxonisParser(
+        str(export_root),
+        dataset_type=DatasetType.NATIVE,
+        dataset_name=dataset_name,
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+
+
+def _newer_export(dataset_name: str, tempdir: Path, version: str) -> Path:
+    """Export a dataset and restamp it as written by a newer install."""
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    root = _export(dataset, tempdir, f"from_{version}")
+    _stamp(root, version)
+    return root
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        # A newer major, and -- the case a `.major`-only comparison
+        # misses -- a newer minor. `sample_metadata` arrived in exactly
+        # such a bump, so a same-major export is just as unreadable.
+        f"{LDF_VERSION.major + 1}.0.0",
+        str(LDF_VERSION.bump_minor()),
+        str(LDF_VERSION.bump_patch()),
+    ],
+)
+def test_import_warns_once_on_newer_export(
+    dataset_name: str, tempdir: Path, warnings_log: list[str], version: str
+):
+    """A newer stamp warns exactly once, not once per split.
+
+    `NativeParser.from_dir` parses train, val and test, and the stamp sits
+    above all three.
+    """
+    root = _newer_export(dataset_name, tempdir, version)
+    _import(root, f"{dataset_name}_imported", tempdir)
+
+    warned = [msg for msg in warnings_log if "declares LDF" in msg]
+    assert len(warned) == 1
+    assert version in warned[0]
+
+
+@pytest.mark.parametrize("version", ["2.0.0", None])
+def test_import_is_quiet_for_current_or_older_exports(
+    dataset_name: str,
+    tempdir: Path,
+    warnings_log: list[str],
+    version: str | None,
+):
+    """An older export is a strict subset of what this version accepts."""
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    root = _export(dataset, tempdir, "quiet", ldf_version=version)
+    _import(root, f"{dataset_name}_imported", tempdir)
+
+    assert not [msg for msg in warnings_log if "declares LDF" in msg]
+
+
+# ``None`` removes the stamp altogether, standing for an export made
+# before the stamp existed.
+@pytest.mark.parametrize(
+    "stamp", ['{"ldf_version": "banana"}', "{}", "{", None]
+)
+def test_damaged_or_missing_stamp_does_not_break_the_import(
+    dataset_name: str,
+    tempdir: Path,
+    warnings_log: list[str],
+    stamp: str | None,
+):
+    """The stamp is best-effort, so neither case may fail the parse."""
+    dataset = create_dataset(
+        dataset_name, _generator(tempdir), splits=(1, 0, 0)
+    )
+    root = _export(dataset, tempdir, "damaged")
+    if stamp is None:
+        (root / "metadata.json").unlink()
+    else:
+        (root / "metadata.json").write_text(stamp)
+
+    _import(root, f"{dataset_name}_imported", tempdir)
+
+    # Nothing readable says the export is newer, so nothing to report.
+    assert not [msg for msg in warnings_log if "declares LDF" in msg]
+
+
 # `DatasetType` mixes in `str`, so the bare string is a real calling
 # convention and must reach the same error as the enum.
 @pytest.mark.parametrize("dataset_type", [DatasetType.COCO, "coco"])


### PR DESCRIPTION




## Purpose
`DatasetRecord` forbids extra fields, so a record carrying a field the reading installation does not know fails validation outright. LDF 2.1 added `sample_metadata`, which made every native export unreadable by an older luxonis-ml, with no way to ask for one it could read and no way to tell afterwards which version an export directory held.


`luxonis_ml data export ds --type native --ldf-version 2.0` now writes an export an older install parses cleanly.

## Specification
<!-- Briefly describe what’s changing and any relevant details. Replace the default or keep if not applicable (explain why). -->
Records are built at the current `LDF_VERSION` and passed through an ordered chain of per-step downgrade transforms on the way out -- the counterpart of `migration.py`, which upgrades a stored dataframe on load. Today the chain holds one step, 2.1 -> 2.0, dropping `sample_metadata`. Supporting a future version is one prepended entry, and a test fails if `LDF_VERSION` is raised without a matching step.

Downgrading is lossy, so it warns with the dropped field and the record count, staying quiet when nothing populated was actually discarded.

Every export root (and every partition) now carries a `metadata.json` naming the version written. It is only a version stamp, deliberately not the full `Metadata` model a dataset keeps in its own storage. `NativeParser` reads it solely to warn about exports from a *newer* version; an older record is a strict subset of what it accepts, so reading one needs no transform, and a missing stamp stays non-fatal for existing exports.


## Dependencies & Potential Impact
<!-- Any affected services, breaking changes, or risks? Replace the default or keep if not applicable (explain why).-->
None / not applicable

## Deployment Plan
<!-- Steps for rollout, rollback, and monitoring. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## Testing & Validation
<!-- How was this tested? Include relevant test results. Replace the default or keep if not applicable (explain why). -->
None / not applicable

## AI Usage
<!-- 
What AI tools have you used? Is this PR AI assisted? Example of Assisted-by: Claude:claude-3-opus coccinelle sparse
Where:
- AGENT_NAME is the name of the AI tool or framework
- MODEL_VERSION is the specific model version used
- [TOOL1] [TOOL2] are optional specialized analysis tools used (e.g., coccinelle, sparse, smatch, clang-tidy)
-->
Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native dataset exports can target a specific LDF version, including supported older versions.
  * Exported partitions now include metadata identifying their LDF version.
  * Older-version exports automatically remove unsupported fields and report discarded data.

* **Bug Fixes**
  * Added validation for unsupported, malformed, or incompatible LDF versions.
  * Added compatibility warnings when loading exports created with newer LDF versions.
  * Prevented LDF version selection for non-native export formats.

* **Documentation**
  * Clarified LDF version constraints, downgrade behavior, and metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->