### PR TITLE
Fail the docs build on a pydoctor warning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,15 +131,21 @@ uv run pydoctor luxonis_ml
 ```
 
 Open `apidocs/index.html` to inspect the result. CI runs the same command. The
-`[tool.pydoctor]` section of `pyproject.toml` sets the Google docstring format,
-which pydoctor reads on its own.
+`[tool.pydoctor]` section of `pyproject.toml` sets the Google docstring format
+and `warnings-as-errors`, which pydoctor reads on its own.
 
 > [!IMPORTANT]
-> A malformed docstring is a syntax error. pydoctor reports it and exits
-> non-zero, so the CI job fails on broken markup. pydoctor exits 0 for
-> unresolved-reference and annotation warnings, and the build reports some of
-> those today. Read the command output after you change a docstring, because
-> those warnings do not stop the build.
+> A warning fails the build. pydoctor exits non-zero on broken markup, on a
+> reference it cannot resolve, and on an annotation it cannot parse.
+
+Single backticks ask pydoctor for a link. Put a name it cannot resolve, such
+as a class from another library, in double backticks instead. For a real link
+to external documentation, use the reST hyperlink form with an explicit target.
+
+pydoctor also parses each string inside an annotation as a forward reference,
+`Annotated[...]` metadata included. Write `Parameter(negative=())`, not
+`Parameter(negative="")`. Keep a value such as a file extension in a module
+constant that the annotation names.
 
 The published reference lives on the Luxonis documentation portal. The
 `Export pydoctor reference` workflow builds it from these docstrings with the
@@ -195,7 +201,7 @@ PR CI runs:
 | Check        | Notes                                                  |
 | ------------ | ------------------------------------------------------ |
 | `pre-commit` | Must pass before docs, type check, and tests proceed.  |
-| `docs`       | Builds the pydoctor docs to check that they parse.     |
+| `docs`       | Builds the pydoctor docs. A warning fails the job.     |
 | `type-check` | Runs Pyright on Python 3.10.                           |
 | `semgrep`    | Runs security and secret scanning.                     |
 | `tests`      | Runs pytest on Ubuntu and Windows in six split groups. |

--- a/luxonis_ml/data/__main__.py
+++ b/luxonis_ml/data/__main__.py
@@ -43,6 +43,12 @@ app = App(help="Dataset utilities.")
 
 BucketStorageT: TypeAlias = Annotated[BucketStorage, Parameter(alias="-b")]
 
+# pydoctor parses each string in an annotation as a forward reference,
+# and ".json" is not one. The extensions stay out of the annotation.
+AUG_CONFIG_VALIDATOR = validators.Path(
+    exists=True, ext={".json", ".yaml", ".yml"}
+)
+
 
 @app.command
 def info(
@@ -67,13 +73,13 @@ def delete(
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
     local: Annotated[
         bool,
-        Parameter(alias="-l", negative=""),
+        Parameter(alias="-l", negative=()),
     ] = False,
     remote: Annotated[
         bool,
-        Parameter(alias="-r", negative=""),
+        Parameter(alias="-r", negative=()),
     ] = False,
-    yes: Annotated[bool, Parameter(alias="-y", negative="")] = False,
+    yes: Annotated[bool, Parameter(alias="-y", negative=())] = False,
 ):
     """Delete a dataset from local storage, remote storage, or both.
 
@@ -188,12 +194,7 @@ def inspect(
     view: Annotated[list[str] | None, Parameter(alias="-v")] = None,
     aug_config: Annotated[
         Path | None,
-        Parameter(
-            alias="-a",
-            validator=validators.Path(
-                exists=True, ext={".json", ".yaml", ".yml"}
-            ),
-        ),
+        Parameter(alias="-a", validator=AUG_CONFIG_VALIDATOR),
     ] = None,
     size_multiplier: Annotated[
         float,
@@ -201,35 +202,35 @@ def inspect(
     ] = 1.0,
     ignore_aspect_ratio: Annotated[
         bool,
-        Parameter(alias="-i", negative=""),
+        Parameter(alias="-i", negative=()),
     ] = False,
     deterministic: Annotated[
         bool,
-        Parameter(alias="-d", negative=""),
+        Parameter(alias="-d", negative=()),
     ] = False,
     force_update: Annotated[
         bool,
-        Parameter(alias="-f", negative=""),
+        Parameter(alias="-f", negative=()),
     ] = False,
     blend_all: Annotated[
         bool,
-        Parameter(alias="-bl", negative=""),
+        Parameter(alias="-bl", negative=()),
     ] = False,
     per_instance: Annotated[
         bool,
-        Parameter(alias="-pi", negative=""),
+        Parameter(alias="-pi", negative=()),
     ] = False,
     list_augmentations: Annotated[
         bool,
-        Parameter(negative=""),
+        Parameter(negative=()),
     ] = False,
     print_sample_metadata: Annotated[
         bool,
-        Parameter(negative=""),
+        Parameter(negative=()),
     ] = True,
     skeletons: Annotated[
         bool,
-        Parameter(negative=""),
+        Parameter(negative=()),
     ] = False,
     keypoint_labels: Annotated[
         Literal["none", "numbers", "names", "full"],
@@ -435,7 +436,7 @@ def export(
         Parameter(
             name="--delete",
             alias="-d",
-            negative="",
+            negative=(),
         ),
     ] = False,
     max_partition_size_gb: Annotated[
@@ -505,7 +506,7 @@ def parse(
         Parameter(
             name="--delete",
             alias="-d",
-            negative="",
+            negative=(),
         ),
     ] = False,
     save_dir: Annotated[
@@ -762,7 +763,7 @@ def push(
     bucket_storage: BucketStorage,
     force: Annotated[
         bool,
-        Parameter(alias="-f", negative=""),
+        Parameter(alias="-f", negative=()),
     ] = False,
 ):
     """Push a local dataset to cloud storage.
@@ -811,7 +812,7 @@ def pull(
     *,
     force: Annotated[
         bool,
-        Parameter(alias="-f", negative=""),
+        Parameter(alias="-f", negative=()),
     ] = False,
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
 ):
@@ -855,7 +856,7 @@ def clone(
     *,
     push: Annotated[
         bool,
-        Parameter(alias="-p", negative=""),
+        Parameter(alias="-p", negative=()),
     ] = True,
     bucket_storage: BucketStorageT = BucketStorage.LOCAL,
     split: Annotated[

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -808,9 +808,9 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
         Transformations are matched by identity rather than by class name,
         which keeps registry aliases and repeated entries apart. Only
-        `A.BaseCompose` instances are descended into; a ``transforms``
-        attribute is not enough, as leaves such as `A.ColorJitter` expose
-        one for their internal adjustment functions.
+        ``A.BaseCompose`` instances are descended into; a ``transforms``
+        attribute is not enough, as leaves such as ``A.ColorJitter``
+        expose one for their internal adjustment functions.
         """
         if isinstance(transform, A.BaseCompose):
             for child in transform.transforms:
@@ -1195,7 +1195,7 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
         Args:
             transform: Albumentations composition to wrap. Must be an
-                `A.ReplayCompose` when ``is_pixel`` is set.
+                ``A.ReplayCompose`` when ``is_pixel`` is set.
             is_pixel: Whether the composition contains pixel-only
                 transforms that should be replayed across image sources.
             source_names: Image source names replayed for pixel-only
@@ -1249,7 +1249,7 @@ def _normalize_params(
     """Keep the sampled parameters that can be reported as provenance.
 
     Args:
-        params: Parameters `Albumentations` reported back.
+        params: Parameters Albumentations reported back.
         transform: Transformation they belong to, needed to tell a
             configured value from a sampled one. Nested parameters have no
             transformation of their own.
@@ -1268,10 +1268,10 @@ def _normalize_params(
 def _is_configured(transform: Any, key: str, value: Any) -> bool:
     """Whether a reported parameter only echoes back the configuration.
 
-    Some transformations do sample these: `A.CropAndPad` draws its ``fill``
-    from the range it was given, and the drawn value belongs in the report.
-    Keys the transformation knows nothing about, such as the input
-    ``shape``, are never sampled.
+    Some transformations do sample these: ``A.CropAndPad`` draws its
+    ``fill`` from the range it was given, and the drawn value belongs in
+    the report. Keys the transformation knows nothing about, such as the
+    input ``shape``, are never sampled.
     """
     if key not in _STATIC_PARAMS:
         return False

--- a/luxonis_ml/nn_archive/__main__.py
+++ b/luxonis_ml/nn_archive/__main__.py
@@ -24,23 +24,23 @@ def inspect(
     *,
     inputs: Annotated[
         bool,
-        Parameter(alias="-i", negative=""),
+        Parameter(alias="-i", negative=()),
     ] = False,
     metadata: Annotated[
         bool,
-        Parameter(alias="-m", negative=""),
+        Parameter(alias="-m", negative=()),
     ] = False,
     outputs: Annotated[
         bool,
-        Parameter(alias="-o", negative=""),
+        Parameter(alias="-o", negative=()),
     ] = False,
     heads: Annotated[
         bool,
-        Parameter(alias="-h", negative=""),
+        Parameter(alias="-h", negative=()),
     ] = False,
     buildinfo: Annotated[
         bool,
-        Parameter(alias="-b", negative=""),
+        Parameter(alias="-b", negative=()),
     ] = False,
 ):
     """Print NN Archive configuration.

--- a/luxonis_ml/utils/__main__.py
+++ b/luxonis_ml/utils/__main__.py
@@ -57,7 +57,7 @@ def ls(
     *,
     recursive: Annotated[
         bool,
-        Parameter(alias="-r", negative=""),
+        Parameter(alias="-r", negative=()),
     ] = False,
     typ: Annotated[
         Literal["file", "directory", "all"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,6 +205,7 @@ wrap-descriptions = 72
 
 [tool.pydoctor]
 docformat = "google"
+warnings-as-errors = true
 
 [tool.pyright]
 pythonVersion = "3.10"


### PR DESCRIPTION
## Purpose

The docs build cannot run with `--warnings-as-errors` today. `pydoctor luxonis_ml`
reports 28 warnings on the current tree:

- 23 come from the `__main__` modules. pydoctor parses each string in an
  annotation as a forward reference. `Parameter(negative="")` and
  `ext={".json", ".yaml", ".yml"}` are not Python expressions.
- 5 come from `albumentations_engine.py`. Single backticks ask pydoctor for a
  link, and no target exists for `A.BaseCompose` and four similar names.

This PR removes all 28 warnings and makes a warning fail the build.

## Specification

Three commits, one change each:

1. `keep pydoctor from parsing CLI parameter strings` — `negative=""` becomes
   `negative=()` in the three `__main__.py` files. The `--aug-config` validator
   moves into the module constant `AUG_CONFIG_VALIDATOR`, so the file
   extensions leave the annotation.
1. `mark unresolvable Albumentations names as literals` — double backticks for
   the five external names in `albumentations_engine.py`.
1. `fail the docs build on a pydoctor warning` — `warnings-as-errors = true` in
   `[tool.pydoctor]`, plus the matching CONTRIBUTING.md text.

## Dependencies & Potential Impact

- No behavior change. cyclopts converts `negative=""` and `negative=()` to the
  same empty tuple.
- `ci.yaml` needs no change. `[tool.pydoctor]` holds the setting, so the local
  command and the CI job now give the same result.
- The portal export is not affected. `luxonis/docs-content` patches pydoctor to
  skip `Annotated` metadata, which is why the published CLI pages were always
  correct while the bare build warned.
- This PR stacks on #488. Merge #488 first.

## Deployment Plan

None / not applicable. The change touches docstrings, CLI parameter metadata,
and the docs configuration only.


## AI Usage

Assisted-by: Claude Code:claude-opus-5[1m]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
