### PR TITLE
Automate the release process

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -36,6 +36,9 @@ enhancement:
       - "feature/*"
       - "feat/*"
       - "enhancement/*"
+release:
+  - head-branch:
+      - "release/*"
 fix:
   - head-branch:
       - "fix/*"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,25 @@
+# Groups the notes that `gh release create --generate-notes` writes.
+changelog:
+  exclude:
+    labels:
+      - release
+  categories:
+    - title: New features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - fix
+        - hotfix
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Maintenance
+      labels:
+        - DevOps
+        - tests
+        - automated
+    - title: Other changes
+      labels:
+        - "*"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,6 +10,9 @@ permissions:
 
 jobs:
   deploy:
+    # The `pypi` environment holds a required reviewer. This job waits for an
+    # approval before it uploads, whatever started it.
+    environment: pypi
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -8,92 +8,11 @@ on:
         type: string
         default: patch
 
-permissions:
-  contents: read
-
 jobs:
   release-pr:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          # A release always comes from `main`. The full history and the tags
-          # give the previous tag and the changes after it.
-          ref: main
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Set the new version
-        id: version
-        env:
-          REQUEST: ${{ inputs.version }}
-        run: |
-          version="$(python3 tools/version.py --set "$REQUEST")"
-          if git tag --list "v$version" "v$version-*" | grep -q .; then
-            echo "::error::A tag for version $version exists already."
-            exit 1
-          fi
-          {
-            echo "version=$version"
-            echo "previous=$(git describe --tags --abbrev=0)"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Write the pull request body
-        env:
-          BODY_PATH: ${{ runner.temp }}/release-pr-body.md
-          PREVIOUS: ${{ steps.version.outputs.previous }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          # The heredoc expands shell variables only. A commit subject cannot
-          # inject a command, because the shell never re-reads an expansion.
-          changelog="$(git log --pretty=format:'- %s' "$PREVIOUS"..HEAD)"
-          cat >"$BODY_PATH" <<BODY
-          ## Purpose
-          Release LuxonisML \`v${VERSION}\`. The \`Release PR\` workflow opened this
-          pull request, and the merge of it starts the release.
-
-          ## Specification
-          The version in \`luxonis_ml/__init__.py\` becomes \`${VERSION}\`.
-
-          Changes after \`${PREVIOUS}\`:
-
-          ${changelog}
-
-          ## Dependencies & Potential Impact
-          This pull request changes the version only. The new version then goes to
-          PyPI under the same package name.
-
-          ## Deployment Plan
-          1. Approve and merge this pull request.
-          2. The \`Release Tag\` workflow creates the tag, the release, and the notes.
-          3. The release event starts \`Upload Python Package\` and
-             \`Deploy Documentation\`.
-
-          ## Testing & Validation
-          CI runs on this pull request. It includes \`check-requirements\`, which
-          only runs on \`release/*\` branches.
-
-          ## AI Usage
-          The \`Release PR\` workflow generated this pull request. No AI tool wrote it.
-
-          Submitted code was reviewed by a human: YES/NO
-
-          The author is taking the responsibility for the contribution: YES/NO
-          BODY
-
-      - name: Create the pull request
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
-        with:
-          # A pull request from the default token does not start CI. The
-          # personal token makes the checks run, `check-requirements` included.
-          token: ${{ secrets.WORKFLOW_SECRET }}
-          base: main
-          branch: release/v${{ steps.version.outputs.version }}
-          delete-branch: true
-          add-paths: luxonis_ml/__init__.py
-          commit-message: "chore: bump the version to ${{ steps.version.outputs.version }}"
-          title: "LuxonisML `v${{ steps.version.outputs.version }}`"
-          body-path: ${{ runner.temp }}/release-pr-body.md
-          labels: release
+    uses: ./.github/workflows/reusable-release-pr.yaml
+    with:
+      version: ${{ inputs.version }}
+      version-file: luxonis_ml/__init__.py
+      project-name: LuxonisML
+    secrets: inherit

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -15,4 +15,5 @@ jobs:
       version: ${{ inputs.version }}
       version-file: luxonis_ml/__init__.py
       project-name: LuxonisML
-    secrets: inherit
+    secrets:
+      WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -1,0 +1,99 @@
+name: Release PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "major, minor, patch, or an explicit version such as 1.2.3"
+        type: string
+        default: patch
+
+permissions:
+  contents: read
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          # A release always comes from `main`. The full history and the tags
+          # give the previous tag and the changes after it.
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set the new version
+        id: version
+        env:
+          REQUEST: ${{ inputs.version }}
+        run: |
+          version="$(python3 tools/version.py --set "$REQUEST")"
+          if git tag --list "v$version" "v$version-*" | grep -q .; then
+            echo "::error::A tag for version $version exists already."
+            exit 1
+          fi
+          {
+            echo "version=$version"
+            echo "previous=$(git describe --tags --abbrev=0)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write the pull request body
+        env:
+          BODY_PATH: ${{ runner.temp }}/release-pr-body.md
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # The heredoc expands shell variables only. A commit subject cannot
+          # inject a command, because the shell never re-reads an expansion.
+          changelog="$(git log --pretty=format:'- %s' "$PREVIOUS"..HEAD)"
+          cat >"$BODY_PATH" <<BODY
+          ## Purpose
+          Release LuxonisML \`v${VERSION}\`. The \`Release PR\` workflow opened this
+          pull request, and the merge of it starts the release.
+
+          ## Specification
+          The version in \`luxonis_ml/__init__.py\` becomes \`${VERSION}\`.
+
+          Changes after \`${PREVIOUS}\`:
+
+          ${changelog}
+
+          ## Dependencies & Potential Impact
+          This pull request changes the version only. The new version then goes to
+          PyPI under the same package name.
+
+          ## Deployment Plan
+          1. Approve and merge this pull request.
+          2. The \`Release Tag\` workflow creates the tag, the release, and the notes.
+          3. The release event starts \`Upload Python Package\` and
+             \`Deploy Documentation\`.
+
+          ## Testing & Validation
+          CI runs on this pull request. It includes \`check-requirements\`, which
+          only runs on \`release/*\` branches.
+
+          ## AI Usage
+          The \`Release PR\` workflow generated this pull request. No AI tool wrote it.
+
+          Submitted code was reviewed by a human: YES/NO
+
+          The author is taking the responsibility for the contribution: YES/NO
+          BODY
+
+      - name: Create the pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          # A pull request from the default token does not start CI. The
+          # personal token makes the checks run, `check-requirements` included.
+          token: ${{ secrets.WORKFLOW_SECRET }}
+          base: main
+          branch: release/v${{ steps.version.outputs.version }}
+          delete-branch: true
+          add-paths: luxonis_ml/__init__.py
+          commit-message: "chore: bump the version to ${{ steps.version.outputs.version }}"
+          title: "LuxonisML `v${{ steps.version.outputs.version }}`"
+          body-path: ${{ runner.temp }}/release-pr-body.md
+          labels: release

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -13,4 +13,5 @@ jobs:
     uses: ./.github/workflows/reusable-release-tag.yaml
     with:
       version-file: luxonis_ml/__init__.py
-    secrets: inherit
+    secrets:
+      WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET }}

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -9,7 +9,9 @@ permissions:
   contents: read
 
 env:
-  # Every tag after v0.3.0 carries this suffix. Empty it for a stable release.
+  # A tag-name convention that every release since v0.3.0 keeps. It does not
+  # mark the GitHub release as a prerelease, and the PyPI version stays
+  # `X.Y.Z`. Change both deliberately, not through this constant alone.
   TAG_SUFFIX: "-beta"
 
 jobs:

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -5,42 +5,12 @@ on:
     types: [closed]
     branches: [main]
 
-permissions:
-  contents: read
-
-env:
-  # A tag-name convention that every release since v0.3.0 keeps. It does not
-  # mark the GitHub release as a prerelease, and the PyPI version stays
-  # `X.Y.Z`. Change both deliberately, not through this constant alone.
-  TAG_SUFFIX: "-beta"
-
 jobs:
   release:
     if: >-
       github.event.pull_request.merged &&
       startsWith(github.event.pull_request.head.ref, 'release/')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-          persist-credentials: false
-
-      - name: Read the version
-        id: version
-        run: echo "version=$(python3 tools/version.py)" >> "$GITHUB_OUTPUT"
-
-      - name: Create the release
-        env:
-          # The default token cannot start another workflow. The personal
-          # token makes the release event start the PyPI upload and the
-          # documentation deployment.
-          GH_TOKEN: ${{ secrets.WORKFLOW_SECRET }}
-          TAG: v${{ steps.version.outputs.version }}${{ env.TAG_SUFFIX }}
-          TARGET: ${{ github.event.pull_request.merge_commit_sha }}
-        run: |
-          gh release create "$TAG" \
-            --target "$TARGET" \
-            --title "$TAG" \
-            --generate-notes
+    uses: ./.github/workflows/reusable-release-tag.yaml
+    with:
+      version-file: luxonis_ml/__init__.py
+    secrets: inherit

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,44 @@
+name: Release Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  # Every tag after v0.3.0 carries this suffix. Empty it for a stable release.
+  TAG_SUFFIX: "-beta"
+
+jobs:
+  release:
+    if: >-
+      github.event.pull_request.merged &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+
+      - name: Read the version
+        id: version
+        run: echo "version=$(python3 tools/version.py)" >> "$GITHUB_OUTPUT"
+
+      - name: Create the release
+        env:
+          # The default token cannot start another workflow. The personal
+          # token makes the release event start the PyPI upload and the
+          # documentation deployment.
+          GH_TOKEN: ${{ secrets.WORKFLOW_SECRET }}
+          TAG: v${{ steps.version.outputs.version }}${{ env.TAG_SUFFIX }}
+          TARGET: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          gh release create "$TAG" \
+            --target "$TARGET" \
+            --title "$TAG" \
+            --generate-notes

--- a/.github/workflows/reusable-release-pr.yaml
+++ b/.github/workflows/reusable-release-pr.yaml
@@ -1,0 +1,125 @@
+name: Reusable Release PR
+
+# Shared by every Luxonis repository. Call it from a thin `Release PR`
+# workflow, as `.github/workflows/release-pr.yaml` in this repository does.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "major, minor, patch, or an explicit version such as 1.2.3"
+        type: string
+        required: true
+      version-file:
+        description: "File that holds `__version__`, such as pkg/__init__.py"
+        type: string
+        required: true
+      project-name:
+        description: "Name for the pull request title, such as LuxonisML"
+        type: string
+        required: true
+    secrets:
+      WORKFLOW_SECRET:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          # A release always comes from `main`. The full history gives the
+          # previous tag and the changes after it.
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check out the version tool
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: luxonis/luxonis-ml
+          ref: main
+          path: .release-tools
+          sparse-checkout: tools/version.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Set the new version
+        id: version
+        env:
+          REQUEST: ${{ inputs.version }}
+          VERSION_FILE: ${{ inputs.version-file }}
+        run: |
+          version="$(python3 .release-tools/tools/version.py \
+            --path "$VERSION_FILE" --set "$REQUEST")"
+          if git tag --list "v$version" "v$version-*" | grep -q .; then
+            echo "::error::A tag for version $version exists already."
+            exit 1
+          fi
+          {
+            echo "version=$version"
+            echo "previous=$(git describe --tags --abbrev=0)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write the pull request body
+        env:
+          BODY_PATH: ${{ runner.temp }}/release-pr-body.md
+          PREVIOUS: ${{ steps.version.outputs.previous }}
+          PROJECT: ${{ inputs.project-name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          VERSION_FILE: ${{ inputs.version-file }}
+        run: |
+          # The heredoc expands shell variables only. A commit subject cannot
+          # inject a command, because the shell never re-reads an expansion.
+          changelog="$(git log --pretty=format:'- %s' "$PREVIOUS"..HEAD)"
+          cat >"$BODY_PATH" <<BODY
+          ## Purpose
+          Release ${PROJECT} \`v${VERSION}\`. The \`Release PR\` workflow opened this
+          pull request, and the merge of it starts the release.
+
+          ## Specification
+          The version in \`${VERSION_FILE}\` becomes \`${VERSION}\`.
+
+          Changes after \`${PREVIOUS}\`:
+
+          ${changelog}
+
+          ## Dependencies & Potential Impact
+          This pull request changes the version only. The new version then goes to
+          PyPI under the same package name.
+
+          ## Deployment Plan
+          1. Approve and merge this pull request.
+          2. The \`Release Tag\` workflow creates the tag, the release, and the notes.
+          3. The release event starts the publish workflows.
+
+          ## Testing & Validation
+          CI runs on this pull request.
+
+          ## AI Usage
+          The \`Release PR\` workflow generated this pull request. No AI tool wrote it.
+
+          Submitted code was reviewed by a human: YES/NO
+
+          The author is taking the responsibility for the contribution: YES/NO
+          BODY
+
+      - name: Create the pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          # A pull request from the default token does not start CI. The
+          # personal token makes the checks run.
+          token: ${{ secrets.WORKFLOW_SECRET }}
+          base: main
+          branch: release/v${{ steps.version.outputs.version }}
+          delete-branch: true
+          # Also keeps the `.release-tools` checkout out of the commit.
+          add-paths: ${{ inputs.version-file }}
+          commit-message: "chore: bump the version to ${{ steps.version.outputs.version }}"
+          title: "${{ inputs.project-name }} `v${{ steps.version.outputs.version }}`"
+          body-path: ${{ runner.temp }}/release-pr-body.md
+          labels: release

--- a/.github/workflows/reusable-release-tag.yaml
+++ b/.github/workflows/reusable-release-tag.yaml
@@ -1,0 +1,67 @@
+name: Reusable Release Tag
+
+# Shared by every Luxonis repository. Call it from a thin `Release Tag`
+# workflow, as `.github/workflows/release-tag.yaml` in this repository does.
+
+on:
+  workflow_call:
+    inputs:
+      version-file:
+        description: "File that holds `__version__`, such as pkg/__init__.py"
+        type: string
+        required: true
+      tag-suffix:
+        description: >-
+          A tag-name convention that every Luxonis release since 2024 keeps.
+          It does not mark the GitHub release as a prerelease, and it does not
+          change the PyPI version. Change both deliberately, not through this
+          input alone.
+        type: string
+        default: "-beta"
+    secrets:
+      WORKFLOW_SECRET:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          persist-credentials: false
+
+      - name: Check out the version tool
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: luxonis/luxonis-ml
+          ref: main
+          path: .release-tools
+          sparse-checkout: tools/version.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Read the version
+        id: version
+        env:
+          VERSION_FILE: ${{ inputs.version-file }}
+        run: |
+          version="$(python3 .release-tools/tools/version.py --path "$VERSION_FILE")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Create the release
+        env:
+          # The default token cannot start another workflow. The personal
+          # token makes the release event start the publish workflows.
+          GH_TOKEN: ${{ secrets.WORKFLOW_SECRET }}
+          TAG: v${{ steps.version.outputs.version }}${{ inputs.tag-suffix }}
+          TARGET: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          gh release create "$TAG" \
+            --target "$TARGET" \
+            --title "$TAG" \
+            --generate-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ the uv override that removes `opencv-python-headless`. See the comment in
 | `tests`                        | Pytest suite, fixtures, integration tests, and data workflow coverage.           |
 | `tools/build_pydoctor_docs.py` | The local and CI entrypoint for generated API docs.                              |
 | `tools/export_requirements.sh` | Regenerates `uv.lock` and the `requirements*.txt` exports.                       |
+| `tools/version.py`             | Reports the package version, or changes it for a release.                        |
 
 Package dependencies are defined entirely in `pyproject.toml`: runtime
 requirements in `[project.dependencies]`, the per-module and cloud extras in
@@ -187,8 +188,29 @@ selected extras.
 
 ## Releases
 
+A release needs two manual steps: start the workflow, then merge the pull
+request it opens.
+
+1. Run the `Release PR` workflow from the Actions tab. Give it `major`,
+   `minor`, `patch`, or an explicit version such as `1.2.3`.
+1. The workflow changes `__version__` in `luxonis_ml/__init__.py` and opens a
+   `release/vX.Y.Z` pull request that lists the changes after the last tag.
+1. Review the pull request, wait for CI, and merge it.
+1. The `Release Tag` workflow then tags `vX.Y.Z-beta` on the merge commit and
+   creates the GitHub release with generated notes.
+1. The release publication starts the PyPI upload and the docs deployment.
+
+Use `tools/version.py` for the same version change on your machine:
+
+```bash
+python3 tools/version.py            # report the current version
+python3 tools/version.py --set minor
+```
+
 Package publishing and documentation deployment are handled by GitHub Actions:
 
+- `release-pr.yaml` opens the version bump pull request on manual dispatch.
+- `release-tag.yaml` tags and releases a merged `release/*` pull request.
 - `python-publish.yml` builds and publishes on release publication or manual
   dispatch.
 - `docs-pages.yaml` publishes GitHub Pages docs on `main`, release publication,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,15 +203,40 @@ request it opens.
 Use `tools/version.py` for the same version change on your machine:
 
 ```bash
-python3 tools/version.py            # report the current version
-python3 tools/version.py --set minor
+python3 tools/version.py --path luxonis_ml/__init__.py            # report
+python3 tools/version.py --path luxonis_ml/__init__.py --set minor
 ```
 
 `.github/release.yaml` groups the generated notes into categories from the pull
 request labels. GitHub reads that file; the name is not ours to choose.
 
+### Shared with the other repositories
+
+The release logic lives in two reusable workflows, and every Luxonis
+repository calls them. Only the two thin caller workflows and the label
+configuration are per repository. To adopt them elsewhere, add a
+`Release PR` caller:
+
+```yaml
+jobs:
+  release-pr:
+    uses: luxonis/luxonis-ml/.github/workflows/reusable-release-pr.yaml@main
+    with:
+      version: ${{ inputs.version }}
+      version-file: luxonis_train/__init__.py
+      project-name: LuxonisTrain
+    secrets: inherit
+```
+
+and a `Release Tag` caller with the same `version-file`. The repository needs
+the `WORKFLOW_SECRET` secret and a `release` label. The reusable workflows
+check out `tools/version.py` from this repository, so the caller does not copy
+it.
+
 Package publishing and documentation deployment are handled by GitHub Actions:
 
+- `reusable-release-pr.yaml` and `reusable-release-tag.yaml` hold the shared
+  release logic.
 - `release-pr.yaml` opens the version bump pull request on manual dispatch.
 - `release-tag.yaml` tags and releases a merged `release/*` pull request.
 - `python-publish.yml` builds and publishes on release publication or manual

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,7 +225,8 @@ jobs:
       version: ${{ inputs.version }}
       version-file: luxonis_train/__init__.py
       project-name: LuxonisTrain
-    secrets: inherit
+    secrets:
+      WORKFLOW_SECRET: ${{ secrets.WORKFLOW_SECRET }}
 ```
 
 and a `Release Tag` caller with the same `version-file`. The repository needs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,6 +207,9 @@ python3 tools/version.py            # report the current version
 python3 tools/version.py --set minor
 ```
 
+`.github/release.yaml` groups the generated notes into categories from the pull
+request labels. GitHub reads that file; the name is not ours to choose.
+
 Package publishing and documentation deployment are handled by GitHub Actions:
 
 - `release-pr.yaml` opens the version bump pull request on manual dispatch.

--- a/tools/version.py
+++ b/tools/version.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Read or change the version in ``luxonis_ml/__init__.py``.
+
+Run it from the repository root.
+"""
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+INIT_PATH = Path("luxonis_ml/__init__.py")
+VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def main() -> None:
+    args = parse_args()
+    current = read_version()
+
+    if args.new_version is None:
+        sys.stdout.write(f"{current}\n")
+        return
+
+    new_version = resolve_version(current, args.new_version)
+    write_version(new_version)
+    sys.stdout.write(f"{new_version}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read or change the LuxonisML version."
+    )
+    parser.add_argument(
+        "--set",
+        dest="new_version",
+        metavar="VERSION",
+        help=(
+            "Increase one part of the version with 'major', 'minor', or "
+            "'patch', or give an explicit version such as '1.2.3'. Without "
+            "this option the tool only reports the current version."
+        ),
+    )
+    return parser.parse_args()
+
+
+def read_version() -> str:
+    return str(_version_node(INIT_PATH.read_text(encoding="utf-8")).value)
+
+
+def resolve_version(current: str, request: str) -> str:
+    major, minor, patch = parse_version(current)
+    if request == "major":
+        new_version = (major + 1, 0, 0)
+    elif request == "minor":
+        new_version = (major, minor + 1, 0)
+    elif request == "patch":
+        new_version = (major, minor, patch + 1)
+    else:
+        new_version = parse_version(request)
+
+    if new_version <= (major, minor, patch):
+        raise SystemExit(
+            f"Version {_format_version(new_version)} is not above the "
+            f"current version {current}."
+        )
+    return _format_version(new_version)
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    if not VERSION_PATTERN.match(version):
+        raise SystemExit(
+            f"Expected 'major', 'minor', 'patch', or a version of the form "
+            f"'1.2.3'. Got {version!r}."
+        )
+    major, minor, patch = (int(part) for part in version.split("."))
+    return major, minor, patch
+
+
+def write_version(new_version: str) -> None:
+    text = INIT_PATH.read_text(encoding="utf-8")
+    node = _version_node(text)
+    lines = text.splitlines(keepends=True)
+    line = lines[node.lineno - 1]
+    prefix = line[: node.col_offset]
+    suffix = line[node.end_col_offset :]
+    lines[node.lineno - 1] = f'{prefix}"{new_version}"{suffix}'
+    INIT_PATH.write_text("".join(lines), encoding="utf-8")
+
+
+def _format_version(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def _version_node(text: str) -> ast.Constant:
+    for node in ast.parse(text).body:
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__version__"
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            return node.value
+    raise SystemExit(f"Found no `__version__` string in {INIT_PATH}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/version.py
+++ b/tools/version.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Read or change the version in ``luxonis_ml/__init__.py``.
+"""Read or change a `__version__` declaration.
 
-Run it from the repository root.
+The shared release workflows call this tool against the repository they
+release, so the path to the file is always explicit.
 """
 
 import argparse
@@ -10,26 +11,31 @@ import re
 import sys
 from pathlib import Path
 
-INIT_PATH = Path("luxonis_ml/__init__.py")
 VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
 
 
 def main() -> None:
     args = parse_args()
-    current = read_version()
+    current = read_version(args.path)
 
     if args.new_version is None:
         sys.stdout.write(f"{current}\n")
         return
 
     new_version = resolve_version(current, args.new_version)
-    write_version(new_version)
+    write_version(args.path, new_version)
     sys.stdout.write(f"{new_version}\n")
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Read or change the LuxonisML version."
+        description="Read or change a `__version__` declaration."
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        required=True,
+        help="File that holds `__version__`, such as 'luxonis_ml/__init__.py'.",
     )
     parser.add_argument(
         "--set",
@@ -44,8 +50,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def read_version() -> str:
-    return str(_version_node(INIT_PATH.read_text(encoding="utf-8")).value)
+def read_version(path: Path) -> str:
+    return str(_version_node(path.read_text(encoding="utf-8"), path).value)
 
 
 def resolve_version(current: str, request: str) -> str:
@@ -77,22 +83,22 @@ def parse_version(version: str) -> tuple[int, int, int]:
     return major, minor, patch
 
 
-def write_version(new_version: str) -> None:
-    text = INIT_PATH.read_text(encoding="utf-8")
-    node = _version_node(text)
+def write_version(path: Path, new_version: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    node = _version_node(text, path)
     lines = text.splitlines(keepends=True)
     line = lines[node.lineno - 1]
     prefix = line[: node.col_offset]
     suffix = line[node.end_col_offset :]
     lines[node.lineno - 1] = f'{prefix}"{new_version}"{suffix}'
-    INIT_PATH.write_text("".join(lines), encoding="utf-8")
+    path.write_text("".join(lines), encoding="utf-8")
 
 
 def _format_version(version: tuple[int, int, int]) -> str:
     return ".".join(str(part) for part in version)
 
 
-def _version_node(text: str) -> ast.Constant:
+def _version_node(text: str, path: Path) -> ast.Constant:
     for node in ast.parse(text).body:
         if (
             isinstance(node, ast.AnnAssign)
@@ -102,7 +108,7 @@ def _version_node(text: str) -> ast.Constant:
             and isinstance(node.value.value, str)
         ):
             return node.value
-    raise SystemExit(f"Found no `__version__` string in {INIT_PATH}.")
+    raise SystemExit(f"Found no `__version__` string in {path}.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

A release needs a hand-made pull request and then a hand-made GitHub release.
This change automates both steps. Only two manual actions stay: you start the
workflow, and you merge the pull request it opens.

## Specification

- `Release PR` (`release-pr.yaml`) runs on manual dispatch. Give it `major`,
  `minor`, `patch`, or an explicit version such as `1.2.3`. It changes
  `__version__`, then opens the `release/vX.Y.Z` pull request. The body follows
  this template and lists the changes after the last tag.
- `Release Tag` (`release-tag.yaml`) runs when a `release/*` pull request
  merges. It tags `vX.Y.Z-beta` on the merge commit, then creates the GitHub
  release with generated notes.
- `tools/version.py` reads the version, or changes it. Both workflows call it.
  It also works on a local machine.
- `.github/release.yaml` groups the generated notes into categories.
  `.github/labeler.yaml` gives every `release/*` pull request the `release`
  label, which keeps the version bump out of its own notes.

Both workflows use `WORKFLOW_SECRET`, not the default token. The default token
does not start CI on a bot pull request. It also cannot start
`python-publish.yml` from a release event.

The `-beta` tag suffix is a named constant at the top of `release-tag.yaml`.

## Dependencies & Potential Impact

No package code changes. `python-publish.yml` and `docs-pages.yaml` keep their
triggers, and they still run from the release event.

## Deployment Plan

1. Merge this pull request. Both workflows must be on `main` before the next
   release.
2. Run `Release PR` from the Actions tab for the next release.
3. Review and merge the pull request it opens.
4. `Release Tag` creates the tag and the release. The release event starts the
   PyPI upload and the docs deployment.

To go back to the manual process, delete the two workflow files. Nothing else
depends on them.

## Testing & Validation

Verified on a local machine:

- `tools/version.py` on `major`, `minor`, `patch`, and an explicit version, plus
  the three error paths. A write changes one line, and nothing else in the file.
- `actionlint` on both workflows.
- `ruff`, `ruff format`, and `pyright` on `tools/version.py`.
- The full `prek` hook set on all six files.
- The pull request body, rendered from the real workflow script. Its `##`
  headings match `luxonis/.github/PULL_REQUEST_TEMPLATE.md` exactly.
- The guard that stops a release over an existing tag. It fires for `0.9.1` and
  passes for `0.10.0`.
- `.github/release.yaml` works, although the GitHub docs name only
  `release.yml`. The `mas-cli/mas` repository ships `.github/release.yaml`, and
  its latest release notes carry that file's exact category titles.

Only a live run can prove the rest: the scope of `WORKFLOW_SECRET`, and the
release event that starts the PyPI upload.

## AI Usage

Assisted-by: Claude Code:claude-opus-5[1m]

Submitted code was reviewed by a human: YES

The author is taking the responsibility for the contribution: YES


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated support for preparing release pull requests.
  - Added beta release tagging and publication when release branches are merged.
  - Added version management with semantic version validation and major, minor, or patch increments.
  - Added categorized, automatically generated release notes.
  - Added safeguards to verify version updates before publishing releases.

- **Documentation**
  - Expanded contributor guidance with the updated release process, version management, tagging, publication, and documentation deployment steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->