### PR TITLE
Add task-keyed LDF records and LoaderOutput conversion

### DIFF
--- a/luxonis_ml/data/__init__.py
+++ b/luxonis_ml/data/__init__.py
@@ -111,16 +111,16 @@ Records, Tasks, and Labels
 ==========================
 
 Dataset ingestion is record-based. A record points to one file or to multiple
-synchronized files, optionally assigns a task name, and optionally provides an
-annotation payload.
+synchronized files through ``media``, and groups its annotation payloads by
+task name.
 
 Example:
-    The two supported media-key styles are easy to distinguish.
+    The same key takes one file or a mapping of source names.
 
-    >>> single_source = {"file": "image.jpg", "annotation": None}
-    >>> multi_source = {"files": {"rgb": "rgb.png", "depth": "depth.png"}}
-    >>> "file" in single_source, "files" in multi_source
-    (True, True)
+    >>> single_source = {"media": "image.jpg"}
+    >>> multi_source = {"media": {"rgb": "rgb.png", "depth": "depth.png"}}
+    >>> isinstance(multi_source["media"], dict)
+    True
 
 Task names group annotations that should be consumed together by a model or
 loader. Loader label keys use ``"task_name/task_type"``. If no task name is

--- a/luxonis_ml/data/augmentations/albumentations_engine.py
+++ b/luxonis_ml/data/augmentations/albumentations_engine.py
@@ -11,7 +11,7 @@ from loguru import logger
 from pydantic import Field
 from typing_extensions import override
 
-from luxonis_ml.data.utils.task_utils import get_task_type, task_is_metadata
+from luxonis_ml.data.utils.task_utils import get_task_group, task_is_metadata
 from luxonis_ml.typing import ConfigItem, LoaderMultiOutput, Params
 from luxonis_ml.utils import deprecated
 
@@ -496,8 +496,8 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
 
             self._targets[target_name] = target_type
             self._target_names_to_tasks[target_name] = task
-            self._target_names_to_task_groups[target_name] = (
-                self._get_task_group(task)
+            self._target_names_to_task_groups[target_name] = get_task_group(
+                task
             )
 
         for source_name in source_names:
@@ -1163,21 +1163,6 @@ class AlbumentationsEngine(AugmentationEngine, register_name="albumentations"):
         if not isinstance(transform, A.BaseCompose):
             tracked_paths[id(transform)] = "/".join(current_path)
         return transform
-
-    @staticmethod
-    def _get_task_group(task: str) -> str:
-        """Return the complete task path without its task-type suffix.
-
-        Unlike `get_task_name`, this keeps every level of a nested task
-        name, so ``"a/b/keypoints"`` groups under ``"a/b"``. The leading
-        ``"/"`` of LDF's default task marks a name that is empty on purpose,
-        while a task with no separator at all has no name to group by and is
-        only ever grouped with itself.
-        """
-        group = task.removesuffix(get_task_type(task)).removesuffix("/")
-        if group:
-            return group
-        return "" if task.startswith("/") else task
 
     @staticmethod
     def _task_to_target_name(task: str) -> str:

--- a/luxonis_ml/data/datasets/__init__.py
+++ b/luxonis_ml/data/datasets/__init__.py
@@ -41,16 +41,19 @@ Typical mutation flow:
 
     def records():
         yield {
-            "file": "path/to/image.jpg",
-            "task_name": "detection",
+            "media": "path/to/image.jpg",
             "annotation": {
-                "class": "car",
-                "boundingbox": {
-                    "x": 0.1,
-                    "y": 0.2,
-                    "w": 0.3,
-                    "h": 0.4,
-                },
+                "detection": [
+                    {
+                        "class": "car",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.2,
+                            "w": 0.3,
+                            "h": 0.4,
+                        },
+                    }
+                ],
             },
         }
 
@@ -131,8 +134,7 @@ tasks.
 .. code-block:: json
 
     {
-      "file": "images/frame_001.jpg",
-      "task_name": "detection",
+      "media": "images/frame_001.jpg",
 
       "sample_metadata": {
         "record_id": 123,

--- a/luxonis_ml/data/datasets/annotation.py
+++ b/luxonis_ml/data/datasets/annotation.py
@@ -18,6 +18,7 @@ from luxonis_ml.ldf.annotation import (
     KeypointMetadata,
     KeypointVisibility,
     NormalizedFloat,
+    PathOrArray,
     SegmentationAnnotation,
     load_annotation,
 )
@@ -38,6 +39,7 @@ __all__ = [
     "KeypointVisibility",
     "NormalizedFloat",
     "ParquetRecord",
+    "PathOrArray",
     "SegmentationAnnotation",
     "load_annotation",
 ]

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -678,7 +678,7 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
             )
 
         if attempt_migration and self.version.major != LDF_VERSION.major:
-            df = migrate_dataframe(df)
+            df = migrate_dataframe(df, self.version)
 
         return df
 
@@ -846,11 +846,15 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                 df = df.with_columns(pl.col("uuid").alias("group_id"))
                 self._save_df_offline(df)
 
-            version = Version.parse(metadata_json.get("ldf_version", "1.0.0"))
-            if version.major != LDF_VERSION.major:  # pragma: no cover
+            version = Version.parse(
+                metadata_json.get("ldf_version", "1.0.0"),
+                optional_minor_and_patch=True,
+            )
+            if version.major != LDF_VERSION.major:
                 return migrate_metadata(
                     metadata_json,
                     self._load_df_offline(lazy=True, attempt_migration=False),
+                    version,
                 )
             return Metadata(**metadata_json)
         return Metadata(

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -2,7 +2,7 @@ import json
 import math
 import shutil
 from collections import defaultdict
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from functools import cached_property
@@ -1351,15 +1351,23 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
         uuid_dict = {}
         for record in data_batch:
             self._progress.update(task, advance=1)
-            if record.annotation is None or record.annotation.array is None:
-                continue
-            ann = record.annotation.array
-            if self.is_remote:
-                uuid = self._fs.get_file_uuid(ann.path, local=True)
-                uuid_dict[str(ann.path)] = uuid
-                ann.path = Path(uuid).with_suffix(ann.path.suffix)
-            else:
-                ann.path = ann.path.absolute().resolve()
+            for detections in record.annotation.values():
+                for detection in _walk_detections(detections):
+                    ann = detection.array
+                    if ann is None:
+                        continue
+                    if isinstance(ann.path, np.ndarray):
+                        raise NotImplementedError(
+                            "An array annotation holds its data in memory, "
+                            "which a dataset cannot store. Save it as a "
+                            "'.npy' file and pass that path instead."
+                        )
+                    if self.is_remote:
+                        uuid = self._fs.get_file_uuid(ann.path, local=True)
+                        uuid_dict[str(ann.path)] = uuid
+                        ann.path = Path(uuid).with_suffix(ann.path.suffix)
+                    else:
+                        ann.path = ann.path.absolute().resolve()
         self._progress.stop()
         self._progress.remove_task(task)
         if self.is_remote:
@@ -1395,7 +1403,9 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
         keypoint_metadata = self._alignment_keypoint_metadata(
             declared_keypoint_metadata
         )
-        paths = {path for data in data_batch for path in data.all_file_paths}
+        paths = {
+            path for data in data_batch for path in data.file_paths.values()
+        }
         logger.info("Generating UUIDs...")
         uuid_dict = self._fs.get_file_uuids(paths, local=True)
 
@@ -1431,7 +1441,7 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
         logger.info("Saving annotations...")
         with self._progress:
             for record in data_batch:
-                file_paths = record.all_file_paths
+                file_paths = record.file_paths.values()
                 uuid_list = [
                     uuid_dict[str(file_path)] for file_path in file_paths
                 ]
@@ -1444,6 +1454,30 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                     pfm.write(uuid_dict[row["file"]], row, group_id)
                 self._progress.update(task, advance=1)
         self._progress.remove_task(task)
+
+    def _infer_default_task(self, record: DatasetRecord) -> None:
+        """Re-file the record's unnamed detections under an inferred task.
+
+        A detection whose class belongs to a known task moves there. One
+        whose class is unknown stays under the default task.
+        """
+        detections = record.annotation.get("")
+        if not detections:
+            return
+
+        current_classes = self.get_classes()
+        inferred: dict[str, list[Detection]] = defaultdict(list)
+        for detection in detections:
+            task_name = (
+                infer_task("", detection.class_name, current_classes)
+                if detection.class_name is not None
+                else ""
+            )
+            inferred[task_name].append(detection)
+
+        del record.annotation[""]
+        for task_name, task_detections in inferred.items():
+            record.annotation.setdefault(task_name, []).extend(task_detections)
 
     @override
     def add(
@@ -1468,7 +1502,6 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                     def record_generator():
                         yield {
                             "file": "/path/to/image.jpg",
-                            "task_name": "animals",
 
                             "sample_metadata": {
                                 "record_id": 123,
@@ -1477,24 +1510,28 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                             },
 
                             "annotation": {
-                                "instance_id": 1,
-                                "class": "cat",
-                                "boundingbox": {
-                                    "x": 0.10,
-                                    "y": 0.20,
-                                    "w": 0.30,
-                                    "h": 0.40,
-                                },
-                                "keypoints": {
-                                    "keypoints": [
-                                        (0.15, 0.25, 1),
-                                        (0.50, 0.60, 1),
-                                        (0.70, 0.80, 0),
-                                    ],
-                                },
-                                "instance_segmentation": {
-                                    "mask": "/path/to/mask.png",
-                                },
+                                "animals": [
+                                    {
+                                        "instance_id": 1,
+                                        "class": "cat",
+                                        "boundingbox": {
+                                            "x": 0.10,
+                                            "y": 0.20,
+                                            "w": 0.30,
+                                            "h": 0.40,
+                                        },
+                                        "keypoints": {
+                                            "keypoints": [
+                                                (0.15, 0.25, 1),
+                                                (0.50, 0.60, 1),
+                                                (0.70, 0.80, 0),
+                                            ],
+                                        },
+                                        "instance_segmentation": {
+                                            "mask": "/path/to/mask.png",
+                                        },
+                                    }
+                                ],
                             },
                         }
 
@@ -1535,73 +1572,61 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
 
         assert annotations_path is not None
 
+        def update_state(task_name: str, ann: Detection) -> None:
+            if ann.class_name is not None:
+                classes_per_task[task_name].add(ann.class_name)
+            elif not classes_per_task[task_name]:
+                classes_per_task[task_name] = set()
+
+            tasks[task_name] |= ann.get_task_types()
+
+            if ann.keypoints is not None:
+                num_kpts_per_task[task_name].add(len(ann.keypoints.keypoints))
+                declared = ann.keypoints.declared_metadata()
+                if declared is not None:
+                    current = declared_keypoint_metadata.get(task_name)
+                    declared_keypoint_metadata[task_name] = (
+                        declared
+                        if current is None
+                        else current.merge_with(
+                            declared, f"task '{task_name}'"
+                        )
+                    )
+            for name, value in ann.metadata.items():
+                task = f"{task_name}/metadata/{name}"
+                typ = type(value).__name__
+                if task in metadata_types and metadata_types[task] != typ:
+                    if {typ, metadata_types[task]} == {"int", "float"}:
+                        metadata_types[task] = "float"
+                    else:
+                        raise ValueError(
+                            f"Metadata type mismatch for {task}: {metadata_types[task]} and {typ}"
+                        )
+                else:
+                    metadata_types[task] = typ
+
+                if not isinstance(value, Category):
+                    continue
+                if value not in categorical_encodings[task]:
+                    categorical_encodings[task][value] = len(
+                        categorical_encodings[task]
+                    )
+            for name, sub_detection in ann.sub_detections.items():
+                update_state(f"{task_name}/{name}", sub_detection)
+
         with ParquetFileManager(annotations_path, batch_size) as pfm:
             for i, record in enumerate(generator, start=1):
                 if not isinstance(record, DatasetRecord):
                     record = DatasetRecord(**record)
                 sources.update(record.files.keys())
-                ann = record.annotation
-                if ann is not None:
-                    if not record.task_name:
-                        record.task_name = infer_task(
-                            record.task_name,
-                            ann.class_name,
-                            self.get_classes(),
-                        )
 
-                    def update_state(task_name: str, ann: Detection) -> None:
-                        if ann.class_name is not None:
-                            classes_per_task[task_name].add(ann.class_name)
-                        elif not classes_per_task[task_name]:
-                            classes_per_task[task_name] = set()
-
-                        tasks[task_name] |= ann.get_task_types()
-
-                        if ann.keypoints is not None:
-                            num_kpts_per_task[task_name].add(
-                                len(ann.keypoints.keypoints)
-                            )
-                            declared = ann.keypoints.declared_metadata()
-                            if declared is not None:
-                                current = declared_keypoint_metadata.get(
-                                    task_name
-                                )
-                                declared_keypoint_metadata[task_name] = (
-                                    declared
-                                    if current is None
-                                    else current.merge_with(
-                                        declared, f"task '{task_name}'"
-                                    )
-                                )
-                        for name, value in ann.metadata.items():
-                            task = f"{task_name}/metadata/{name}"
-                            typ = type(value).__name__
-                            if (
-                                task in metadata_types
-                                and metadata_types[task] != typ
-                            ):
-                                if {typ, metadata_types[task]} == {
-                                    "int",
-                                    "float",
-                                }:
-                                    metadata_types[task] = "float"
-                                else:
-                                    raise ValueError(
-                                        f"Metadata type mismatch for {task}: {metadata_types[task]} and {typ}"
-                                    )
-                            else:
-                                metadata_types[task] = typ
-
-                            if not isinstance(value, Category):
-                                continue
-                            if value not in categorical_encodings[task]:
-                                categorical_encodings[task][value] = len(
-                                    categorical_encodings[task]
-                                )
-                        for name, sub_detection in ann.sub_detections.items():
-                            update_state(f"{task_name}/{name}", sub_detection)
-
-                    update_state(record.task_name, ann)
+                self._infer_default_task(record)
+                for task_name, detections in record.annotation.items():
+                    # A task with no detections is a negative that still
+                    # declares the task, so it is registered either way.
+                    tasks.setdefault(task_name, set())
+                    for detection in detections:
+                        update_state(task_name, detection)
 
                 data_batch.append(record)
                 if i % batch_size == 0:
@@ -2241,3 +2266,10 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                     task=task_name,
                     rewrite_metadata=False,
                 )
+
+
+def _walk_detections(detections: Iterable[Detection]) -> Iterator[Detection]:
+    """Yield every detection, and every detection nested under it."""
+    for detection in detections:
+        yield detection
+        yield from _walk_detections(detection.sub_detections.values())

--- a/luxonis_ml/data/datasets/luxonis_dataset.py
+++ b/luxonis_ml/data/datasets/luxonis_dataset.py
@@ -331,11 +331,6 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
             f"Saved DataFrame to Parquet files in '{annotations_path}'."
         )
 
-    def _merge_metadata_with(self, other: "LuxonisDataset") -> None:
-        """Merge relevant metadata from ``other`` into ``self``."""
-        self._metadata = self._metadata.merge_with(other._metadata)
-        self._write_metadata()
-
     def clone(
         self,
         new_dataset_name: str,
@@ -504,6 +499,12 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                 k: v for k, v in splits_other.items() if k in splits_to_merge
             }
 
+        # The metadata decides whether the two datasets can merge at all, so
+        # it is merged before anything is written. Writing the rows first
+        # would leave the target holding the incoming data with its own
+        # classes and tasks never updated.
+        merged_metadata = target_dataset._metadata.merge_with(other._metadata)
+
         df_merged = pl.concat([df_self, df_other])
         target_dataset._save_df_offline(df_merged)
 
@@ -544,7 +545,8 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                 dst_path.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy(src_path, dst_path)
 
-        target_dataset._merge_metadata_with(other)
+        target_dataset._metadata = merged_metadata
+        target_dataset._write_metadata()
 
         return target_dataset
 
@@ -1443,6 +1445,11 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
         )
 
         logger.info("Saving annotations...")
+        # One sample is often built from several records, each holding one
+        # detection, so the instance numbers have to run across them. The
+        # counter is keyed by sample, and every record of that sample
+        # continues it.
+        instance_counters: dict[str, dict[str, int]] = defaultdict(dict)
         with self._progress:
             for record in data_batch:
                 file_paths = record.file_paths.values()
@@ -1454,7 +1461,9 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
                     if len(uuid_list) > 1
                     else str(uuid_list[0])
                 )
-                for row in record.to_parquet_rows(keypoint_metadata):
+                for row in record.to_parquet_rows(
+                    keypoint_metadata, instance_counters[group_id]
+                ):
                     pfm.write(uuid_dict[row["file"]], row, group_id)
                 self._progress.update(task, advance=1)
         self._progress.remove_task(task)
@@ -1663,7 +1672,17 @@ class LuxonisDataset(BaseDataset):  # noqa: PLW1641
 
         self._metadata.categorical_encodings = dict(categorical_encodings)
         self._metadata.metadata_types = metadata_types
-        self.set_tasks(tasks)
+        # An `add` sees only the records it is given. A later one that
+        # carries a negative declares the task with no task type, so the
+        # stored types have to survive it.
+        stored_tasks = self.get_tasks()
+        merged_tasks = {
+            task_name: set(stored_tasks.get(task_name, [])) | set(task_types)
+            for task_name, task_types in tasks.items()
+        }
+        for task_name, task_types in stored_tasks.items():
+            merged_tasks.setdefault(task_name, set(task_types))
+        self.set_tasks(merged_tasks)
         if sources:
             components = {
                 source_name: LuxonisComponent(

--- a/luxonis_ml/data/datasets/migration.py
+++ b/luxonis_ml/data/datasets/migration.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from typing import Any, Final, Literal, overload
 
 import polars as pl
+from semver.version import Version
 from typing_extensions import TypedDict
 
 from luxonis_ml.data.utils.parquet import DEFAULT_METADATA
@@ -67,14 +68,33 @@ class LDF_1_0_0_MetadataDict(TypedDict):
 
 
 @overload
-def migrate_dataframe(df: pl.LazyFrame) -> pl.LazyFrame: ...
+def migrate_dataframe(df: pl.LazyFrame, version: Version) -> pl.LazyFrame: ...
 
 
 @overload
-def migrate_dataframe(df: pl.DataFrame) -> pl.DataFrame: ...
+def migrate_dataframe(df: pl.DataFrame, version: Version) -> pl.DataFrame: ...
 
 
 def migrate_dataframe(
+    df: pl.LazyFrame | pl.DataFrame, version: Version
+) -> pl.LazyFrame | pl.DataFrame:
+    """Migrate an annotation dataframe to the layout this version reads.
+
+    Args:
+        df: Dataframe as it was stored.
+        version: LDF version the dataframe was written by.
+
+    Returns:
+        The dataframe in the current layout.
+
+    """
+    if version.major < 2:
+        return _migrate_dataframe_from_1_0(df)
+    # LDF 3.0 changed the record contract, not the rows it writes.
+    return df
+
+
+def _migrate_dataframe_from_1_0(
     df: pl.LazyFrame | pl.DataFrame,
 ) -> pl.LazyFrame | pl.DataFrame:  # pragma: no cover
     return (
@@ -126,14 +146,17 @@ def migrate_dataframe(
 
 
 def migrate_metadata(
-    metadata: LDF_1_0_0_MetadataDict, df: pl.LazyFrame | None
-) -> Metadata:  # pragma: no cover
-    """Migrate LDF ``1.0.0`` metadata to the current schema.
+    metadata: LDF_1_0_0_MetadataDict,
+    df: pl.LazyFrame | None,
+    version: Version,
+) -> Metadata:
+    """Migrate stored metadata to the schema this version reads.
 
     Args:
-        metadata: Metadata dictionary in the LDF ``1.0.0`` layout.
+        metadata: Metadata dictionary as it was stored.
         df: Optional annotation dataframe used to infer task names for
-            non-default datasets.
+            non-default datasets. Only LDF :math:`1.0.0` needs it.
+        version: LDF version the metadata was written by.
 
     Returns:
         Migrated metadata model.
@@ -143,6 +166,10 @@ def migrate_metadata(
             ``df`` is ``None``.
 
     """
+    if version.major >= 2:
+        # LDF 3.0 changed the record contract, not the metadata it keeps.
+        return Metadata.model_validate(metadata)
+
     new_metadata = {}
     old_classes = metadata["classes"]
     if set(old_classes.keys()) <= LDF_1_0_0_TASKS:

--- a/luxonis_ml/data/datasets/migration.py
+++ b/luxonis_ml/data/datasets/migration.py
@@ -5,6 +5,7 @@ import polars as pl
 from semver.version import Version
 from typing_extensions import TypedDict
 
+from luxonis_ml.data.utils.constants import LDF_VERSION
 from luxonis_ml.data.utils.parquet import DEFAULT_METADATA
 
 from .metadata import Metadata
@@ -167,8 +168,13 @@ def migrate_metadata(
 
     """
     if version.major >= 2:
-        # LDF 3.0 changed the record contract, not the metadata it keeps.
-        return Metadata.model_validate(metadata)
+        # LDF 3.0 changed the record contract, not the metadata it keeps, so
+        # nothing stored has to move. The stamp does: a dataset that keeps
+        # its old one is never migrated, and can never merge with a dataset
+        # this version wrote.
+        return Metadata.model_validate(
+            {**metadata, "ldf_version": str(LDF_VERSION)}
+        )
 
     new_metadata = {}
     old_classes = metadata["classes"]

--- a/luxonis_ml/data/exporters/classification_directory_exporter.py
+++ b/luxonis_ml/data/exporters/classification_directory_exporter.py
@@ -38,12 +38,12 @@ class ClassificationDirectoryExporter(BaseExporter):
 
             split = split_of_group(prepared_ldf, group_id)
 
+            # The directory names the class of the whole image, so every
+            # classification row of the image counts. The instance number
+            # cannot narrow that: every detection carries one.
             class_names: set[str] = set()
             for row in entry.iter_rows(named=True):
-                if (
-                    row["task_type"] == "classification"
-                    and row["instance_id"] == -1
-                ):
+                if row["task_type"] == "classification":
                     cname = row["class_name"]
                     if cname:
                         class_names.add(str(cname))

--- a/luxonis_ml/data/exporters/fiftyone_classification_exporter.py
+++ b/luxonis_ml/data/exporters/fiftyone_classification_exporter.py
@@ -81,12 +81,11 @@ class FiftyOneClassificationExporter(BaseExporter):
             self.split_labels[split] = {}
             self.split_image_counter[split] = 0
 
+        # Every classification row counts. The instance number cannot
+        # narrow that: every detection carries one.
         all_classes: set[str] = set()
         for row in prepared_ldf.processed_df.iter_rows(named=True):
-            if (
-                row["task_type"] == "classification"
-                and row["instance_id"] == -1
-            ):
+            if row["task_type"] == "classification":
                 cname = row["class_name"]
                 if cname:
                     all_classes.add(str(cname))
@@ -110,10 +109,7 @@ class FiftyOneClassificationExporter(BaseExporter):
 
             class_name: str | None = None
             for row in entry.iter_rows(named=True):
-                if (
-                    row["task_type"] == "classification"
-                    and row["instance_id"] == -1
-                ):
+                if row["task_type"] == "classification":
                     cname = row["class_name"]
                     if cname:
                         class_name = str(cname)

--- a/luxonis_ml/data/exporters/ldf_downgrade.py
+++ b/luxonis_ml/data/exporters/ldf_downgrade.py
@@ -149,13 +149,13 @@ class LDFDowngrader:
         return record
 
     @staticmethod
-    def _flatten(record: dict[str, Any]) -> dict[str, Any]:
+    def _flatten(record: Params) -> Params:
         """Rewrite a record into the flat shape older LDF versions read.
 
         The exporter writes one detection per record, so the task-keyed
         mapping always holds a single task and at most one detection.
         """
-        flattened: dict[str, Any] = {}
+        flattened: Params = {}
         media = record.pop("media", None)
         if isinstance(media, dict):
             flattened["files"] = media

--- a/luxonis_ml/data/exporters/ldf_downgrade.py
+++ b/luxonis_ml/data/exporters/ldf_downgrade.py
@@ -8,15 +8,21 @@ version therefore drops every field introduced above it.
 Annotations forbid extra fields as well, so the same holds one level
 down: LDF 2.2 added ``edges``, ``flip_pairs`` and ``sigmas`` to a keypoint
 annotation.
+
+LDF 3.0 changed the shape rather than the fields: it groups the detections
+of a record by task name. An older version reads the flat
+``file``/``task_name``/``annotation`` record, so the downgrade rebuilds it.
 """
 
 from collections import Counter
-from typing import Any, Final
+from collections.abc import Mapping
+from typing import Any, Final, TypeGuard
 
 from loguru import logger
 from semver.version import Version
 
 from luxonis_ml.data.utils.constants import LDF_VERSION
+from luxonis_ml.typing import Params, ParamValue
 
 
 def _parse(version: str) -> Version:
@@ -40,6 +46,10 @@ _ADDED_ANNOTATION_FIELDS: Final[dict[tuple[str, str], Version]] = {
 #: The version that started to key the keypoints by name. An older one
 #: reads them as a plain list.
 _KEYPOINT_NAMES_ADDED_IN: Final[Version] = _parse("2.2")
+
+#: The version that grouped a record's detections by task name. Anything
+#: older reads the flat ``file``/``task_name``/``annotation`` shape.
+_TASK_KEYED_RECORDS: Final[Version] = _parse("3.0")
 
 #: LDF versions the native exporter can write, newest first.
 SUPPORTED_EXPORT_VERSIONS: Final[tuple[Version, ...]] = (
@@ -114,12 +124,15 @@ class LDFDowngrader:
             if added_in > target_version
         ]
         self._keeps_keypoint_names = target_version >= _KEYPOINT_NAMES_ADDED_IN
+        self._flatten_record = target_version < _TASK_KEYED_RECORDS
         self._dropped: Counter[str] = Counter()
         self._n_records = 0
 
     def __call__(self, record: dict[str, Any]) -> dict[str, Any]:
         """Rewrite one exported record in place and return it."""
         self._n_records += 1
+        if self._flatten_record:
+            record = self._flatten(record)
         for field in self._to_drop:
             # An empty value is no loss, so drop it but do not report it.
             if record.pop(field, None):
@@ -133,6 +146,34 @@ class LDFDowngrader:
                     self._dropped[f"{task_type}.{field}"] += 1
             self._strip_keypoint_names(annotation)
         return record
+
+    @staticmethod
+    def _flatten(record: dict[str, Any]) -> dict[str, Any]:
+        """Rewrite a record into the flat shape older LDF versions read.
+
+        The exporter writes one detection per record, so the task-keyed
+        mapping always holds a single task and at most one detection.
+        """
+        flattened: dict[str, Any] = {}
+        media = record.pop("media", None)
+        if isinstance(media, dict):
+            flattened["files"] = media
+        elif media is not None:
+            flattened["file"] = media
+
+        annotation = record.pop("annotation", None)
+        if _is_task_keyed(annotation):
+            task_name, detections = next(iter(annotation.items()))
+            flattened["task_name"] = task_name
+            if detections:
+                flattened["annotation"] = detections[0]
+        elif annotation:
+            # Already flat, so it holds the one detection of the record.
+            flattened["annotation"] = annotation
+
+        # The remaining fields keep the order the record had.
+        flattened.update(record)
+        return flattened
 
     def log_summary(self) -> None:
         """Warn about populated data the downgrade discarded."""
@@ -157,3 +198,21 @@ class LDFDowngrader:
         if isinstance(values, dict):
             keypoints["keypoints"] = list(values.values())
             self._dropped["keypoints.names"] += 1
+
+
+def _is_task_keyed(
+    annotation: ParamValue,
+) -> TypeGuard[Mapping[str, list[Params]]]:
+    """Whether an annotation payload groups its detections by task name.
+
+    LDF 3.0 keys the detections of a record by task name. A record written
+    by an older version carries a single detection here, whose values are
+    annotation payloads rather than lists of them.
+    """
+    return (
+        isinstance(annotation, Mapping)
+        and bool(annotation)
+        and all(
+            isinstance(detections, list) for detections in annotation.values()
+        )
+    )

--- a/luxonis_ml/data/exporters/ldf_downgrade.py
+++ b/luxonis_ml/data/exporters/ldf_downgrade.py
@@ -54,6 +54,7 @@ _TASK_KEYED_RECORDS: Final[Version] = _parse("3.0")
 #: LDF versions the native exporter can write, newest first.
 SUPPORTED_EXPORT_VERSIONS: Final[tuple[Version, ...]] = (
     LDF_VERSION,
+    _parse("2.2"),
     _parse("2.1"),
     _parse("2.0"),
 )

--- a/luxonis_ml/data/exporters/native_exporter.py
+++ b/luxonis_ml/data/exporters/native_exporter.py
@@ -16,6 +16,7 @@ from luxonis_ml.data.exporters.ldf_downgrade import LDFDowngrader
 from luxonis_ml.data.utils.constants import LDF_VERSION
 from luxonis_ml.enums import DatasetType
 from luxonis_ml.ldf import DatasetRecord, KeypointMetadata
+from luxonis_ml.typing import Params
 from luxonis_ml.utils.path import path_to_posix
 
 
@@ -30,7 +31,7 @@ class NativeExporter(BaseExporter):
     ``files``. It is **record-level metadata**, not an annotation label.
 
     The export root also holds a ``metadata.json`` version stamp, such as
-    ``{"ldf_version": "2.2.0"}``. It is not the full `Metadata` model a
+    ``{"ldf_version": "3.0.0"}``. It is not the full `Metadata` model a
     dataset keeps in its own storage.
 
     Passing an older ``ldf_version`` strips the fields that version does
@@ -244,7 +245,7 @@ class NativeExporter(BaseExporter):
             ),
         }
 
-        detections: list[dict[str, Any]] = []
+        detections: list[Params] = []
         if ann_str is not None:
             data = json.loads(ann_str)
             ann: dict[str, Any] = {
@@ -261,9 +262,11 @@ class NativeExporter(BaseExporter):
             elif task_type.startswith("metadata/"):
                 ann["metadata"] = {task_type[9:]: data}
             detections.append(ann)
-        # An empty list still names the task, so a sample that is a negative
-        # for it says so.
-        record["annotation"] = {task_name: detections}
+        # A named empty list still names the task, so a sample that is a
+        # negative for it says so. An empty name names no task, so it must
+        # not become one on the way back in.
+        if task_name or detections:
+            record["annotation"] = {task_name: detections}
 
         return record
 

--- a/luxonis_ml/data/exporters/native_exporter.py
+++ b/luxonis_ml/data/exporters/native_exporter.py
@@ -155,40 +155,44 @@ class NativeExporter(BaseExporter):
         because the task fields do not describe it.
         """
         for record in records:
-            keypoints = record.get("annotation", {}).get("keypoints")
-            if keypoints is None:
-                continue
-            task_name = record["task_name"]
-            task_keypoints = self.keypoint_metadata.get(task_name)
-            if task_keypoints is None:
-                continue
-            values = keypoints["keypoints"]
-            if len(values) < len(task_keypoints.labels):
-                # A task can hold records with fewer keypoints. The task
-                # fields describe the full set, so such a record must not
-                # carry them. The import checks each record on its own.
-                continue
-            # Keyed on the partition as well: rolling over starts a fresh
-            # `annotations.json`, which has to carry the fields again.
-            key = (self.part, split, task_name)
-            if key in self._metadata_attached:
-                continue
-            self._metadata_attached.add(key)
-            keypoints.update(
-                {
-                    field: value
-                    for field, value in task_keypoints.model_dump(
-                        exclude={"labels"}
-                    ).items()
-                    if value
-                }
-            )
-            # The names are the keys of the payload, so this one record
-            # carries them as a mapping instead of a positional list.
-            if len(task_keypoints.labels) == len(values):
-                keypoints["keypoints"] = dict(
-                    zip(task_keypoints.labels, values, strict=True)
-                )
+            for task_name, detections in record.get("annotation", {}).items():
+                task_keypoints = self.keypoint_metadata.get(task_name)
+                if task_keypoints is None:
+                    continue
+                for detection in detections:
+                    keypoints = detection.get("keypoints")
+                    if keypoints is None:
+                        continue
+                    values = keypoints["keypoints"]
+                    if len(values) < len(task_keypoints.labels):
+                        # A task can hold records with fewer keypoints. The
+                        # task fields describe the full set, so such a record
+                        # must not carry them. The import checks each record
+                        # on its own.
+                        continue
+                    # Keyed on the partition as well: rolling over starts a
+                    # fresh `annotations.json`, which has to carry the fields
+                    # again.
+                    key = (self.part, split, task_name)
+                    if key in self._metadata_attached:
+                        continue
+                    self._metadata_attached.add(key)
+                    keypoints.update(
+                        {
+                            field: value
+                            for field, value in task_keypoints.model_dump(
+                                exclude={"labels"}
+                            ).items()
+                            if value
+                        }
+                    )
+                    # The names are the keys of the payload, so this one
+                    # record carries them as a mapping instead of a
+                    # positional list.
+                    if len(task_keypoints.labels) == len(values):
+                        keypoints["keypoints"] = dict(
+                            zip(task_keypoints.labels, values, strict=True)
+                        )
 
     def _maybe_roll_partition(
         self,
@@ -230,17 +234,17 @@ class NativeExporter(BaseExporter):
 
         multi_source = len(source_to_file) > 1
         record: dict[str, Any] = {
-            ("files" if multi_source else "file"): (
+            "media": (
                 source_to_file
                 if multi_source
                 else source_to_file[group_source_names[0]]
             ),
-            "task_name": task_name,
             "sample_metadata": DatasetRecord.decode_metadata(
                 row.get("sample_metadata")
             ),
         }
 
+        detections: list[dict[str, Any]] = []
         if ann_str is not None:
             data = json.loads(ann_str)
             ann: dict[str, Any] = {
@@ -256,7 +260,10 @@ class NativeExporter(BaseExporter):
                 ann[task_type] = data
             elif task_type.startswith("metadata/"):
                 ann["metadata"] = {task_type[9:]: data}
-            record["annotation"] = ann
+            detections.append(ann)
+        # An empty list still names the task, so a sample that is a negative
+        # for it says so.
+        record["annotation"] = {task_name: detections}
 
         return record
 

--- a/luxonis_ml/data/exporters/segmentation_mask_directory_exporter.py
+++ b/luxonis_ml/data/exporters/segmentation_mask_directory_exporter.py
@@ -117,13 +117,13 @@ class SegmentationMaskDirectoryExporter(BaseExporter):
             # Ensure background exists for this split up-front
             self._ensure_background(split)
 
-            # Only semantic segmentation rows for the entire image (instance_id == -1)
+            # Only semantic segmentation, which describes the whole image.
+            # An instance mask is a different task type, so the instance
+            # number says nothing here. Every detection carries one.
             seg_rows = [
                 row
                 for row in entry.iter_rows(named=True)
-                if row["task_type"] == "segmentation"
-                and row["instance_id"] == -1
-                and row["annotation"]
+                if row["task_type"] == "segmentation" and row["annotation"]
             ]
             if not seg_rows:
                 continue

--- a/luxonis_ml/data/loaders/__init__.py
+++ b/luxonis_ml/data/loaders/__init__.py
@@ -180,6 +180,18 @@ as it describes the returned arrays rather than the dataset record:
 Both keys are reserved. A record defining one of them keeps its own value,
 and the loader warns rather than overwriting it.
 
+A third reserved key, ``"schema"``, holds the dataset's `DatasetSchema`: its
+tasks, class IDs, keypoint metadata, keypoint counts, and categorical
+encodings. It is what makes a sample self-describing, so the arrays can be
+turned back into a record:
+
+.. python::
+
+    record = loader[0].to_ldf()
+
+The rebuilt record holds its images in memory. It can be rendered and
+inspected, but a dataset cannot store it until they are written to files.
+
 When a batch augmentation combines several samples, metadata from the input
 samples is preserved in ``"batch_augmentation_metadata"``:
 

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -32,6 +32,7 @@ from luxonis_ml.data.utils import (
 )
 from luxonis_ml.ldf import (
     SCHEMA_METADATA_KEY,
+    Annotation,
     DatasetRecord,
     DatasetSchema,
     Detection,
@@ -248,6 +249,14 @@ class LuxonisLoader(BaseLoader):
 
         self._df = self.dataset._load_df_offline(raise_when_empty=True)
         self._classes = self.dataset.get_classes()
+        # The names as the dataset declared them, taken before this loader
+        # adds a `background` class to the tasks it fills. Rebuilding a
+        # record drops only the background this loader made up; one the
+        # dataset declares was annotated, so it is data and it stays.
+        self._declared_classes = {
+            task_name: set(classes)
+            for task_name, classes in self._classes.items()
+        }
 
         # Cached because both are read for every loaded sample.
         self._keypoint_metadata = self.dataset.get_keypoint_metadata()
@@ -263,11 +272,28 @@ class LuxonisLoader(BaseLoader):
                     f"`filter_task_names` contains task names that "
                     f"are not in the dataset: {extras}"
                 )
+            # A row with no annotation belongs to one of two kinds, and only
+            # the first may survive a filter on its own. A record with no
+            # annotation at all is a negative for every task. A secondary
+            # source of an annotated record also writes such a row, and that
+            # one belongs to whichever task the record's annotated rows name.
+            group_is_annotated = (
+                pl.col("annotation").is_not_null().any().over("group_id")
+            )
+            group_is_asked_for = (
+                (
+                    pl.col("task_name").is_in(self._filter_task_names)
+                    & pl.col("annotation").is_not_null()
+                )
+                .any()
+                .over("group_id")
+            )
             self._df = self._df.filter(
                 pl.col("task_name").is_in(self._filter_task_names)
-                # A record with no annotation is a negative for every task,
-                # so its row must survive whichever task is asked for.
-                | pl.col("annotation").is_null()
+                | (
+                    pl.col("annotation").is_null()
+                    & (group_is_asked_for | ~group_is_annotated)
+                )
             )
             self._classes = {
                 task_name: self._classes[task_name]
@@ -494,7 +520,19 @@ class LuxonisLoader(BaseLoader):
             else:
                 img_dict[source_name] = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
-        detections_by_task: dict[str, list[Detection]] = defaultdict(list)
+        # The dataframe holds one row per task type of an instance, so the
+        # rows of one instance are put back together here. A detection then
+        # carries its own class, geometry and metadata, which is the shape
+        # every other producer of a record builds, and the shape the
+        # conversion needs to pair the two by row.
+        instance_order: dict[str, list[tuple[str, int]]] = defaultdict(list)
+        fields_by_instance: dict[
+            tuple[str, int], dict[str, Annotation | str | int | None]
+        ] = {}
+        metadata_by_instance: dict[
+            tuple[str, int], dict[str, int | float | str]
+        ] = defaultdict(dict)
+        rows_seen: dict[tuple[str, str], int] = defaultdict(int)
 
         for annotation_data in ann_rows:
             task_name: str = annotation_data[col["task_name"]]
@@ -512,14 +550,25 @@ class LuxonisLoader(BaseLoader):
             if task_type == "array" and self.dataset.is_remote:
                 data["path"] = self.dataset._arrays_path / data["path"]
 
-            # The task type names the field to fill, so the detection is
-            # validated from a dictionary rather than constructed.
-            fields: dict[str, object] = {
-                "class_name": class_name,
-                "instance_id": instance_id,
-            }
+            # A row that carries no instance ID belongs to the instance at
+            # its own position among the rows of the same task type.
+            position = rows_seen[task_name, task_type]
+            rows_seen[task_name, task_type] = position + 1
+            key = (task_name, instance_id if instance_id >= 0 else position)
+
+            fields = fields_by_instance.get(key)
+            if fields is None:
+                fields = {
+                    "class_name": class_name,
+                    "instance_id": instance_id,
+                }
+                fields_by_instance[key] = fields
+                instance_order[task_name].append(key)
+            elif fields["class_name"] is None:
+                fields["class_name"] = class_name
+
             if task_type.startswith("metadata/"):
-                fields["metadata"] = {task_type[len("metadata/") :]: data}
+                metadata_by_instance[key][task_type[len("metadata/") :]] = data
             elif task_type != "classification":
                 if (
                     "points" in data and "width" not in data
@@ -530,6 +579,8 @@ class LuxonisLoader(BaseLoader):
                     data["height"] = sample_img.shape[0]
                     data["points"] = [tuple(p) for p in data["points"]]
 
+                # The task type names the field to fill, so the detection is
+                # validated from a dictionary rather than constructed.
                 task_keypoints = self._keypoint_metadata.get(task_name)
                 fields[task_type] = load_annotation(
                     task_type,  # type: ignore[arg-type]
@@ -539,9 +590,18 @@ class LuxonisLoader(BaseLoader):
                     ),
                 )
 
-            detections_by_task[task_name].append(
-                Detection.model_validate(fields)
-            )
+        detections_by_task: dict[str, list[Detection]] = {
+            task_name: [
+                Detection.model_validate(
+                    {
+                        **fields_by_instance[key],
+                        "metadata": metadata_by_instance[key],
+                    }
+                )
+                for key in keys
+            ]
+            for task_name, keys in instance_order.items()
+        }
 
         # The rows are already normalized, so validating the record again
         # would repeat that work, and its file checks, for every sample.
@@ -611,6 +671,22 @@ class LuxonisLoader(BaseLoader):
             sample_metadata_list.append(sample_metadata)
 
         img_dict, labels = self._augmentations.apply(loaded_anns)
+
+        # The engine drops a label that has no rows, and puts back only the
+        # ones grouped with a bounding box. A task whose group has none, such
+        # as a keypoints-only task, would lose its key on a negative sample,
+        # and the augmented path would then disagree with the plain one.
+        image_shape = next(iter(img_dict.values())).shape[:2]
+        for key, array in loaded_anns[0][1].items():
+            if key in labels:
+                continue
+            # Only an empty label is ever dropped, so the row count is zero.
+            # A mask carries the image shape, which augmentation changed.
+            shape = (
+                (0, *image_shape) if array.ndim == 3 else (0, *array.shape[1:])
+            )
+            labels[key] = np.zeros(shape, dtype=array.dtype)
+
         metadata_indices = self._augmentations.batch_augmentation_indices
         if len(metadata_indices) > 1:
             sample_metadata = self._merge_sample_metadata(
@@ -827,10 +903,17 @@ class LuxonisLoader(BaseLoader):
             if self._filter_task_names is None
             or task_name in self._filter_task_names
         }
+        synthesized_background = {
+            task_name
+            for task_name, classes in self._classes.items()
+            if "background" in classes
+            and "background" not in self._declared_classes.get(task_name, ())
+        }
         return DatasetSchema(
             tasks=tasks,
             classes=self._classes,
             keypoint_metadata=self._keypoint_metadata,
             categorical_encodings=self.dataset.get_categorical_encodings(),
             n_keypoints=self._n_keypoints,
+            synthesized_background=synthesized_background,
         )

--- a/luxonis_ml/data/loaders/luxonis_loader.py
+++ b/luxonis_ml/data/loaders/luxonis_loader.py
@@ -20,21 +20,23 @@ from luxonis_ml.data.augmentations import (
     AugmentationEngine,
 )
 from luxonis_ml.data.datasets import (
-    Annotation,
-    Category,
     LuxonisDataset,
     UpdateMode,
     load_annotation,
 )
 from luxonis_ml.data.loaders.base_loader import BaseLoader
 from luxonis_ml.data.utils import (
-    get_task_name,
+    get_task_group,
     get_task_type,
-    split_task,
     task_type_iterator,
 )
-from luxonis_ml.data.utils.task_utils import task_is_metadata
-from luxonis_ml.ldf import DatasetRecord, KeypointMetadata
+from luxonis_ml.ldf import (
+    SCHEMA_METADATA_KEY,
+    DatasetRecord,
+    DatasetSchema,
+    Detection,
+    KeypointMetadata,
+)
 from luxonis_ml.typing import (
     Labels,
     LoaderOutput,
@@ -74,6 +76,17 @@ class LuxonisLoader(BaseLoader):
     mapping from configured transformation paths to the runtime parameters
     that were selected. Both are reserved keys that never overwrite metadata
     stored on the record.
+
+    Every sample also carries the dataset's `DatasetSchema` under
+    ``"schema"``, which is what lets `LoaderOutput.to_ldf` turn the arrays
+    back into a `DatasetRecord`:
+
+    .. python::
+
+        record = loader[0].to_ldf()
+
+    All samples of one loader share that one schema object, so reading it is
+    free and writing to it would affect every sample.
 
     Label keys use ``"task_name/task_type"``. If a dataset was created
     without a task name, the default task name is empty and keys look like
@@ -252,6 +265,9 @@ class LuxonisLoader(BaseLoader):
                 )
             self._df = self._df.filter(
                 pl.col("task_name").is_in(self._filter_task_names)
+                # A record with no annotation is a negative for every task,
+                # so its row must survive whichever task is asked for.
+                | pl.col("annotation").is_null()
             )
             self._classes = {
                 task_name: self._classes[task_name]
@@ -293,10 +309,15 @@ class LuxonisLoader(BaseLoader):
         self._tasks_without_background = set()
 
         self._idx_to_img_paths = self._precompute_image_paths()
+        self._schema = self._build_schema()
 
-        _, test_labels, _ = self._load_data(0)
+        # Only real annotations may decide that a task needs a background
+        # class. An empty label has no assigned pixel by construction, so
+        # including one would add the class to any dataset whose first
+        # sample happens to carry no annotation.
+        _, test_labels, _ = self._load_data(0, include_empty=False)
         for task, seg_masks in task_type_iterator(test_labels, "segmentation"):
-            task_name = get_task_name(task)
+            task_name = get_task_group(task)
             if seg_masks.shape[0] > 1 and (
                 "background" not in self._classes[task_name]
                 or self._classes[task_name]["background"] != 0
@@ -321,6 +342,10 @@ class LuxonisLoader(BaseLoader):
                                 ].items()
                             },
                         }
+
+        # The background class shifts the class IDs, so the schema is built
+        # again once they have settled.
+        self._schema = self._build_schema()
 
         self._augmentations = self._init_augmentations(
             augmentation_engine,
@@ -388,9 +413,6 @@ class LuxonisLoader(BaseLoader):
         else:
             img_dict, labels, metadata = self._load_with_augmentations(idx)
 
-        if not self._exclude_empty_annotations:
-            img_dict, labels = self._add_empty_annotations(img_dict, labels)
-
         # Albumentations needs RGB
         bgr_sources = [k for k, v in self._color_space.items() if v == "BGR"]
         for source_name in bgr_sources:
@@ -399,56 +421,23 @@ class LuxonisLoader(BaseLoader):
             )
         return LoaderOutput(img_dict, labels, metadata)
 
-    def _add_empty_annotations(
-        self, img_dict: dict[str, np.ndarray], labels: Labels
-    ) -> tuple[dict[str, np.ndarray], Labels]:
-        image_height, image_width = next(iter(img_dict.values())).shape[:2]
-        for task_name, task_types in self.dataset.get_tasks().items():
-            if (
-                self._filter_task_names is not None
-                and task_name not in self._filter_task_names
-            ):
-                continue
-            for task_type in task_types:
-                task = f"{task_name}/{task_type}"
-                if task not in labels:
-                    if task_type == "boundingbox":
-                        labels[task] = np.zeros((0, 5))
-                    elif task_type == "keypoints":
-                        # A keypoint task can lack metadata entirely.
-                        n_keypoints = self._n_keypoints.get(task_name, 0)
-                        labels[task] = np.zeros((0, n_keypoints * 3))
-                    elif task_type == "instance_segmentation":
-                        labels[task] = np.zeros((0, image_height, image_width))
-                    elif task_type == "segmentation":
-                        labels[task] = np.zeros(
-                            (
-                                len(self._classes[task_name]),
-                                image_height,
-                                image_width,
-                            )
-                        )
-                    elif task_type == "classification" or task_is_metadata(
-                        task
-                    ):
-                        labels[task] = np.zeros(
-                            (len(self._classes[task_name]),)
-                        )
-
-        return img_dict, labels
-
     def _load_data(
-        self, idx: int
+        self, idx: int, *, include_empty: bool | None = None
     ) -> tuple[dict[str, np.ndarray], Labels, Params]:
         """Load image data and annotations by index.
 
         Args:
             idx: Index of the image.
+            include_empty: Whether every task of the dataset gets a label,
+                even when this sample has no annotation for it. Defaults to
+                the loader's ``exclude_empty_annotations`` setting.
 
         Returns:
             Images, labels, and sample metadata present for the sample.
 
         """
+        if include_empty is None:
+            include_empty = not self._exclude_empty_annotations
         if not self._idx_to_df_row:
             raise ValueError(
                 f"No data found in dataset '{self.dataset.identifier}' "
@@ -461,9 +450,11 @@ class LuxonisLoader(BaseLoader):
 
         sample_metadata: Params = {}
         metadata_idx = col.get("sample_metadata")
-        for row in ann_rows:
+        if ann_rows and metadata_idx is not None:
+            # Every row of a group repeats the metadata of the record it came
+            # from, so the last one decides, as it always has.
             sample_metadata = DatasetRecord.decode_metadata(
-                row[metadata_idx] if metadata_idx is not None else None
+                ann_rows[-1][metadata_idx]
             )
 
         source_to_path = self._idx_to_img_paths[idx]
@@ -503,12 +494,7 @@ class LuxonisLoader(BaseLoader):
             else:
                 img_dict[source_name] = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
-        labels_by_task: dict[str, list[Annotation]] = defaultdict(list)
-        class_ids_by_task: dict[str, list[int]] = defaultdict(list)
-        instance_ids_by_task: dict[str, list[int]] = defaultdict(list)
-        metadata_by_task: dict[str, list[str | int | float | Category]] = (
-            defaultdict(list)
-        )
+        detections_by_task: dict[str, list[Detection]] = defaultdict(list)
 
         for annotation_data in ann_rows:
             task_name: str = annotation_data[col["task_name"]]
@@ -526,65 +512,68 @@ class LuxonisLoader(BaseLoader):
             if task_type == "array" and self.dataset.is_remote:
                 data["path"] = self.dataset._arrays_path / data["path"]
 
+            # The task type names the field to fill, so the detection is
+            # validated from a dictionary rather than constructed.
+            fields: dict[str, object] = {
+                "class_name": class_name,
+                "instance_id": instance_id,
+            }
             if task_type.startswith("metadata/"):
-                metadata_by_task[full_task_name].append(data)
-            else:  # pragma: no cover
-                # Conversion from LDF v1.0
-                if "points" in data and "width" not in data:
+                fields["metadata"] = {task_type[len("metadata/") :]: data}
+            elif task_type != "classification":
+                if (
+                    "points" in data and "width" not in data
+                ):  # pragma: no cover
+                    # Conversion from LDF v1.0
                     sample_img = next(iter(img_dict.values()))
                     data["width"] = sample_img.shape[1]
                     data["height"] = sample_img.shape[0]
                     data["points"] = [tuple(p) for p in data["points"]]
 
                 task_keypoints = self._keypoint_metadata.get(task_name)
-                annotation = load_annotation(
+                fields[task_type] = load_annotation(
                     task_type,  # type: ignore[arg-type]
                     data,
                     keypoint_labels=(
                         task_keypoints.labels if task_keypoints else None
                     ),
                 )
-                labels_by_task[full_task_name].append(annotation)
-                if class_name is not None:
-                    class_ids_by_task[full_task_name].append(
-                        self._classes[task_name][class_name]
-                    )
-                else:
-                    class_ids_by_task[full_task_name].append(0)
-                instance_ids_by_task[full_task_name].append(instance_id)
 
-        labels: Labels = {}
-        encodings = self.dataset.get_categorical_encodings()
-        for task, metadata in metadata_by_task.items():
-            if not self._keep_categorical_as_strings and task in encodings:
-                metadata = [encodings[task][m] for m in metadata]  # type: ignore
-            labels[task] = np.array(metadata)
-
-        for task, anns in labels_by_task.items():
-            assert anns, f"No annotations found for task {task_name}"
-            instance_ids = instance_ids_by_task[task]
-
-            anns = [
-                ann
-                for _, ann in sorted(
-                    zip(instance_ids, anns, strict=True), key=lambda x: x[0]
-                )
-            ]
-
-            task_name, task_type = split_task(task)
-            array = anns[0].combine_to_numpy(
-                anns,
-                class_ids_by_task[task],
-                len(self._classes[task_name]),
+            detections_by_task[task_name].append(
+                Detection.model_validate(fields)
             )
-            if task in self._tasks_without_background:
-                unassigned_pixels = ~np.any(array, axis=0)
-                background_idx = self._classes[task_name]["background"]
-                array[background_idx, unassigned_pixels] = 1
 
-            labels[task] = array
+        # The rows are already normalized, so validating the record again
+        # would repeat that work, and its file checks, for every sample.
+        record = DatasetRecord.model_construct(
+            files=source_to_path,
+            annotation=dict(detections_by_task),
+            sample_metadata=sample_metadata,
+        )
+        output = record.to_loader_output(
+            self._schema,
+            images=img_dict,
+            keep_categorical_as_strings=self._keep_categorical_as_strings,
+            include_empty=include_empty,
+        )
 
-        return img_dict, labels, sample_metadata
+        # Only a mask this sample really carries gets its unassigned pixels
+        # filled. A sample with no mask at all keeps an empty label, as it
+        # always has.
+        annotated = {
+            f"{task_name}/segmentation"
+            for task_name, detections in detections_by_task.items()
+            if any(
+                detection.segmentation is not None for detection in detections
+            )
+        }
+        for task in self._tasks_without_background & annotated:
+            array = output.labels[task]
+            unassigned_pixels = ~np.any(array, axis=0)
+            background_idx = self._classes[get_task_group(task)]["background"]
+            array[background_idx, unassigned_pixels] = 1
+
+        return output.images, output.labels, output.metadata
 
     def _load_with_augmentations(
         self, idx: int
@@ -686,7 +675,21 @@ class LuxonisLoader(BaseLoader):
         if input_indices is None:
             input_indices = list(range(len(metadata_batch)))
 
+        # The schema is the same object for every sample of a dataset, so it
+        # is carried over rather than copied. Copying it costs 45 times as
+        # much as copying the metadata it sits in.
+        schema = metadata_batch[0].get(SCHEMA_METADATA_KEY)
+        metadata_batch = [
+            {
+                key: value
+                for key, value in sample.items()
+                if key != SCHEMA_METADATA_KEY
+            }
+            for sample in metadata_batch
+        ]
         metadata = deepcopy(metadata_batch[0])
+        if schema is not None:
+            metadata[SCHEMA_METADATA_KEY] = schema
 
         metadata["batch_augmentation_metadata"] = [  # type: ignore
             {
@@ -810,3 +813,24 @@ class LuxonisLoader(BaseLoader):
             idx_to_img_paths[idx] = dict(sorted(source_to_path.items()))
 
         return idx_to_img_paths
+
+    def _build_schema(self) -> DatasetSchema:
+        """Describe the dataset for the conversion and for the consumer.
+
+        The schema travels with every sample, so a consumer can read class
+        names off the arrays without reaching for the dataset. Build it again
+        whenever the class IDs change.
+        """
+        tasks = {
+            task_name: task_types
+            for task_name, task_types in self.dataset.get_tasks().items()
+            if self._filter_task_names is None
+            or task_name in self._filter_task_names
+        }
+        return DatasetSchema(
+            tasks=tasks,
+            classes=self._classes,
+            keypoint_metadata=self._keypoint_metadata,
+            categorical_encodings=self.dataset.get_categorical_encodings(),
+            n_keypoints=self._n_keypoints,
+        )

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -2,7 +2,7 @@ import inspect
 import random
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -488,21 +488,26 @@ class BaseParser(ABC):
             Unique added image paths.
 
         """
-        return list(
-            {
-                Path(v)
-                for item in generator
-                for v in (
-                    [item["file"]]
-                    if isinstance(item, dict) and "file" in item
-                    else item["files"].values()
-                    if isinstance(item, dict) and "files" in item
-                    else [item.file]
-                    if isinstance(item, DatasetRecord)
-                    else []
-                )
-            }
-        )
+        paths: set[Path] = set()
+        for item in generator:
+            if isinstance(item, DatasetRecord):
+                paths.update(Path(file) for file in item.file_paths.values())
+                continue
+            media = next(
+                (
+                    item[key]
+                    for key in ("media", "file", "files")
+                    if key in item
+                ),
+                None,
+            )
+            if media is None:
+                continue
+            if isinstance(media, Mapping):
+                paths.update(Path(file) for file in media.values())
+            else:
+                paths.add(Path(media))
+        return list(paths)
 
     def _warn_skipped_annotation(
         self,

--- a/luxonis_ml/data/parsers/base_parser.py
+++ b/luxonis_ml/data/parsers/base_parser.py
@@ -12,7 +12,7 @@ from loguru import logger
 from luxonis_ml.data import BaseDataset, DatasetIterator
 from luxonis_ml.data.utils.enums import ParserIssue, ParserIssueMessage
 from luxonis_ml.enums.enums import DatasetType
-from luxonis_ml.ldf import DatasetRecord
+from luxonis_ml.ldf import DatasetRecord, Detection
 from luxonis_ml.typing import PathType
 
 if TYPE_CHECKING:
@@ -652,23 +652,33 @@ class BaseParser(ABC):
             if isinstance(item, dict):
                 item = DatasetRecord(**item)
 
-            if self._task_name is not None:
-                if item.annotation is None:
-                    for task_name in set(self._task_name.values()):
-                        yield item.model_copy(
-                            update={"task_name": task_name}, deep=True
-                        )
-                else:
-                    class_name = item.annotation.class_name
-                    if class_name is not None:
-                        try:
-                            task_name = self._task_name[class_name]
-                        except KeyError:
-                            raise ValueError(
-                                f"Class '{class_name}' not found in task names."
-                            ) from None
-
-                        item.task_name = self._task_name[class_name]
-                    yield item
-            else:
+            if self._task_name is None:
                 yield item
+                continue
+
+            if not any(item.annotation.values()):
+                for task_name in set(self._task_name.values()):
+                    yield item.model_copy(
+                        update={"annotation": {task_name: []}}, deep=True
+                    )
+                continue
+
+            grouped: dict[str, list[Detection]] = defaultdict(list)
+            for task_name, detections in item.annotation.items():
+                for detection in detections:
+                    class_name = detection.class_name
+                    # A detection with no class has nothing to resolve, so
+                    # it stays under the task it came with.
+                    if class_name is None:
+                        grouped[task_name].append(detection)
+                        continue
+                    try:
+                        resolved = self._task_name[class_name]
+                    except KeyError:
+                        raise ValueError(
+                            f"Class '{class_name}' not found in task names."
+                        ) from None
+                    grouped[resolved].append(detection)
+
+            item.annotation = dict(grouped)
+            yield item

--- a/luxonis_ml/data/parsers/classification_directory_parser.py
+++ b/luxonis_ml/data/parsers/classification_directory_parser.py
@@ -96,7 +96,7 @@ class ClassificationDirectoryParser(BaseParser):
             for class_name in class_names:
                 for img_path in self._list_images(class_dir / class_name):
                     yield {
-                        "file": str(img_path.absolute().resolve()),
+                        "media": str(img_path.absolute().resolve()),
                         "annotation": {"class": class_name},
                     }
 

--- a/luxonis_ml/data/parsers/coco_parser.py
+++ b/luxonis_ml/data/parsers/coco_parser.py
@@ -333,7 +333,7 @@ class COCOParser(BaseParser):
                         # Keypoint annotations: skip images with no labels
                         continue
                     # Register image with no annotations (valid COCO case)
-                    yield {"file": file, "annotation": None}
+                    yield {"media": file, "annotation": None}
                     continue
 
                 for ann in img_anns:
@@ -395,7 +395,7 @@ class COCOParser(BaseParser):
                         next_fallback_id += 1
 
                     record = {
-                        "file": file,
+                        "media": file,
                         "annotation": {
                             "class": class_name,
                             "instance_id": instance_id,

--- a/luxonis_ml/data/parsers/create_ml_parser.py
+++ b/luxonis_ml/data/parsers/create_ml_parser.py
@@ -121,7 +121,7 @@ class CreateMLParser(BaseParser):
                 path = curr_annotations["path"]
                 for bbox_class, (x, y, w, h) in curr_annotations["bboxes"]:
                     yield {
-                        "file": path,
+                        "media": path,
                         "annotation": {
                             "class": bbox_class,
                             "boundingbox": {

--- a/luxonis_ml/data/parsers/darknet_parser.py
+++ b/luxonis_ml/data/parsers/darknet_parser.py
@@ -83,7 +83,7 @@ class DarknetParser(BaseParser):
                     annotation_data = []
 
                 if not annotation_data:
-                    yield {"file": file, "annotation": None}
+                    yield {"media": file, "annotation": None}
                     continue
 
                 for ann_line in annotation_data:
@@ -93,7 +93,7 @@ class DarknetParser(BaseParser):
                     class_name = class_names[int(class_id)]
 
                     yield {
-                        "file": file,
+                        "media": file,
                         "annotation": {
                             "class": class_name,
                             "boundingbox": {

--- a/luxonis_ml/data/parsers/fiftyone_classification_parser.py
+++ b/luxonis_ml/data/parsers/fiftyone_classification_parser.py
@@ -134,7 +134,7 @@ class FiftyOneClassificationParser(BaseParser):
                 class_name = classes[class_idx]
 
                 yield {
-                    "file": img_path,
+                    "media": img_path,
                     "annotation": {"class": class_name},
                 }
 

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -118,16 +118,14 @@ class NativeParser(BaseParser):
         def generator() -> DatasetIterator:
             for record in data:
                 with suppress(KeyError):
-                    if "file" in record:
-                        record["file"] = resolve_manifest_path(
-                            annotation_path.parent, record["file"]
-                        )
-                    elif "files" in record:
-                        for key, value in record["files"].items():
-                            if isinstance(value, PathType):
-                                record["files"][key] = resolve_manifest_path(
-                                    annotation_path.parent, value
-                                )
+                    # An older manifest names the media with the keys a
+                    # record now accepts only as deprecated ones.
+                    for key in ("media", "file", "files"):
+                        if key in record:
+                            record["media"] = _resolve_media(
+                                record.pop(key), annotation_path.parent
+                            )
+                            break
                 annotation = record.get("annotation")
                 for detection in (
                     annotation
@@ -171,6 +169,23 @@ class NativeParser(BaseParser):
                 )
 
 
+def _resolve_media(media: object, base_dir: Path) -> object:
+    """Resolve one path, or a mapping of source names to paths.
+
+    Anything else is returned untouched, so the record model reports it.
+    """
+    if isinstance(media, dict):
+        return {
+            source: resolve_manifest_path(base_dir, path)
+            if isinstance(path, PathType)
+            else path
+            for source, path in media.items()
+        }
+    if isinstance(media, PathType):
+        return resolve_manifest_path(base_dir, media)
+    return media
+
+
 def _resolve_annotation_paths(
     annotation: dict[str, Any], base_dir: Path
 ) -> None:
@@ -185,6 +200,10 @@ def _resolve_annotation_paths(
         value = annotation.get(field)
         if isinstance(value, dict) and isinstance(value.get(key), PathType):
             value[key] = resolve_manifest_path(base_dir, value[key])
+            if field == "array":
+                # The manifest keeps the stored key, which the annotation
+                # now accepts only as a deprecated name.
+                value["data"] = value.pop(key)
     sub_detections = annotation.get("sub_detections")
     if isinstance(sub_detections, dict):
         for sub_detection in sub_detections.values():

--- a/luxonis_ml/data/parsers/native_parser.py
+++ b/luxonis_ml/data/parsers/native_parser.py
@@ -1,17 +1,27 @@
 import json
+from collections.abc import Iterator, Mapping
 from contextlib import suppress
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias
 
 from loguru import logger
 from semver.version import Version
 
 from luxonis_ml.data import DatasetIterator
 from luxonis_ml.data.utils.constants import LDF_VERSION
-from luxonis_ml.typing import PathType
+from luxonis_ml.typing import PathType, PrimitiveType
 from luxonis_ml.utils.path import resolve_manifest_path
 
 from .base_parser import BaseParser, ParserOutput
+
+ManifestValue: TypeAlias = (
+    dict[str, "ManifestValue"] | list["ManifestValue"] | Path | PrimitiveType
+)
+"""A value of a decoded ``annotations.json``.
+
+The parser rewrites the relative path of every companion file in place, so a
+`pathlib.Path` belongs here beside the values the JSON itself holds.
+"""
 
 # Annotation fields holding a path to a companion file, as ``(field, key)``.
 # These are written relative to ``annotations.json`` so a dataset directory
@@ -126,16 +136,10 @@ class NativeParser(BaseParser):
                                 record.pop(key), annotation_path.parent
                             )
                             break
-                annotation = record.get("annotation")
-                for detection in (
-                    annotation
-                    if isinstance(annotation, list)
-                    else [annotation]
-                ):
-                    if isinstance(detection, dict):
-                        _resolve_annotation_paths(
-                            detection, annotation_path.parent
-                        )
+                for detection in _walk_detections(record.get("annotation")):
+                    _resolve_annotation_paths(
+                        detection, annotation_path.parent
+                    )
                 yield record
 
         added_images = self._get_added_images(generator())
@@ -169,7 +173,7 @@ class NativeParser(BaseParser):
                 )
 
 
-def _resolve_media(media: object, base_dir: Path) -> object:
+def _resolve_media(media: ManifestValue, base_dir: Path) -> ManifestValue:
     """Resolve one path, or a mapping of source names to paths.
 
     Anything else is returned untouched, so the record model reports it.
@@ -209,3 +213,42 @@ def _resolve_annotation_paths(
         for sub_detection in sub_detections.values():
             if isinstance(sub_detection, dict):
                 _resolve_annotation_paths(sub_detection, base_dir)
+
+
+def _walk_detections(
+    annotation: ManifestValue,
+) -> Iterator[dict[str, ManifestValue]]:
+    """Yield every detection of a record's annotation payload.
+
+    A payload maps a task name to its detections. The flat forms, one
+    detection or a list of them, are deprecated but still appear in an
+    export written by an older version.
+
+    The task mapping is recognized the same way `DatasetRecord` recognizes
+    it, by every value being a list or a tuple. The two must agree, or a
+    payload the record accepts reaches this parser as something else.
+    """
+    if isinstance(annotation, Mapping):
+        grouped = [
+            detections
+            for detections in annotation.values()
+            if isinstance(detections, (list, tuple))
+        ]
+        if len(grouped) == len(annotation):
+            for detections in grouped:
+                yield from (
+                    detection
+                    for detection in detections
+                    if isinstance(detection, dict)
+                )
+            return
+        # The caller rewrites the paths in place, so the detection itself
+        # is yielded, never a copy of it.
+        if isinstance(annotation, dict):
+            yield annotation
+    elif isinstance(annotation, (list, tuple)):
+        yield from (
+            detection
+            for detection in annotation
+            if isinstance(detection, dict)
+        )

--- a/luxonis_ml/data/parsers/segmentation_mask_directory_parser.py
+++ b/luxonis_ml/data/parsers/segmentation_mask_directory_parser.py
@@ -104,7 +104,7 @@ class SegmentationMaskDirectoryParser(BaseParser):
                     curr_seg_mask = np.zeros_like(mask)
                     curr_seg_mask[mask == id] = 1
                     yield {
-                        "file": file,
+                        "media": file,
                         "annotation": {
                             "class": class_name,
                             "segmentation": {"mask": curr_seg_mask},

--- a/luxonis_ml/data/parsers/solo_parser.py
+++ b/luxonis_ml/data/parsers/solo_parser.py
@@ -208,7 +208,7 @@ class SOLOParser(BaseParser):
                                         mask_int == target_int
                                     ).astype(np.uint8)
                                     yield {
-                                        "file": img_path,
+                                        "media": img_path,
                                         "annotation": {
                                             "class": class_name,
                                             "segmentation": {
@@ -240,7 +240,7 @@ class SOLOParser(BaseParser):
 
                                     instance_id = bbox_annotation["instanceId"]
                                     bounding_boxes[instance_id] = {
-                                        "file": img_path,
+                                        "media": img_path,
                                         "annotation": {
                                             "class": class_name,
                                             "instance_id": instance_id,
@@ -295,7 +295,7 @@ class SOLOParser(BaseParser):
                                     instance_id = instance["instanceId"]
 
                                     instance_segmentations[instance_id] = {
-                                        "file": img_path,
+                                        "media": img_path,
                                         "annotation": {
                                             "instance_id": instance_id,
                                             "instance_segmentation": {
@@ -336,7 +336,7 @@ class SOLOParser(BaseParser):
                                     ]
 
                                     instance_keypoints[instance_id] = {
-                                        "file": img_path,
+                                        "media": img_path,
                                         "annotation": {
                                             "instance_id": instance_id,
                                             "keypoints": {
@@ -389,7 +389,7 @@ class SOLOParser(BaseParser):
                                 )
 
                             yield {
-                                "file": img_path,
+                                "media": img_path,
                                 "annotation": annotation_entry,
                             }
 

--- a/luxonis_ml/data/parsers/tensorflow_csv_parser.py
+++ b/luxonis_ml/data/parsers/tensorflow_csv_parser.py
@@ -108,11 +108,11 @@ class TensorflowCSVParser(BaseParser):
                 path = str(img_path.resolve())
                 curr_annotations = images_annotations.get(path, {"bboxes": []})
                 if not curr_annotations["bboxes"]:
-                    yield {"file": path, "annotation": None}
+                    yield {"media": path, "annotation": None}
                     continue
                 for bbox_class, (x, y, w, h) in curr_annotations["bboxes"]:
                     yield {
-                        "file": path,
+                        "media": path,
                         "annotation": {
                             "class": bbox_class,
                             "boundingbox": {

--- a/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
+++ b/luxonis_ml/data/parsers/ultralytics_ndjson_parser.py
@@ -308,7 +308,7 @@ class UltralyticsNDJSONParser(BaseParser):
                         class_id, x_center, y_center, width, height = box
                         yielded_annotation = True
                         yield {
-                            "file": str(image_path),
+                            "media": str(image_path),
                             "annotation": {
                                 "class": class_names[int(class_id)],
                                 "instance_id": instance_id,
@@ -329,7 +329,7 @@ class UltralyticsNDJSONParser(BaseParser):
                         )
                         yielded_annotation = True
                         yield {
-                            "file": str(image_path),
+                            "media": str(image_path),
                             "annotation": {
                                 "class": class_names[int(class_id)],
                                 "instance_id": instance_id,
@@ -383,7 +383,7 @@ class UltralyticsNDJSONParser(BaseParser):
 
                         yielded_annotation = True
                         yield {
-                            "file": str(image_path),
+                            "media": str(image_path),
                             "annotation": {
                                 "class": class_names[int(class_id)],
                                 "instance_id": instance_id,
@@ -404,7 +404,7 @@ class UltralyticsNDJSONParser(BaseParser):
                         instance_id += 1
 
                     if not yielded_annotation:
-                        yield {"file": str(image_path), "annotation": None}
+                        yield {"media": str(image_path), "annotation": None}
 
         return generator(), added_by_split, added_images
 

--- a/luxonis_ml/data/parsers/voc_parser.py
+++ b/luxonis_ml/data/parsers/voc_parser.py
@@ -127,11 +127,11 @@ class VOCParser(BaseParser):
             for curr_annotations in images_annotations:
                 path = str(curr_annotations["path"])
                 if not curr_annotations["bboxes"]:
-                    yield {"file": path, "annotation": None}
+                    yield {"media": path, "annotation": None}
                     continue
                 for bbox_class, bbox in curr_annotations["bboxes"]:
                     yield {
-                        "file": path,
+                        "media": path,
                         "annotation": {
                             "class": bbox_class,
                             "boundingbox": {

--- a/luxonis_ml/data/parsers/yolov4_parser.py
+++ b/luxonis_ml/data/parsers/yolov4_parser.py
@@ -110,7 +110,7 @@ class YoloV4Parser(BaseParser):
 
                 # Handle image names listed with no following annotation in the line
                 if len(data) == 1:
-                    yield {"file": file, "annotation": None}
+                    yield {"media": file, "annotation": None}
                     continue
 
                 img = Image.open(file)
@@ -122,7 +122,7 @@ class YoloV4Parser(BaseParser):
 
                     bbox_xyxy = [float(i) for i in curr_ann_data[:4]]
                     yield {
-                        "file": file,
+                        "media": file,
                         "annotation": {
                             "class": class_name,
                             "boundingbox": {
@@ -137,7 +137,7 @@ class YoloV4Parser(BaseParser):
             # Images in the directory not listed in annotations file
             for img_path in self._list_images(image_dir):
                 if img_path.resolve() not in annotated_images:
-                    yield {"file": str(img_path), "annotation": None}
+                    yield {"media": str(img_path), "annotation": None}
 
         added_images = self._get_added_images(generator())
 

--- a/luxonis_ml/data/parsers/yolov6_parser.py
+++ b/luxonis_ml/data/parsers/yolov6_parser.py
@@ -142,7 +142,7 @@ class YoloV6Parser(BaseParser):
                         annotation_data = f.readlines()
 
                 if not annotation_data:
-                    yield {"file": str(img_path), "annotation": None}
+                    yield {"media": str(img_path), "annotation": None}
                     continue
 
                 for ann_line in annotation_data:
@@ -152,7 +152,7 @@ class YoloV6Parser(BaseParser):
                     class_name = class_names[int(class_id)]
 
                     yield {
-                        "file": str(img_path),
+                        "media": str(img_path),
                         "annotation": {
                             "class": class_name,
                             "boundingbox": {

--- a/luxonis_ml/data/parsers/yolov8_parser.py
+++ b/luxonis_ml/data/parsers/yolov8_parser.py
@@ -354,7 +354,7 @@ class YOLOv8Parser(BaseParser):
 
                 # Handle missing annotations
                 if not annotation_data:
-                    yield {"file": str(img_path), "annotation": None}
+                    yield {"media": str(img_path), "annotation": None}
                     continue
 
                 for instance_id, ann_line in enumerate(annotation_data):
@@ -378,7 +378,7 @@ class YOLOv8Parser(BaseParser):
                         class_name = class_names[int(class_id)]
 
                         yield {
-                            "file": str(img_path),
+                            "media": str(img_path),
                             "annotation": {
                                 "class": class_name,
                                 "instance_id": instance_id,
@@ -407,7 +407,7 @@ class YOLOv8Parser(BaseParser):
                         class_name = class_names[int(class_id)]
 
                         yield {
-                            "file": str(img_path),
+                            "media": str(img_path),
                             "annotation": {
                                 "class": class_name,
                                 "instance_id": instance_id,
@@ -442,7 +442,7 @@ class YOLOv8Parser(BaseParser):
                         ]
 
                         yield {
-                            "file": str(img_path),
+                            "media": str(img_path),
                             "annotation": {
                                 "class": class_name,
                                 "instance_id": instance_id,

--- a/luxonis_ml/data/utils/__init__.py
+++ b/luxonis_ml/data/utils/__init__.py
@@ -10,9 +10,9 @@ the part of the data workflow they support:
    * - Group
      - Public APIs
    * - Task keys
-     - `task_is_metadata`, `split_task`, `get_task_name`, `get_task_type`,
-       and `task_type_iterator` parse and filter ``"task_name/task_type"``
-       labels.
+     - `task_is_metadata`, `split_task`, `get_task_name`, `get_task_group`,
+       `get_task_type`, and `task_type_iterator` parse and filter
+       ``"task_name/task_type"`` labels.
    * - Storage and parser enums
      - `BucketStorage`, `BucketType`, `MediaType`, `ImageType`,
        `UpdateMode`, `ParserIssue`, and `ParserIssueMessage`.
@@ -63,6 +63,7 @@ from .remote_file_downloader import (
     download_remote_file,
 )
 from .task_utils import (
+    get_task_group,
     get_task_name,
     get_task_type,
     split_task,
@@ -101,6 +102,7 @@ __all__ = [
     "get_duplicates_info",
     "get_heatmaps",
     "get_missing_annotations",
+    "get_task_group",
     "get_task_name",
     "get_task_type",
     "infer_task",

--- a/luxonis_ml/data/utils/constants.py
+++ b/luxonis_ml/data/utils/constants.py
@@ -3,5 +3,10 @@ from typing import Final
 from semver.version import Version
 
 LDF_VERSION: Final[Version] = Version.parse(
-    "2.2", optional_minor_and_patch=True
+    "3.0", optional_minor_and_patch=True
 )
+"""The LDF version this installation writes.
+
+LDF 3.0 groups a record's detections by task name, so one record can carry a
+whole sample. The parquet rows did not move, but the record contract did.
+"""

--- a/luxonis_ml/data/utils/ldf_equivalence.py
+++ b/luxonis_ml/data/utils/ldf_equivalence.py
@@ -390,10 +390,7 @@ class LDFEquivalence:
             hashed_key = (cls.file_sha256(Path(file_path)),)
             classes = []
             for row in entry.iter_rows(named=True):
-                if (
-                    row["task_type"] == "classification"
-                    and row["instance_id"] == -1
-                ):
+                if row["task_type"] == "classification":
                     classes.append(row["class_name"])
             if classes:
                 out.setdefault(hashed_key, Counter()).update(classes)
@@ -413,10 +410,7 @@ class LDFEquivalence:
             hashed_key = (cls.file_sha256(Path(file_path)),)
             classes = []
             for row in entry.iter_rows(named=True):
-                if (
-                    row["task_type"] == "segmentation"
-                    and row["instance_id"] == -1
-                ):
+                if row["task_type"] == "segmentation":
                     classes.append(row["class_name"])
             if classes:
                 out.setdefault(hashed_key, Counter()).update(classes)
@@ -437,10 +431,7 @@ class LDFEquivalence:
             img_hash = cls.file_sha256(Path(file_path))
 
             for row in entry.iter_rows(named=True):
-                if (
-                    row["task_type"] == "segmentation"
-                    and row["instance_id"] == -1
-                ):
+                if row["task_type"] == "segmentation":
                     d = json.loads(row["annotation"])
                     class_name = row["class_name"]
                     if isinstance(d.get("counts"), str):

--- a/luxonis_ml/data/utils/task_utils.py
+++ b/luxonis_ml/data/utils/task_utils.py
@@ -1,131 +1,24 @@
-from collections.abc import Iterator
-from functools import lru_cache
+"""Re-exports of the LDF task-key helpers.
 
-import numpy as np
+The task-key grammar belongs to the format itself, so the helpers live in
+`luxonis_ml.ldf.tasks`. This module keeps imports such as
+``from luxonis_ml.data.utils.task_utils import get_task_type`` working.
+"""
 
-from luxonis_ml.typing import Labels, TaskType
+from luxonis_ml.ldf.tasks import (
+    get_task_group,
+    get_task_name,
+    get_task_type,
+    split_task,
+    task_is_metadata,
+    task_type_iterator,
+)
 
-
-@lru_cache
-def task_is_metadata(task: str) -> bool:
-    """Check whether a task is a metadata task.
-
-    Args:
-        task: Task to check.
-
-    Returns:
-        Whether the task is a metadata task.
-
-    Examples:
-        >>> task_is_metadata("metadata/weather")
-        True
-        >>> task_is_metadata("camera/metadata/weather")
-        True
-        >>> task_is_metadata("camera/boundingbox")
-        False
-
-    """
-    return get_task_type(task).startswith("metadata/")
-
-
-@lru_cache
-def split_task(task: str) -> tuple[str, str]:
-    """Split a task into task name and task type.
-
-    Args:
-        task: Task to split.
-
-    Returns:
-        Task name and task type.
-
-    Examples:
-        >>> split_task("detector/boundingbox")
-        ('detector', 'boundingbox')
-        >>> split_task("classification")
-        ('', 'classification')
-
-    """
-    splits = task.split("/", 1)
-    if len(splits) == 1:
-        return "", splits[0]
-    return splits[0], splits[1]
-
-
-@lru_cache
-def get_task_name(task: str) -> str:
-    """Return the task name from a task string.
-
-    Args:
-        task: Task string.
-
-    Returns:
-        Task name.
-
-    Examples:
-        >>> get_task_name("detector/boundingbox")
-        'detector'
-        >>> get_task_name("classification")
-        'classification'
-
-    """
-    return task.split("/", maxsplit=1)[0]
-
-
-@lru_cache
-def get_task_type(task: str) -> str:
-    """Return the task type from a task string.
-
-    Example:
-        >>> get_task_type("task_name/type")
-        'type'
-        >>> get_task_type("metadata/name")
-        'metadata/name'
-        >>> get_task_type("task_name/metadata/name")
-        'metadata/name'
-
-    Args:
-        task: Task string, such as ``"task_name/type"``.
-
-    Returns:
-        Task type. Metadata tasks are returned as ``"metadata/type"``.
-
-    """
-    parts = task.split("/")
-    if len(parts) == 1:
-        return parts[0]
-    if len(parts) == 2:
-        if parts[0] == "metadata":
-            return task
-        return parts[1]
-    if parts[-2] == "metadata":
-        return f"metadata/{parts[-1]}"
-    return task.rsplit("/", maxsplit=1)[-1]
-
-
-def task_type_iterator(
-    labels: Labels, task_type: TaskType
-) -> Iterator[tuple[str, np.ndarray]]:
-    """Iterate over labels of a specific task type.
-
-    Args:
-        labels: Labels to iterate over.
-        task_type: Label type to yield.
-
-    Returns:
-        Iterator over matching labels.
-
-    Examples:
-        >>> labels = {
-        ...     "detector/boundingbox": np.array([1]),
-        ...     "pose/keypoints": np.array([2]),
-        ... }
-        >>> [
-        ...     (task, arr.tolist())
-        ...     for task, arr in task_type_iterator(labels, "keypoints")
-        ... ]
-        [('pose/keypoints', [2])]
-
-    """
-    for task, array in labels.items():
-        if get_task_type(task) == task_type:
-            yield task, array
+__all__ = [
+    "get_task_group",
+    "get_task_name",
+    "get_task_type",
+    "split_task",
+    "task_is_metadata",
+    "task_type_iterator",
+]

--- a/luxonis_ml/ldf/__init__.py
+++ b/luxonis_ml/ldf/__init__.py
@@ -16,10 +16,19 @@ Example:
         from luxonis_ml.ldf import DatasetRecord
 
         record = DatasetRecord(
-            file="images/frame_001.jpg",
+            media="images/frame_001.jpg",
             annotation={
-                "class": "person",
-                "boundingbox": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+                "detection": [
+                    {
+                        "class": "person",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.2,
+                            "w": 0.3,
+                            "h": 0.4,
+                        },
+                    }
+                ],
             },
         )
 

--- a/luxonis_ml/ldf/__init__.py
+++ b/luxonis_ml/ldf/__init__.py
@@ -28,8 +28,10 @@ Note:
     the data stack. The extra is a subset of ``luxonis-ml[data]``.
 
 See:
-    `luxonis_ml.ldf.annotation` for the record and annotation schemas and
-    `luxonis_ml.ldf.parquet` for the row they are serialized to.
+    `luxonis_ml.ldf.annotation` for the record and annotation schemas,
+    `luxonis_ml.ldf.parquet` for the row they are serialized to, and
+    `luxonis_ml.ldf.schema` for the dataset-level schema a conversion
+    needs.
 
 """
 
@@ -54,14 +56,17 @@ with guard_missing_extra("ldf"):
         load_annotation,
     )
     from .parquet import ParquetRecord
+    from .schema import SCHEMA_METADATA_KEY, DatasetSchema
 
 __all__ = [
+    "SCHEMA_METADATA_KEY",
     "Annotation",
     "ArrayAnnotation",
     "BBoxAnnotation",
     "Category",
     "ClassificationAnnotation",
     "DatasetRecord",
+    "DatasetSchema",
     "Detection",
     "InstanceSegmentationAnnotation",
     "Keypoint",

--- a/luxonis_ml/ldf/__init__.py
+++ b/luxonis_ml/ldf/__init__.py
@@ -52,6 +52,7 @@ with guard_missing_extra("ldf"):
         KeypointMetadata,
         KeypointVisibility,
         NormalizedFloat,
+        PathOrArray,
         SegmentationAnnotation,
         load_annotation,
     )
@@ -75,6 +76,7 @@ __all__ = [
     "KeypointVisibility",
     "NormalizedFloat",
     "ParquetRecord",
+    "PathOrArray",
     "SegmentationAnnotation",
     "load_annotation",
 ]

--- a/luxonis_ml/ldf/annotation.py
+++ b/luxonis_ml/ldf/annotation.py
@@ -431,13 +431,14 @@ from pydantic import (
 )
 from pydantic.types import FilePath, NonNegativeInt, PositiveFloat, PositiveInt
 from pydantic_core import core_schema
-from typing_extensions import Self, deprecated, override
+from typing_extensions import Self, TypeForm, deprecated, override
 
 from luxonis_ml.ldf.parquet import ParquetRecord
 from luxonis_ml.typing import (
     BaseModelExtraForbid,
     Params,
     PathType,
+    TaskType,
     check_type,
 )
 from luxonis_ml.utils.logging import log_once
@@ -800,7 +801,9 @@ class Category(str):
 
     @classmethod
     def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: GetCoreSchemaHandler
+        cls,
+        source_type: TypeForm["Category"],
+        handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         return core_schema.is_instance_schema(cls)
 
@@ -819,7 +822,9 @@ class _PathOrArraySchema:
 
     @classmethod
     def __get_pydantic_core_schema__(
-        cls, source_type: Any, handler: GetCoreSchemaHandler
+        cls,
+        source_type: TypeForm[FilePath | np.ndarray],
+        handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         return core_schema.no_info_wrap_validator_function(
             cls._validate, handler.generate_schema(FilePath)
@@ -827,8 +832,9 @@ class _PathOrArraySchema:
 
     @staticmethod
     def _validate(
-        value: Any, handler: core_schema.ValidatorFunctionWrapHandler
-    ) -> Any:
+        value: PathType | np.ndarray,
+        handler: core_schema.ValidatorFunctionWrapHandler,
+    ) -> FilePath | np.ndarray:
         return value if isinstance(value, np.ndarray) else handler(value)
 
 
@@ -2354,7 +2360,9 @@ class DatasetRecord(BaseModelExtraForbid):
         )
 
     def to_parquet_rows(
-        self, keypoint_metadata: Mapping[str, KeypointMetadata] | None = None
+        self,
+        keypoint_metadata: Mapping[str, KeypointMetadata] | None = None,
+        instance_counter: dict[str, int] | None = None,
     ) -> Iterable[ParquetRecord]:
         """Recursively convert the dataset record and all its
         annotations and sub-annotations to parquet rows.
@@ -2367,6 +2375,13 @@ class DatasetRecord(BaseModelExtraForbid):
                 keyed by task name. A keypoint payload is positional. The
                 keypoint metadata thus sets the order and pads the omitted
                 keypoints.
+            instance_counter: Next instance number of each task name, shared
+                by every record of one sample. A detection that carries no
+                instance ID takes the next number and advances it, so the
+                rows of one instance can be found again when they are read
+                back. The records of one sample arrive separately, so the
+                counter cannot live on the record. Numbers are left alone
+                when this is omitted.
 
         Yields:
             Annotation data rows.
@@ -2404,6 +2419,7 @@ class DatasetRecord(BaseModelExtraForbid):
                         file_path,
                         sample_metadata,
                         keypoint_metadata,
+                        instance_counter=instance_counter,
                     )
 
     @staticmethod
@@ -2433,14 +2449,34 @@ class DatasetRecord(BaseModelExtraForbid):
         file_path: FilePath,
         sample_metadata: str,
         keypoint_metadata: Mapping[str, KeypointMetadata],
+        *,
+        instance_counter: dict[str, int] | None = None,
+        instance_id: int | None = None,
     ) -> Iterable[ParquetRecord]:
+        """Yield one row per task type of a detection.
+
+        ``instance_counter`` holds the next instance number of each task
+        name, as `to_parquet_rows` describes. ``instance_id`` overrides the
+        number the counter would give: a sub-detection takes the number of
+        its parent, which is what records that it belongs to it.
+        """
+        if instance_id is None:
+            instance_id = annotation.instance_id
+            if instance_counter is not None:
+                # An ID the record sets itself is kept, and the counter moves
+                # past it so a later detection cannot be given the same one.
+                next_id = instance_counter.get(task_name, 0)
+                if instance_id < 0:
+                    instance_id = next_id
+                instance_counter[task_name] = max(next_id, instance_id + 1)
+
         def row(task_type: str, payload: str) -> ParquetRecord:
             return {
                 "file": str(file_path),
                 "source_name": source,
                 "task_name": task_name,
                 "class_name": annotation.class_name,
-                "instance_id": annotation.instance_id,
+                "instance_id": instance_id,
                 "task_type": task_type,
                 "annotation": payload,
                 "sample_metadata": sample_metadata,
@@ -2465,6 +2501,10 @@ class DatasetRecord(BaseModelExtraForbid):
                 file_path,
                 sample_metadata,
                 keypoint_metadata,
+                instance_counter=instance_counter,
+                instance_id=(
+                    instance_id if detection.instance_id < 0 else None
+                ),
             )
 
     @staticmethod
@@ -2496,14 +2536,7 @@ class DatasetRecord(BaseModelExtraForbid):
 
 
 def load_annotation(
-    task_type: Literal[
-        "classification",
-        "boundingbox",
-        "keypoints",
-        "segmentation",
-        "instance_segmentation",
-        "array",
-    ],
+    task_type: TaskType,
     data: Mapping[str, Any],
     *,
     keypoint_labels: Sequence[str] | None = None,

--- a/luxonis_ml/ldf/annotation.py
+++ b/luxonis_ml/ldf/annotation.py
@@ -309,12 +309,16 @@ sample:
     {
         "class": "embedding",
         "array": {
-            "path": "path/to/embedding.npy",
+            "data": "path/to/embedding.npy",
         },
     }
 
 Arrays are useful for modality-specific targets or auxiliary data that should
 be stored with the dataset but does not fit standard spatial schemas.
+
+``data`` also takes the array itself, for a record that was never on disk.
+Such a record can be rendered but not stored. The stored key stays ``path``,
+which is deprecated as an input name.
 
 
 Metadata and Categories
@@ -396,6 +400,7 @@ from pydantic import (
     AliasChoices,
     Field,
     GetCoreSchemaHandler,
+    PlainSerializer,
     ValidationInfo,
     field_serializer,
     field_validator,
@@ -771,6 +776,45 @@ class Category(str):
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
         return core_schema.is_instance_schema(cls)
+
+
+def _serialize_path_or_array(value: FilePath | np.ndarray) -> str:
+    if not isinstance(value, np.ndarray):
+        return str(value)
+    raise ValueError(
+        f"Cannot serialize an in-memory array of shape {value.shape}. "
+        "Save it to a file and reference that path instead."
+    )
+
+
+class _PathOrArraySchema:
+    """Accept an array without naming the union branches in the errors."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_wrap_validator_function(
+            cls._validate, handler.generate_schema(FilePath)
+        )
+
+    @staticmethod
+    def _validate(
+        value: Any, handler: core_schema.ValidatorFunctionWrapHandler
+    ) -> Any:
+        return value if isinstance(value, np.ndarray) else handler(value)
+
+
+PathOrArray: TypeAlias = Annotated[
+    FilePath | np.ndarray,
+    _PathOrArraySchema,
+    PlainSerializer(_serialize_path_or_array, when_used="json"),
+]
+"""A path to a file, or the data itself held in memory.
+
+A record that holds data in memory can be rendered and converted, but not
+stored. Save the data to a file and reference that path to store it.
+"""
 
 
 #: The `Detection` fields holding a single `Annotation`, in parquet row order.
@@ -1727,19 +1771,27 @@ class InstanceSegmentationAnnotation(SegmentationAnnotation):
 
 
 class ArrayAnnotation(Annotation):
-    """Custom annotation backed by an array file.
+    """Custom annotation backed by an array file or an in-memory array.
 
     All instances of this annotation must have the same shape.
 
     Attributes:
-        path: Path to the array saved as a ``.npy`` file.
+        path: Path to the array saved as a ``.npy`` file, or the array
+            itself. An in-memory array cannot be stored; save it to a file
+            and reference that path instead.
+
+            .. deprecated:: 0.10.0
+                The ``path`` input name is deprecated. Use ``data``, which
+                also accepts the array itself. The stored key stays ``path``.
 
     """
 
-    path: FilePath
+    path: PathOrArray
 
     def to_numpy(self) -> np.ndarray:
-        """Load the array from the file path."""
+        """Return the array, and load it from the file when needed."""
+        if isinstance(self.path, np.ndarray):
+            return self.path
         return np.load(self.path)
 
     @staticmethod
@@ -1762,20 +1814,38 @@ class ArrayAnnotation(Annotation):
             :math:`N` is the number of instances.
 
         """
-        out_arr = np.zeros(
-            (len(annotations), n_classes, *np.load(annotations[0].path).shape)
-        )
-        for i, ann in enumerate(annotations):
-            out_arr[i, classes[i]] = np.load(ann.path)
+        arrays = [ann.to_numpy() for ann in annotations]
+        out_arr = np.zeros((len(arrays), n_classes, *arrays[0].shape))
+        for i, array in enumerate(arrays):
+            out_arr[i, classes[i]] = array
         return out_arr
 
-    @field_serializer("path", when_used="json")
-    def _serialize_path(self, value: FilePath) -> str:
-        return str(value)
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_data(cls, values: Any) -> Any:
+        """Accept the array under either the old or the new name."""
+        if not isinstance(values, Mapping):
+            return values
+        if "data" in values:
+            if "path" in values:
+                raise ValueError("Provide either 'path' or 'data', not both.")
+            values = dict(values)
+            values["path"] = values.pop("data")
+        elif "path" in values:
+            log_once(
+                logger.warning,
+                "The 'path' field of an array annotation is deprecated. "
+                "Use 'data', which also accepts the array itself.",
+            )
+        return values
 
     @field_validator("path")
     @classmethod
-    def _validate_path(cls, path: FilePath) -> FilePath:
+    def _validate_path(
+        cls, path: FilePath | np.ndarray
+    ) -> FilePath | np.ndarray:
+        if isinstance(path, np.ndarray):
+            return path
         if path.suffix != ".npy":
             raise ValueError(
                 f"Array annotation file must be a .npy file. Got {path}"
@@ -1796,12 +1866,16 @@ class ArrayAnnotation(Annotation):
 
 
 class DatasetRecord(BaseModelExtraForbid):
-    """Dataset record containing file paths and an optional annotation.
+    """Dataset record containing file paths and its annotations.
 
     A record is the unit of ingestion for `LuxonisDataset.add`. It may point
     to one media source through ``file`` or to multiple synchronized sources
     through ``files``, but never both -- passing both is an error, where
     ``files`` used to be silently discarded in favor of ``file``.
+
+    Annotations are grouped by task name, so one record can carry every
+    detection of a sample. The older flat forms still work: a single
+    detection, or a list of them, together with a ``task_name``.
 
     ``sample_metadata`` stores **record-level metadata**. It is preserved by
     native import/export and returned by `LuxonisLoader` as
@@ -1842,14 +1916,14 @@ class DatasetRecord(BaseModelExtraForbid):
 
     """
 
-    files: dict[str, FilePath]
+    files: dict[str, PathOrArray]
     annotation: Detection | None = None
     task_name: str = ""
     sample_metadata: Params = Field(default_factory=dict)
 
     @property
-    def file(self) -> FilePath:
-        """The file path of the dataset record.
+    def file(self) -> FilePath | np.ndarray:
+        """The single file of the dataset record.
 
         This property is provided for convenience when the dataset record has
         exactly one file.
@@ -1863,8 +1937,34 @@ class DatasetRecord(BaseModelExtraForbid):
         return next(iter(self.files.values()))
 
     @property
+    def file_paths(self) -> dict[str, FilePath]:
+        """The record's files, guaranteed to be paths on disk.
+
+        Use this wherever a record is about to be stored, because anything
+        that writes the record needs somewhere to read the media from.
+
+        Raises:
+            NotImplementedError: If any source holds an in-memory image.
+
+        """
+        paths: dict[str, FilePath] = {}
+        in_memory: list[str] = []
+        for source, file in self.files.items():
+            if isinstance(file, np.ndarray):
+                in_memory.append(source)
+            else:
+                paths[source] = file
+        if in_memory:
+            raise NotImplementedError(
+                f"Sources {sorted(in_memory)} hold an in-memory image "
+                "instead of a file path. A dataset cannot store those: write "
+                "the image to a file and reference that path instead."
+            )
+        return paths
+
+    @property
     @deprecated("Use `list(record.files.values())` instead.")
-    def all_file_paths(self) -> list[FilePath]:
+    def all_file_paths(self) -> list[FilePath | np.ndarray]:
         """All file paths associated with the dataset record.
 
         .. deprecated:: 0.9.0
@@ -1907,20 +2007,37 @@ class DatasetRecord(BaseModelExtraForbid):
         # A shallow copy is enough: nothing below mutates a nested value,
         # and deep-copying would duplicate any mask the payload carries.
         values = dict(values)
-        if "file" in values:
-            if "files" in values:
-                raise ValueError("Provide either 'file' or 'files', not both.")
-            values["files"] = {"image": values.pop("file")}
-        if "files" in values:
-            files = values["files"]
-            # Anything else is left untouched for pydantic to report
-            # against `files` instead of failing on the paths below.
-            if isinstance(files, Mapping) and all(
-                isinstance(path, PathType) for path in files.values()
-            ):
-                values["files"] = {
-                    key: Path(path).absolute() for key, path in files.items()
-                }
+        provided = [key for key in ("media", "file", "files") if key in values]
+        if len(provided) > 1:
+            names = " or ".join(f"'{key}'" for key in provided)
+            raise ValueError(f"Provide either {names}, not both.")
+        if provided and provided != ["media"]:
+            log_once(
+                logger.warning,
+                "The 'file' and 'files' fields are deprecated. Use 'media', "
+                "which takes one path or a mapping of source names to paths.",
+            )
+        if not provided:
+            return values
+
+        media = values.pop(provided[0])
+        # 'file' always named one source. 'media' names one only when it is
+        # a file itself, so that it can also take the mapping 'files' took.
+        if provided[0] == "file" or (
+            provided[0] == "media"
+            and isinstance(media, (PathType, np.ndarray))
+        ):
+            media = {"image": media}
+        # Anything else is left untouched for pydantic to report against
+        # `files` instead of failing on the paths below.
+        if isinstance(media, Mapping):
+            media = {
+                source: Path(file).absolute()
+                if isinstance(file, PathType)
+                else file
+                for source, file in media.items()
+            }
+        values["files"] = media
         return values
 
     def to_parquet_rows(
@@ -2074,6 +2191,11 @@ def load_annotation(
     }
     if task_type not in classes:
         raise ValueError(f"Unknown label type: {task_type}")
+    if task_type == "array" and "path" in data:
+        # Stored arrays keep the old key, so reading one back must not look
+        # like a caller that still uses the deprecated name.
+        data = {**data, "data": data["path"]}
+        del data["path"]
     return classes[task_type].model_validate(
         data, context={"keypoint_labels": keypoint_labels}
     )
@@ -2195,6 +2317,7 @@ __all__ = [
     "KeypointMetadata",
     "KeypointVisibility",
     "NormalizedFloat",
+    "PathOrArray",
     "SegmentationAnnotation",
     "load_annotation",
 ]

--- a/luxonis_ml/ldf/annotation.py
+++ b/luxonis_ml/ldf/annotation.py
@@ -403,6 +403,7 @@ from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Annotated,
     Any,
     Final,
@@ -440,6 +441,11 @@ from luxonis_ml.typing import (
     check_type,
 )
 from luxonis_ml.utils.logging import log_once
+
+if TYPE_CHECKING:
+    from luxonis_ml.typing import LoaderOutput
+
+    from .schema import DatasetSchema
 
 KeypointVisibility: TypeAlias = Literal[0, 1, 2]
 """Keypoint visibility following the COCO convention.
@@ -975,7 +981,11 @@ class Detection(BaseModelExtraForbid):
     )
     instance_id: int = -1
 
-    metadata: dict[str, int | float | str | Category] = {}
+    # A literal default is deep-copied into every instance, which the
+    # loader pays for once per annotation row.
+    metadata: dict[str, int | float | str | Category] = Field(
+        default_factory=dict
+    )
 
     boundingbox: Optional["BBoxAnnotation"] = None
     keypoints: Optional["KeypointAnnotation"] = None
@@ -985,7 +995,7 @@ class Detection(BaseModelExtraForbid):
 
     scale_to_boxes: bool = False
 
-    sub_detections: dict[str, "Detection"] = {}
+    sub_detections: dict[str, "Detection"] = Field(default_factory=dict)
 
     def get_task_types(self) -> set[str]:
         """Get all the task type associated with this detection.
@@ -2305,6 +2315,43 @@ class DatasetRecord(BaseModelExtraForbid):
             }
         values["files"] = media
         return values
+
+    def to_loader_output(
+        self,
+        schema: "DatasetSchema",
+        *,
+        images: dict[str, np.ndarray] | None = None,
+        keep_categorical_as_strings: bool = False,
+        include_empty: bool = True,
+    ) -> "LoaderOutput":
+        """Convert this record into the arrays a loader returns.
+
+        Args:
+            schema: Schema of the dataset this record belongs to. It supplies
+                what a record cannot: the class IDs, the number of classes of
+                a segmentation task, and the keypoint count of an empty
+                keypoint label.
+            images: Images keyed by source name. Read from the record's files
+                when omitted.
+            keep_categorical_as_strings: Whether categorical metadata keeps
+                its string values instead of the encoded integers.
+            include_empty: Whether every task of the schema gets a label, even
+                when this record has no annotation for it.
+
+        Returns:
+            The images, one label per task and task type, and this record's
+            metadata with the schema attached.
+
+        """
+        from luxonis_ml.ldf.conversion import record_to_loader_output
+
+        return record_to_loader_output(
+            self,
+            schema,
+            images=images,
+            keep_categorical_as_strings=keep_categorical_as_strings,
+            include_empty=include_empty,
+        )
 
     def to_parquet_rows(
         self, keypoint_metadata: Mapping[str, KeypointMetadata] | None = None

--- a/luxonis_ml/ldf/annotation.py
+++ b/luxonis_ml/ldf/annotation.py
@@ -14,17 +14,16 @@ normalized before they are written to LDF parquet shards.
 Record Model
 ============
 
-Dataset ingestion starts with `DatasetRecord`. A record points to media,
-optionally assigns a task name, and optionally carries an annotation payload
-validated by `Detection`.
+Dataset ingestion starts with `DatasetRecord`. A record points to media and
+groups its annotation payloads, each validated by `Detection`, under the task
+name they belong to.
 
-Single-source records use ``"file"``:
+A single source is named by ``"media"``:
 
 .. code-block:: json
 
     {
-      "file": "path/to/image.jpg",
-      "task_name": "detection",
+      "media": "path/to/image.jpg",
 
       "sample_metadata": {
         "record_id": 123,
@@ -33,26 +32,29 @@ Single-source records use ``"file"``:
       },
 
       "annotation": {
-        "class": "car",
-        "boundingbox": {
-          "x": 0.1,
-          "y": 0.2,
-          "w": 0.3,
-          "h": 0.4
-        }
+        "detection": [
+          {
+            "class": "car",
+            "boundingbox": {
+              "x": 0.1,
+              "y": 0.2,
+              "w": 0.3,
+              "h": 0.4
+            }
+          }
+        ]
       }
     }
 
-Multi-source records use ``"files"``:
+Several synchronized sources are named by the same key:
 
 .. code-block:: json
 
     {
-      "files": {
+      "media": {
         "rgb": "path/to/rgb.png",
         "depth": "path/to/depth.png"
       },
-      "task_name": "detection",
 
       "sample_metadata": {
         "sequence": "loading_dock_07",
@@ -60,13 +62,17 @@ Multi-source records use ``"files"``:
       },
 
       "annotation": {
-        "class": "person",
-        "boundingbox": {
-          "x": 0.1,
-          "y": 0.1,
-          "w": 0.3,
-          "h": 0.4
-        }
+        "detection": [
+          {
+            "class": "person",
+            "boundingbox": {
+              "x": 0.1,
+              "y": 0.1,
+              "w": 0.3,
+              "h": 0.4
+            }
+          }
+        ]
       }
     }
 
@@ -82,10 +88,25 @@ consumed by training code as annotation labels.
 **Frontend note:** ``sample_metadata`` is sample data, not an annotation
 target.
 
-Task names group annotations that should be consumed together. If no
-``task_name`` is provided, the empty string ``""`` is used. Loader label keys
-therefore follow ``"task_name/task_type"`` and default-task keys start with
-``"/"``.
+Task names group annotations that should be consumed together. The empty
+string ``""`` names the default task, so loader label keys follow
+``"task_name/task_type"`` and default-task keys start with ``"/"``.
+
+An empty ``annotation`` mapping marks a true negative. Such a sample counts as
+a negative for every task of the dataset. A task mapped to an empty list is a
+true negative that also declares the task, which is how a dataset can hold a
+task that has no positive sample yet.
+
+The flat form, a single detection or a list of them beside a ``task_name``, is
+deprecated but still accepted:
+
+.. code-block:: json
+
+    {
+      "file": "path/to/image.jpg",
+      "task_name": "detection",
+      "annotation": {"class": "car"}
+    }
 
 
 Coordinates and Instances
@@ -2066,8 +2087,10 @@ class DatasetRecord(BaseModelExtraForbid):
 
     Attributes:
         files: File paths keyed by source name.
-        annotation: Optional detection associated with the dataset record.
-        task_name: The name of the task to which the record belongs.
+        annotation: Detections grouped by task name. An empty mapping marks a
+            true negative, which counts as a negative for every task of the
+            dataset. A task with an empty list is a true negative that also
+            declares the task itself.
         sample_metadata: JSON-like metadata for the whole sample. Values
             should be JSON-serializable. Missing metadata defaults to an empty
             dictionary.
@@ -2077,7 +2100,6 @@ class DatasetRecord(BaseModelExtraForbid):
 
             {
               "file": "images/frame_001.jpg",
-              "task_name": "detection",
 
               "sample_metadata": {
                 "record_id": 123,
@@ -2086,21 +2108,24 @@ class DatasetRecord(BaseModelExtraForbid):
               },
 
               "annotation": {
-                "class": "person",
-                "boundingbox": {
-                  "x": 0.1,
-                  "y": 0.2,
-                  "w": 0.3,
-                  "h": 0.4
-                }
+                "detection": [
+                  {
+                    "class": "person",
+                    "boundingbox": {
+                      "x": 0.1,
+                      "y": 0.2,
+                      "w": 0.3,
+                      "h": 0.4
+                    }
+                  }
+                ]
               }
             }
 
     """
 
     files: dict[str, PathOrArray]
-    annotation: Detection | None = None
-    task_name: str = ""
+    annotation: dict[str, list[Detection]] = Field(default_factory=dict)
     sample_metadata: Params = Field(default_factory=dict)
 
     @property
@@ -2154,30 +2179,89 @@ class DatasetRecord(BaseModelExtraForbid):
         """
         return list(self.files.values())
 
+    @property
+    @deprecated("Use the keys of `record.annotation` instead.")
+    def task_name(self) -> str:
+        """The task name of a record that carries exactly one task.
+
+        .. deprecated:: 0.10.0
+            Group the detections by task name in ``annotation`` instead.
+
+        Raises:
+            ValueError: If the record carries more than one task.
+
+        """
+        if not self.annotation:
+            return ""
+        if len(self.annotation) > 1:
+            raise ValueError(
+                "A record with several tasks has no single task name. "
+                "Read the keys of `record.annotation` instead."
+            )
+        return next(iter(self.annotation))
+
     @model_validator(mode="after")
-    def validate_task_name_valid_identifier(self) -> Self:
-        Detection._check_valid_identifier(self.task_name, label="Task name")
+    def validate_task_names(self) -> Self:
+        for task_name in self.annotation:
+            if not task_name:
+                continue
+            for part in task_name.split("/"):
+                if not part:
+                    raise ValueError(
+                        f"Task name '{task_name}' has an empty part."
+                    )
+                Detection._check_valid_identifier(part, label="Task name")
         return self
 
     @model_validator(mode="before")
     @classmethod
-    def validate_task_name(cls, values: Any) -> Any:
-        if not isinstance(values, Mapping) or "task" not in values:
+    def normalize_annotation(cls, values: Any) -> Any:
+        """Group the record's detections by task name.
+
+        The deprecated flat forms are accepted and normalized: a single
+        detection, a list of detections, and a ``task_name`` or ``task``
+        beside them.
+        """
+        if not isinstance(values, Mapping):
             return values
 
         values = dict(values)
-        task = values.pop("task")
-        if values.get("task_name", task) != task:
+        task = values.pop("task", None)
+        task_name = values.pop("task_name", None)
+        if task is not None and task_name is not None and task != task_name:
             raise ValueError(
                 "Conflicting values for 'task' and 'task_name'. "
-                "Use only 'task_name'."
+                "Group the detections by task name in 'annotation' instead."
             )
+        if task is not None or task_name is not None:
+            log_once(
+                logger.warning,
+                "The 'task' and 'task_name' fields are deprecated. Group "
+                "the detections by task name in 'annotation' instead.",
+            )
+        if task_name is None:
+            task_name = task
 
-        log_once(
-            logger.warning,
-            "The 'task' field is deprecated. Use 'task_name' instead.",
+        annotation = values.get("annotation")
+        if annotation is None or cls._is_task_mapping(annotation):
+            grouped = dict(annotation or {})
+            if task_name is not None and set(grouped) - {task_name}:
+                raise ValueError(
+                    f"The task name '{task_name}' does not match the tasks "
+                    f"of the annotation mapping: {sorted(grouped)}."
+                )
+            # A task name on its own declares a task that has no positives.
+            if not grouped and task_name is not None:
+                grouped = {task_name: []}
+            values["annotation"] = grouped
+            return values
+
+        detections = (
+            list(annotation)
+            if isinstance(annotation, (list, tuple))
+            else [annotation]
         )
-        values["task_name"] = task
+        values["annotation"] = {task_name or "": detections}
         return values
 
     @model_validator(mode="before")
@@ -2228,6 +2312,9 @@ class DatasetRecord(BaseModelExtraForbid):
         """Recursively convert the dataset record and all its
         annotations and sub-annotations to parquet rows.
 
+        Every detection is flattened into the rows of the main source. Each
+        secondary source gets a single row with no annotation.
+
         Args:
             keypoint_metadata: Keypoint metadata of the written tasks,
                 keyed by task name. A keypoint payload is positional. The
@@ -2238,78 +2325,36 @@ class DatasetRecord(BaseModelExtraForbid):
             Annotation data rows.
 
         """
-        yield from self._to_parquet_rows(
-            self.annotation,
-            self.task_name,
-            json.dumps(self.sample_metadata),
-            keypoint_metadata or {},
+        keypoint_metadata = keypoint_metadata or {}
+        sample_metadata = json.dumps(self.sample_metadata)
+        annotations_by_task = self.annotation or {"": []}
+        # A record of one task keeps naming it on the rows of its secondary
+        # sources. Several tasks have no single name to put there.
+        secondary_task = (
+            next(iter(annotations_by_task))
+            if len(annotations_by_task) == 1
+            else ""
         )
 
-    def _to_parquet_rows(
-        self,
-        annotation: Detection | None,
-        task_name: str,
-        sample_metadata: str,
-        keypoint_metadata: Mapping[str, KeypointMetadata],
-    ) -> Iterable[ParquetRecord]:
-        file_items = sorted(self.files.items(), key=lambda x: str(x[1]))
+        file_items = sorted(self.file_paths.items(), key=lambda x: str(x[1]))
         for i, (source, file_path) in enumerate(file_items):
-            is_main = i == 0
+            if i > 0:
+                yield self._empty_row(
+                    source, file_path, secondary_task, sample_metadata
+                )
+                continue
 
-            if annotation is None or not is_main:
-                yield {
-                    "file": str(file_path),
-                    "source_name": source,
-                    "task_name": task_name,
-                    "class_name": None,
-                    "instance_id": None,
-                    "task_type": None,
-                    "annotation": None,
-                    "sample_metadata": sample_metadata,
-                }
-            else:
-                for task_type in _LABEL_TASK_TYPES:
-                    label: Annotation | None = getattr(annotation, task_type)
-
-                    if label is not None:
-                        yield {
-                            "file": str(file_path),
-                            "source_name": source,
-                            "task_name": task_name,
-                            "class_name": annotation.class_name,
-                            "instance_id": annotation.instance_id,
-                            "task_type": task_type,
-                            "annotation": label.to_parquet_json(
-                                keypoint_metadata.get(task_name)
-                            ),
-                            "sample_metadata": sample_metadata,
-                        }
-                for key, data in annotation.metadata.items():
-                    yield {
-                        "file": str(file_path),
-                        "source_name": source,
-                        "task_name": task_name,
-                        "class_name": annotation.class_name,
-                        "instance_id": annotation.instance_id,
-                        "task_type": f"metadata/{key}",
-                        "annotation": json.dumps(data),
-                        "sample_metadata": sample_metadata,
-                    }
-                if annotation.class_name is not None:
-                    yield {
-                        "file": str(file_path),
-                        "source_name": source,
-                        "task_name": task_name,
-                        "class_name": annotation.class_name,
-                        "instance_id": annotation.instance_id,
-                        "task_type": "classification",
-                        "annotation": "{}",
-                        "sample_metadata": sample_metadata,
-                    }
-                for name, detection in annotation.sub_detections.items():
-                    yield from self._to_parquet_rows(
-                        detection,
-                        f"{task_name}/{name}",
+            for task_name, annotations in annotations_by_task.items():
+                if not annotations:
+                    yield self._empty_row(
+                        source, file_path, task_name, sample_metadata
+                    )
+                for annotation in annotations:
+                    yield from self._detection_rows(
+                        annotation,
+                        task_name,
+                        source,
+                        file_path,
                         sample_metadata,
                         keypoint_metadata,
                     )
@@ -2332,6 +2377,75 @@ class DatasetRecord(BaseModelExtraForbid):
         if isinstance(value, str):
             value = json.loads(value)
         return value if isinstance(value, dict) else {}
+
+    def _detection_rows(
+        self,
+        annotation: Detection,
+        task_name: str,
+        source: str,
+        file_path: FilePath,
+        sample_metadata: str,
+        keypoint_metadata: Mapping[str, KeypointMetadata],
+    ) -> Iterable[ParquetRecord]:
+        def row(task_type: str, payload: str) -> ParquetRecord:
+            return {
+                "file": str(file_path),
+                "source_name": source,
+                "task_name": task_name,
+                "class_name": annotation.class_name,
+                "instance_id": annotation.instance_id,
+                "task_type": task_type,
+                "annotation": payload,
+                "sample_metadata": sample_metadata,
+            }
+
+        for task_type in _LABEL_TASK_TYPES:
+            label: Annotation | None = getattr(annotation, task_type)
+            if label is not None:
+                yield row(
+                    task_type,
+                    label.to_parquet_json(keypoint_metadata.get(task_name)),
+                )
+        for key, data in annotation.metadata.items():
+            yield row(f"metadata/{key}", json.dumps(data))
+        if annotation.class_name is not None:
+            yield row("classification", "{}")
+        for name, detection in annotation.sub_detections.items():
+            yield from self._detection_rows(
+                detection,
+                f"{task_name}/{name}",
+                source,
+                file_path,
+                sample_metadata,
+                keypoint_metadata,
+            )
+
+    @staticmethod
+    def _empty_row(
+        source: str,
+        file_path: FilePath,
+        task_name: str,
+        sample_metadata: str,
+    ) -> ParquetRecord:
+        """Return the row of a source that carries no annotation."""
+        return {
+            "file": str(file_path),
+            "source_name": source,
+            "task_name": task_name,
+            "class_name": None,
+            "instance_id": None,
+            "task_type": None,
+            "annotation": None,
+            "sample_metadata": sample_metadata,
+        }
+
+    @staticmethod
+    def _is_task_mapping(annotation: Any) -> bool:
+        """Whether an annotation payload groups detections by task name."""
+        return isinstance(annotation, Mapping) and all(
+            isinstance(detections, (list, tuple))
+            for detections in annotation.values()
+        )
 
 
 def load_annotation(

--- a/luxonis_ml/ldf/annotation.py
+++ b/luxonis_ml/ldf/annotation.py
@@ -1085,6 +1085,28 @@ class Annotation(ABC, BaseModelExtraForbid):
         """
         ...
 
+    @staticmethod
+    @abstractmethod
+    def split_from_numpy(
+        array: np.ndarray,
+    ) -> list[tuple["Annotation", int | None]]:
+        """Split a combined array back into single annotations.
+
+        This is the inverse of `combine_to_numpy`. Only some layouts carry
+        the class of each annotation, so the class ID is optional: keypoints
+        and instance masks are stored without one, and the caller has to
+        take it from another annotation of the same instance.
+
+        Args:
+            array: Array in the layout `combine_to_numpy` produces.
+
+        Returns:
+            One annotation per instance, each with its class ID when the
+            layout carries one.
+
+        """
+        ...
+
 
 class ClassificationAnnotation(Annotation):
     """Dummy wrapper annotation for classification tasks.
@@ -1121,6 +1143,26 @@ class ClassificationAnnotation(Annotation):
         for i in range(len(annotations)):
             classify_vector[classes[i]] = 1
         return classify_vector
+
+    @staticmethod
+    @override
+    def split_from_numpy(
+        array: np.ndarray,
+    ) -> list[tuple["ClassificationAnnotation", int]]:
+        r"""Split a multi-hot label vector into one annotation per class.
+
+        Args:
+            array: Multi-hot class vector of shape
+                :math:`\left(C,\right)`.
+
+        Returns:
+            One annotation per class the vector marks, with its class ID.
+
+        """
+        return [
+            (ClassificationAnnotation(), int(class_id))
+            for class_id in np.flatnonzero(array)
+        ]
 
 
 class BBoxAnnotation(Annotation):
@@ -1178,6 +1220,34 @@ class BBoxAnnotation(Annotation):
         for i, ann in enumerate(annotations):
             boxes[i] = ann.to_numpy(classes[i])
         return boxes
+
+    @staticmethod
+    @override
+    def split_from_numpy(
+        array: np.ndarray,
+    ) -> list[tuple["BBoxAnnotation", int]]:
+        r"""Split bounding box rows into single annotations.
+
+        Args:
+            array: Rows of shape :math:`\left(N, 5\right)`, each in the
+                format ``[class_id, x, y, w, h]``.
+
+        Returns:
+            One bounding box per row, with the class ID of its first column.
+
+        """
+        return [
+            (
+                BBoxAnnotation(
+                    x=float(row[1]),
+                    y=float(row[2]),
+                    w=float(row[3]),
+                    h=float(row[4]),
+                ),
+                int(row[0]),
+            )
+            for row in array
+        ]
 
     @model_validator(mode="before")
     @classmethod
@@ -1323,6 +1393,38 @@ class KeypointAnnotation(Annotation):
                 )
             keypoints[i] = ann.to_numpy()
         return keypoints
+
+    @staticmethod
+    @override
+    def split_from_numpy(
+        array: np.ndarray,
+    ) -> list[tuple["KeypointAnnotation", None]]:
+        r"""Split flattened keypoint rows into single annotations.
+
+        Args:
+            array: Rows of shape :math:`\left(N, 3K\right)`.
+
+        Returns:
+            One keypoint annotation per row. The layout carries no class,
+            so every class ID is ``None``.
+
+        """
+        return [
+            (
+                # Validated rather than constructed: visibility is a literal
+                # that the float array cannot carry.
+                KeypointAnnotation.model_validate(
+                    {
+                        "keypoints": [
+                            (float(x), float(y), round(float(visibility)))
+                            for x, y, visibility in row.reshape(-1, 3)
+                        ]
+                    }
+                ),
+                None,
+            )
+            for row in array
+        ]
 
     def declared_metadata(self) -> KeypointMetadata | None:
         """Return the task-level metadata this annotation describes.
@@ -1570,6 +1672,33 @@ class SegmentationAnnotation(Annotation):
 
         return segmentation
 
+    @staticmethod
+    @override
+    def split_from_numpy(
+        array: np.ndarray,
+    ) -> list[tuple["SegmentationAnnotation", int]]:
+        r"""Split class masks into one annotation per class.
+
+        Args:
+            array: Semantic masks of shape :math:`\left(C, H, W\right)`.
+
+        Returns:
+            One annotation per class that has any pixel, with its class ID.
+            The combination gave each pixel to one class, and the split does
+            not restore the overlaps.
+
+        """
+        return [
+            (
+                SegmentationAnnotation.model_validate(
+                    {"mask": mask.astype(np.uint8)}
+                ),
+                class_id,
+            )
+            for class_id, mask in enumerate(array)
+            if mask.any()
+        ]
+
     @field_serializer("counts", when_used="json")
     def _serialize_counts(self, counts: bytes) -> str:
         return counts.decode("utf-8")
@@ -1769,6 +1898,31 @@ class InstanceSegmentationAnnotation(SegmentationAnnotation):
         """
         return np.stack([ann.to_numpy() for ann in annotations])
 
+    @staticmethod
+    @override
+    def split_from_numpy(
+        array: np.ndarray,
+    ) -> list[tuple["InstanceSegmentationAnnotation", None]]:
+        r"""Split instance masks into single annotations.
+
+        Args:
+            array: Instance masks of shape :math:`\left(N, H, W\right)`.
+
+        Returns:
+            One annotation per mask. The layout carries no class, so every
+            class ID is ``None``.
+
+        """
+        return [
+            (
+                InstanceSegmentationAnnotation.model_validate(
+                    {"mask": mask.astype(np.uint8)}
+                ),
+                None,
+            )
+            for mask in array
+        ]
+
 
 class ArrayAnnotation(Annotation):
     """Custom annotation backed by an array file or an in-memory array.
@@ -1819,6 +1973,34 @@ class ArrayAnnotation(Annotation):
         for i, array in enumerate(arrays):
             out_arr[i, classes[i]] = array
         return out_arr
+
+    @staticmethod
+    @override
+    def split_from_numpy(
+        array: np.ndarray,
+    ) -> list[tuple["ArrayAnnotation", int | None]]:
+        r"""Split class-indexed arrays into single annotations.
+
+        Args:
+            array: Arrays of shape :math:`\left(N, C, \ldots\right)`, where
+                every instance fills the slot of its own class.
+
+        Returns:
+            One annotation per instance, holding the data of its class slot.
+            An instance whose data is all zeros has no slot to tell apart, so
+            it takes the first one and reports no class ID.
+
+        """
+        annotations: list[tuple[ArrayAnnotation, int | None]] = []
+        for instance in array:
+            class_id = next(
+                (i for i, slot in enumerate(instance) if slot.any()), None
+            )
+            slot = instance[class_id or 0]
+            annotations.append(
+                (ArrayAnnotation.model_validate({"data": slot}), class_id)
+            )
+        return annotations
 
     @model_validator(mode="before")
     @classmethod

--- a/luxonis_ml/ldf/conversion.py
+++ b/luxonis_ml/ldf/conversion.py
@@ -1,0 +1,521 @@
+"""Conversions between LDF records and the arrays a loader returns.
+
+A record describes a sample the way it is stored: detections grouped by task,
+each holding its own annotations. A loader returns the same sample the way a
+model consumes it: one array per task and task type, with every instance a row.
+
+The two directions are `record_to_loader_output` and `labels_to_record`, and
+they are reached through `DatasetRecord.to_loader_output` and
+`LoaderOutput.to_ldf`. Both need the `DatasetSchema` of the dataset, because a
+record names its classes while an array numbers them.
+
+Instances are paired by row index. Row :math:`i` of every array of one task
+describes the same instance, which is the invariant the augmentation engine
+already relies on when it filters keypoints and masks by their bounding box.
+"""
+
+from collections import defaultdict, deque
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+
+import numpy as np
+from PIL import Image
+
+from luxonis_ml.typing import Labels, LoaderOutput, Params
+
+from .annotation import (
+    Annotation,
+    ArrayAnnotation,
+    BBoxAnnotation,
+    Category,
+    ClassificationAnnotation,
+    DatasetRecord,
+    Detection,
+    InstanceSegmentationAnnotation,
+    KeypointAnnotation,
+    SegmentationAnnotation,
+)
+from .schema import SCHEMA_METADATA_KEY, DatasetSchema
+from .tasks import get_task_group, get_task_type
+
+__all__ = ["labels_to_record", "record_to_loader_output"]
+
+#: Task types that describe one instance each, in the order they are trusted
+#: to define the instance order of a task.
+_INSTANCE_TASK_TYPES = (
+    "boundingbox",
+    "instance_segmentation",
+    "keypoints",
+    "array",
+)
+
+_ANNOTATION_TYPES: dict[str, type[Annotation]] = {
+    "boundingbox": BBoxAnnotation,
+    "keypoints": KeypointAnnotation,
+    "segmentation": SegmentationAnnotation,
+    "instance_segmentation": InstanceSegmentationAnnotation,
+    "array": ArrayAnnotation,
+}
+
+_METADATA_PREFIX = "metadata/"
+#: Classification carries no data, so every row shares one annotation.
+_CLASSIFICATION = ClassificationAnnotation()
+
+
+def record_to_loader_output(
+    record: DatasetRecord,
+    schema: DatasetSchema,
+    *,
+    images: dict[str, np.ndarray] | None = None,
+    keep_categorical_as_strings: bool = False,
+    include_empty: bool = True,
+) -> LoaderOutput:
+    """Convert a record into the arrays a loader returns.
+
+    Args:
+        record: Record to convert.
+        schema: Schema of the dataset the record belongs to.
+        images: Images keyed by source name. Read from the record's files
+            when omitted.
+        keep_categorical_as_strings: Whether categorical metadata keeps its
+            string values instead of the integers the schema encodes them as.
+        include_empty: Whether every task of the schema gets a label, even
+            when the record has no annotation for it.
+
+    Returns:
+        The images, one label per task and task type, and the record's
+        metadata with the schema attached.
+
+    """
+    annotations = _flatten_sub_detections(record.annotation)
+    images = _load_images(record) if images is None else dict(images)
+    image_shape = next(iter(images.values())).shape[:2]
+
+    task_types: dict[str, set[str]] = (
+        {name: set(types) for name, types in schema.tasks.items()}
+        if include_empty
+        else {}
+    )
+    for task_name, detections in annotations.items():
+        present = task_types.setdefault(task_name, set())
+        for detection in detections:
+            present |= detection.get_task_types()
+
+    labels: Labels = {}
+    for task_name, types in task_types.items():
+        detections = sorted(
+            annotations.get(task_name, []),
+            key=lambda detection: detection.instance_id,
+        )
+        instance_order = _instance_order(detections)
+        for task_type in sorted(types):
+            labels[f"{task_name}/{task_type}"] = _build_label(
+                task_name,
+                task_type,
+                detections,
+                instance_order,
+                schema,
+                image_shape=image_shape,
+                keep_categorical_as_strings=keep_categorical_as_strings,
+            )
+
+    metadata = deepcopy(record.sample_metadata)
+    metadata[SCHEMA_METADATA_KEY] = schema.as_metadata
+    return LoaderOutput(images, labels, metadata)
+
+
+def labels_to_record(
+    labels: Labels,
+    schema: DatasetSchema,
+    *,
+    images: dict[str, np.ndarray] | None = None,
+    sample_metadata: Params | None = None,
+    keep_background: bool = False,
+) -> DatasetRecord:
+    """Convert loader labels back into one record.
+
+    Args:
+        labels: Label arrays keyed by ``"task_name/task_type"``.
+        schema: Schema of the dataset the labels came from.
+        images: Images keyed by source name, held in memory by the record.
+        sample_metadata: Record-level metadata to keep on the record.
+        keep_background: Whether the background class of a semantic mask
+            becomes a detection of its own. It is dropped by default, as the
+            loader adds it to fill the pixels no class claimed.
+
+    Returns:
+        One record holding every detection the labels describe.
+
+    """
+    by_task: dict[str, dict[str, np.ndarray]] = defaultdict(dict)
+    for key, array in labels.items():
+        by_task[get_task_group(key)][get_task_type(key)] = array
+
+    annotations = {
+        task_name: _build_detections(
+            task_name, task_types, schema, keep_background=keep_background
+        )
+        for task_name, task_types in by_task.items()
+    }
+    # Every part is already a validated model, and validating the record
+    # would report our own `files` as the deprecated input name.
+    return DatasetRecord.model_construct(
+        files=dict(images or {}),
+        annotation=_nest_sub_detections(annotations),
+        sample_metadata=deepcopy(sample_metadata or {}),
+    )
+
+
+def _flatten_sub_detections(
+    annotations: Mapping[str, Sequence[Detection]],
+) -> dict[str, list[Detection]]:
+    """Promote every sub-detection to a task of its own.
+
+    A sub-detection is annotated separately from its parent, so a loader sees
+    ``"driver/face"`` as an ordinary task.
+    """
+    flattened: dict[str, list[Detection]] = defaultdict(list)
+
+    def add(task_name: str, detection: Detection) -> None:
+        flattened[task_name].append(detection)
+        for name, sub_detection in detection.sub_detections.items():
+            add(f"{task_name}/{name}", sub_detection)
+
+    for task_name, detections in annotations.items():
+        flattened.setdefault(task_name, [])
+        for detection in detections:
+            add(task_name, detection)
+    return dict(flattened)
+
+
+def _nest_sub_detections(
+    annotations: Mapping[str, Sequence[Detection]],
+) -> dict[str, list[Detection]]:
+    """Put every sub-task back under the detection it belongs to.
+
+    A task named ``"driver/face"`` is the ``"face"`` sub-detection of the
+    ``"driver"`` task. Its detections pair with their parents by row index,
+    which is the same order the instance IDs gave them.
+    """
+    nested = {
+        name: list(detections) for name, detections in annotations.items()
+    }
+    # The deepest tasks nest first, so a chain such as "a/b/c" ends up under
+    # "a/b" before "a/b" itself moves under "a".
+    for task_name in sorted(
+        nested, key=lambda name: name.count("/"), reverse=True
+    ):
+        parent_name, _, sub_name = task_name.rpartition("/")
+        if not sub_name or parent_name not in nested:
+            continue
+        parents = nested[parent_name]
+        children = nested.pop(task_name)
+        for index, child in enumerate(children):
+            if index < len(parents):
+                parents[index].sub_detections[sub_name] = child
+            else:
+                # A sub-detection with no parent of its own keeps its task,
+                # because dropping it would lose an annotation.
+                nested.setdefault(task_name, []).append(child)
+    return nested
+
+
+def _load_images(record: DatasetRecord) -> dict[str, np.ndarray]:
+    images: dict[str, np.ndarray] = {}
+    for source_name, file in record.files.items():
+        if isinstance(file, np.ndarray):
+            images[source_name] = file
+            continue
+        with Image.open(file) as image:
+            images[source_name] = np.asarray(image.convert("RGB"))
+    return images
+
+
+def _instance_order(detections: Sequence[Detection]) -> list[int] | None:
+    """Return the instance IDs of the rows of a task, in row order."""
+    for task_type in _INSTANCE_TASK_TYPES:
+        instance_ids = [
+            detection.instance_id
+            for detection in detections
+            if getattr(detection, task_type) is not None
+        ]
+        if instance_ids:
+            return instance_ids
+    return None
+
+
+def _build_label(
+    task_name: str,
+    task_type: str,
+    detections: Sequence[Detection],
+    instance_order: list[int] | None,
+    schema: DatasetSchema,
+    *,
+    image_shape: tuple[int, ...],
+    keep_categorical_as_strings: bool,
+) -> np.ndarray:
+    if task_type.startswith(_METADATA_PREFIX):
+        return _build_metadata_label(
+            task_name,
+            task_type,
+            detections,
+            instance_order,
+            schema,
+            keep_categorical_as_strings=keep_categorical_as_strings,
+        )
+
+    annotations: list[Annotation] = []
+    class_ids: list[int] = []
+    for detection in detections:
+        if task_type == "classification":
+            # The class is the whole annotation, so a detection without one
+            # contributes nothing, and the rest share one annotation object.
+            annotation = (
+                _CLASSIFICATION if detection.class_name is not None else None
+            )
+        else:
+            annotation = getattr(detection, task_type, None)
+        if annotation is None:
+            continue
+        annotations.append(annotation)
+        class_ids.append(
+            0
+            if detection.class_name is None
+            else schema.class_id(task_name, detection.class_name)
+        )
+
+    if not annotations:
+        return _empty_label(task_name, task_type, schema, image_shape)
+    return annotations[0].combine_to_numpy(
+        annotations, class_ids, schema.n_classes(task_name)
+    )
+
+
+def _build_metadata_label(
+    task_name: str,
+    task_type: str,
+    detections: Sequence[Detection],
+    instance_order: list[int] | None,
+    schema: DatasetSchema,
+    *,
+    keep_categorical_as_strings: bool,
+) -> np.ndarray:
+    name = task_type[len(_METADATA_PREFIX) :]
+    rows = [
+        (detection.instance_id, detection.metadata[name])
+        for detection in detections
+        if name in detection.metadata
+    ]
+    if not rows:
+        return np.zeros(0)
+
+    values = [value for _, value in rows]
+    encoding = schema.categorical_encodings.get(f"{task_name}/{task_type}")
+    if encoding is not None and not keep_categorical_as_strings:
+        values = [encoding[str(value)] for value in values]
+    return _align_to_instances(
+        values, [instance_id for instance_id, _ in rows], instance_order
+    )
+
+
+def _align_to_instances(
+    values: Sequence[str | int | float | Category],
+    instance_ids: Sequence[int],
+    instance_order: Sequence[int] | None,
+) -> np.ndarray:
+    """Put per-instance values into the row order of their task.
+
+    ``instance_order`` holds the instance ID of each row of the task, and is
+    ``None`` when the task has no instance-shaped label to take an order
+    from. The result has one value per row, and a row whose instance carries
+    no value of this kind is filled with ``None``.
+    """
+    if instance_order is None:
+        order = sorted(range(len(values)), key=lambda i: instance_ids[i])
+        return np.array([values[i] for i in order])
+
+    free_rows: dict[int, deque[int]] = defaultdict(deque)
+    for row, instance_id in enumerate(instance_order):
+        free_rows[instance_id].append(row)
+
+    aligned: list[str | int | float | Category | None] = [None] * len(
+        instance_order
+    )
+    for value, instance_id in zip(values, instance_ids, strict=True):
+        rows = free_rows.get(instance_id)
+        if not rows:
+            # More values than rows, or an instance the task does not have.
+            # The pairing is unknown, so the values stay as they came.
+            return np.array(values)
+        aligned[rows.popleft()] = value
+
+    if any(value is None for value in aligned):
+        return np.array(aligned, dtype=object)
+    return np.array(aligned)
+
+
+def _empty_label(
+    task_name: str,
+    task_type: str,
+    schema: DatasetSchema,
+    image_shape: tuple[int, ...],
+) -> np.ndarray:
+    height, width = image_shape[0], image_shape[1]
+    if task_type == "boundingbox":
+        return np.zeros((0, 5))
+    if task_type == "keypoints":
+        return np.zeros((0, schema.n_keypoints.get(task_name, 0) * 3))
+    if task_type == "instance_segmentation":
+        return np.zeros((0, height, width))
+    if task_type == "segmentation":
+        return np.zeros((schema.n_classes(task_name), height, width))
+    if task_type == "classification":
+        return np.zeros(schema.n_classes(task_name))
+    return np.zeros(0)
+
+
+def _build_detections(
+    task_name: str,
+    task_types: Mapping[str, np.ndarray],
+    schema: DatasetSchema,
+    *,
+    keep_background: bool,
+) -> list[Detection]:
+    detections = _instance_detections(task_name, task_types, schema)
+    detections.extend(
+        _semantic_detections(
+            task_name, task_types, schema, keep_background=keep_background
+        )
+    )
+    if all(detection.class_name is None for detection in detections):
+        detections.extend(
+            _classification_detections(task_name, task_types, schema)
+        )
+    return detections
+
+
+def _instance_detections(
+    task_name: str,
+    task_types: Mapping[str, np.ndarray],
+    schema: DatasetSchema,
+) -> list[Detection]:
+    """Rebuild the detections that describe one instance each."""
+    split: dict[str, list[tuple[Annotation, int | None]]] = {}
+    for task_type in _INSTANCE_TASK_TYPES:
+        array = task_types.get(task_type)
+        if array is not None and len(array):
+            split[task_type] = _ANNOTATION_TYPES[task_type].split_from_numpy(
+                array
+            )
+
+    metadata = _split_metadata(task_name, task_types, schema)
+    n_instances = max(
+        [len(rows) for rows in split.values()] + [len(metadata)], default=0
+    )
+
+    detections = []
+    for index in range(n_instances):
+        fields: dict[str, Annotation] = {}
+        class_id: int | None = None
+        for task_type, rows in split.items():
+            if index >= len(rows):
+                continue
+            annotation, row_class_id = rows[index]
+            fields[task_type] = annotation
+            if class_id is None:
+                class_id = row_class_id
+        detections.append(
+            Detection.model_validate(
+                {
+                    "instance_id": index,
+                    "class_name": _class_name(task_name, class_id, schema),
+                    "metadata": metadata.get(index, {}),
+                    **fields,
+                }
+            )
+        )
+    return detections
+
+
+def _semantic_detections(
+    task_name: str,
+    task_types: Mapping[str, np.ndarray],
+    schema: DatasetSchema,
+    *,
+    keep_background: bool,
+) -> list[Detection]:
+    array = task_types.get("segmentation")
+    if array is None:
+        return []
+    detections = []
+    for annotation, class_id in SegmentationAnnotation.split_from_numpy(array):
+        class_name = _class_name(task_name, class_id, schema)
+        if class_name == "background" and not keep_background:
+            continue
+        detections.append(
+            Detection(class_name=class_name, segmentation=annotation)
+        )
+    return detections
+
+
+def _classification_detections(
+    task_name: str,
+    task_types: Mapping[str, np.ndarray],
+    schema: DatasetSchema,
+) -> list[Detection]:
+    """Rebuild the classes no other annotation of the task accounts for.
+
+    Every detection with a class contributes to the vector, so rebuilding it
+    beside them would double each class it already describes.
+    """
+    array = task_types.get("classification")
+    if array is None:
+        return []
+    return [
+        Detection(class_name=_class_name(task_name, class_id, schema))
+        for _, class_id in ClassificationAnnotation.split_from_numpy(array)
+    ]
+
+
+def _split_metadata(
+    task_name: str,
+    task_types: Mapping[str, np.ndarray],
+    schema: DatasetSchema,
+) -> dict[int, dict[str, int | float | str | Category]]:
+    """Return the metadata of each instance, keyed by its row index."""
+    per_instance: dict[int, dict[str, int | float | str | Category]] = (
+        defaultdict(dict)
+    )
+    for task_type, array in task_types.items():
+        if not task_type.startswith(_METADATA_PREFIX):
+            continue
+        name = task_type[len(_METADATA_PREFIX) :]
+        encoding = schema.categorical_encodings.get(f"{task_name}/{task_type}")
+        decoding = (
+            {index: value for value, index in encoding.items()}
+            if encoding is not None
+            else None
+        )
+        # An object array holds the values themselves, a numeric one holds
+        # numpy scalars, and a row with no value of this kind holds None.
+        for index, value in enumerate(np.asarray(array)):
+            item = value.item() if isinstance(value, np.generic) else value
+            if item is None:
+                continue
+            if decoding is not None and isinstance(item, (int, float)):
+                per_instance[index][name] = Category(
+                    decoding.get(int(item), str(item))
+                )
+            elif isinstance(item, (str, int, float)):
+                per_instance[index][name] = item
+            else:
+                per_instance[index][name] = str(item)
+    return dict(per_instance)
+
+
+def _class_name(
+    task_name: str, class_id: int | None, schema: DatasetSchema
+) -> str | None:
+    if class_id is None:
+        return None
+    return schema.class_name(task_name, class_id)

--- a/luxonis_ml/ldf/conversion.py
+++ b/luxonis_ml/ldf/conversion.py
@@ -103,10 +103,10 @@ def record_to_loader_output(
 
     labels: Labels = {}
     for task_name, types in task_types.items():
-        detections = sorted(
-            annotations.get(task_name, []),
-            key=lambda detection: detection.instance_id,
-        )
+        # Already in instance-ID order: `_flatten_sub_detections` sorts each
+        # task before it collects the children, so that a child keeps the
+        # row of its parent. Sorting again here would undo that.
+        detections = annotations.get(task_name, [])
         instance_order = _instance_order(detections)
         for task_type in sorted(types):
             labels[f"{task_name}/{task_type}"] = _build_label(
@@ -173,6 +173,11 @@ def _flatten_sub_detections(
 
     A sub-detection is annotated separately from its parent, so a loader sees
     ``"driver/face"`` as an ordinary task.
+
+    The parents are put in instance-ID order here, before their children are
+    collected, so a child keeps the row of its parent. Sorting each task
+    separately would not: a sub-detection carries the default instance ID, so
+    its own sort leaves it where it was written while the parent moves.
     """
     flattened: dict[str, list[Detection]] = defaultdict(list)
 
@@ -183,7 +188,9 @@ def _flatten_sub_detections(
 
     for task_name, detections in annotations.items():
         flattened.setdefault(task_name, [])
-        for detection in detections:
+        for detection in sorted(
+            detections, key=lambda detection: detection.instance_id
+        ):
             add(task_name, detection)
     return dict(flattened)
 
@@ -205,6 +212,10 @@ def _nest_sub_detections(
     for task_name in sorted(
         nested, key=lambda name: name.count("/"), reverse=True
     ):
+        if "/" not in task_name:
+            # A task at the top level. Without this the default task, whose
+            # name is empty, would claim every other task as its sub-task.
+            continue
         parent_name, _, sub_name = task_name.rpartition("/")
         if not sub_name or parent_name not in nested:
             continue
@@ -409,8 +420,11 @@ def _instance_detections(
             )
 
     metadata = _split_metadata(task_name, task_types, schema)
+    # The metadata is keyed by row index, and a row in the middle can carry
+    # no value, so the count of the keys is not the number of rows.
+    metadata_rows = [max(metadata) + 1] if metadata else []
     n_instances = max(
-        [len(rows) for rows in split.values()] + [len(metadata)], default=0
+        [len(rows) for rows in split.values()] + metadata_rows, default=0
     )
 
     detections = []
@@ -450,7 +464,14 @@ def _semantic_detections(
     detections = []
     for annotation, class_id in SegmentationAnnotation.split_from_numpy(array):
         class_name = _class_name(task_name, class_id, schema)
-        if class_name == "background" and not keep_background:
+        # Only the channel the loader added is dropped. A dataset that
+        # declares a `background` class annotated it itself, and dropping
+        # that one would delete the user's own mask.
+        if (
+            class_name == "background"
+            and task_name in schema.synthesized_background
+            and not keep_background
+        ):
             continue
         detections.append(
             Detection(class_name=class_name, segmentation=annotation)

--- a/luxonis_ml/ldf/schema.py
+++ b/luxonis_ml/ldf/schema.py
@@ -35,6 +35,11 @@ class DatasetSchema(BaseModelExtraForbid):
         categorical_encodings: Integer encodings of categorical metadata,
             keyed by the full metadata task.
         n_keypoints: Number of keypoints grouped by task name.
+        synthesized_background: Names of the tasks whose ``background`` class
+            the loader added to fill the pixels no class claimed. Only such a
+            class is dropped when a record is rebuilt. A dataset that
+            declares a ``background`` class of its own annotated it, so it is
+            data and it stays.
 
     Example:
         >>> schema = DatasetSchema(
@@ -53,6 +58,7 @@ class DatasetSchema(BaseModelExtraForbid):
     keypoint_metadata: dict[str, KeypointMetadata] = {}
     categorical_encodings: dict[str, dict[str, int]] = {}
     n_keypoints: dict[str, int] = {}
+    synthesized_background: set[str] = set()
 
     @cached_property
     def as_metadata(self) -> Params:
@@ -61,8 +67,13 @@ class DatasetSchema(BaseModelExtraForbid):
         Every sample of one dataset shares this dictionary rather than a copy
         of it, so attaching the schema costs nothing per sample. Treat it as
         read-only.
+
+        The dump is in JSON mode, because this dictionary travels in
+        `LoaderOutput.metadata` beside the record's own metadata, and a
+        consumer that writes a sample out needs plain data. Reading it back
+        with `model_validate` restores the field types.
         """
-        return self.model_dump()
+        return self.model_dump(mode="json")
 
     def class_id(self, task_name: str, class_name: str) -> int:
         """Return the ID a task assigns to a class name.

--- a/luxonis_ml/ldf/schema.py
+++ b/luxonis_ml/ldf/schema.py
@@ -1,0 +1,114 @@
+"""The dataset-level schema a single record cannot describe on its own.
+
+A record names its classes, but not the IDs a dataset assigns them, and a
+sample with no annotation names nothing at all. Converting between records and
+loader arrays therefore needs the schema of the dataset the sample came from:
+which tasks exist, which class takes which ID, how many keypoints a task has,
+and how categorical metadata is encoded.
+
+`LuxonisLoader` attaches it to every sample under the reserved
+`SCHEMA_METADATA_KEY` of `LoaderOutput.metadata`, so `LoaderOutput.to_ldf` can
+rebuild a record without being handed the dataset. It is a read-only copy:
+the dataset stays the only writer, and the write paths strip the key.
+"""
+
+from functools import cached_property
+
+from luxonis_ml.typing import BaseModelExtraForbid, Params
+
+from .annotation import KeypointMetadata
+
+__all__ = ["SCHEMA_METADATA_KEY", "DatasetSchema"]
+
+SCHEMA_METADATA_KEY = "schema"
+"""Reserved `LoaderOutput.metadata` key holding the `DatasetSchema`."""
+
+
+class DatasetSchema(BaseModelExtraForbid):
+    """Dataset-level information that a single record does not carry.
+
+    Attributes:
+        tasks: Task types grouped by task name. This is what makes a sample
+            with no annotation a negative for every task rather than for none.
+        classes: Class IDs grouped by task name and class name.
+        keypoint_metadata: Keypoint declarations grouped by task name.
+        categorical_encodings: Integer encodings of categorical metadata,
+            keyed by the full metadata task.
+        n_keypoints: Number of keypoints grouped by task name.
+
+    Example:
+        >>> schema = DatasetSchema(
+        ...     tasks={"detection": ["boundingbox", "classification"]},
+        ...     classes={"detection": {"car": 0, "truck": 1}},
+        ... )
+        >>> schema.class_id("detection", "truck")
+        1
+        >>> schema.n_classes("detection")
+        2
+
+    """
+
+    tasks: dict[str, list[str]] = {}
+    classes: dict[str, dict[str, int]] = {}
+    keypoint_metadata: dict[str, KeypointMetadata] = {}
+    categorical_encodings: dict[str, dict[str, int]] = {}
+    n_keypoints: dict[str, int] = {}
+
+    @cached_property
+    def as_metadata(self) -> Params:
+        """The schema as the plain data that travels in sample metadata.
+
+        Every sample of one dataset shares this dictionary rather than a copy
+        of it, so attaching the schema costs nothing per sample. Treat it as
+        read-only.
+        """
+        return self.model_dump()
+
+    def class_id(self, task_name: str, class_name: str) -> int:
+        """Return the ID a task assigns to a class name.
+
+        Args:
+            task_name: Task the class belongs to.
+            class_name: Name of the class.
+
+        Returns:
+            The class ID.
+
+        Raises:
+            ValueError: If the task does not define the class.
+
+        """
+        try:
+            return self.classes[task_name][class_name]
+        except KeyError:
+            raise ValueError(
+                f"Task '{task_name}' does not define the class '{class_name}'."
+            ) from None
+
+    def class_name(self, task_name: str, class_id: int) -> str | None:
+        """Return the class a task gives an ID to.
+
+        Args:
+            task_name: Task the class belongs to.
+            class_id: ID of the class.
+
+        Returns:
+            The class name, or ``None`` when the task has no such ID.
+
+        """
+        for name, id_ in self.classes.get(task_name, {}).items():
+            if id_ == class_id:
+                return name
+        return None
+
+    def n_classes(self, task_name: str) -> int:
+        """Return how many classes a task defines.
+
+        Args:
+            task_name: Task to count the classes of.
+
+        Returns:
+            The number of classes, and :math:`0` for an unknown task.
+
+        """
+        return len(self.classes.get(task_name, {}))

--- a/luxonis_ml/ldf/tasks.py
+++ b/luxonis_ml/ldf/tasks.py
@@ -1,0 +1,181 @@
+"""Task keys of the Luxonis Data Format.
+
+A label is addressed by ``"task_name/task_type"``. The task name groups the
+annotations a model consumes together, and may itself be nested when a
+detection carries sub-detections, as in ``"driver/face/keypoints"``. Metadata
+task types keep their own name, as in ``"driver/metadata/age"``.
+"""
+
+from collections.abc import Iterator
+from functools import lru_cache
+
+import numpy as np
+
+from luxonis_ml.typing import Labels, TaskType
+
+__all__ = [
+    "get_task_group",
+    "get_task_name",
+    "get_task_type",
+    "split_task",
+    "task_is_metadata",
+    "task_type_iterator",
+]
+
+
+@lru_cache
+def task_is_metadata(task: str) -> bool:
+    """Check whether a task is a metadata task.
+
+    Args:
+        task: Task to check.
+
+    Returns:
+        Whether the task is a metadata task.
+
+    Examples:
+        >>> task_is_metadata("metadata/weather")
+        True
+        >>> task_is_metadata("camera/metadata/weather")
+        True
+        >>> task_is_metadata("camera/boundingbox")
+        False
+
+    """
+    return get_task_type(task).startswith("metadata/")
+
+
+@lru_cache
+def split_task(task: str) -> tuple[str, str]:
+    """Split a task into task name and task type.
+
+    Args:
+        task: Task to split.
+
+    Returns:
+        Task name and task type.
+
+    Examples:
+        >>> split_task("detector/boundingbox")
+        ('detector', 'boundingbox')
+        >>> split_task("classification")
+        ('', 'classification')
+
+    """
+    splits = task.split("/", 1)
+    if len(splits) == 1:
+        return "", splits[0]
+    return splits[0], splits[1]
+
+
+@lru_cache
+def get_task_name(task: str) -> str:
+    """Return the task name from a task string.
+
+    Args:
+        task: Task string.
+
+    Returns:
+        Task name.
+
+    Examples:
+        >>> get_task_name("detector/boundingbox")
+        'detector'
+        >>> get_task_name("classification")
+        'classification'
+
+    """
+    return task.split("/", maxsplit=1)[0]
+
+
+@lru_cache
+def get_task_group(task: str) -> str:
+    """Return the complete task path without its task-type suffix.
+
+    Unlike `get_task_name`, this keeps every level of a nested task name, so
+    the annotations of a sub-detection group under the sub-detection rather
+    than under its parent. The leading ``"/"`` of the default task marks a
+    name that is empty on purpose, while a task with no separator at all has
+    no name to group by.
+
+    Args:
+        task: Task string, such as ``"task_name/type"``.
+
+    Returns:
+        Task name, including every level of a nested one.
+
+    Examples:
+        >>> get_task_group("detector/boundingbox")
+        'detector'
+        >>> get_task_group("driver/face/keypoints")
+        'driver/face'
+        >>> get_task_group("driver/metadata/color")
+        'driver'
+        >>> get_task_group("/segmentation")
+        ''
+
+    """
+    group = task.removesuffix(get_task_type(task)).removesuffix("/")
+    if group:
+        return group
+    return "" if task.startswith("/") else task
+
+
+@lru_cache
+def get_task_type(task: str) -> str:
+    """Return the task type from a task string.
+
+    Example:
+        >>> get_task_type("task_name/type")
+        'type'
+        >>> get_task_type("metadata/name")
+        'metadata/name'
+        >>> get_task_type("task_name/metadata/name")
+        'metadata/name'
+
+    Args:
+        task: Task string, such as ``"task_name/type"``.
+
+    Returns:
+        Task type. Metadata tasks are returned as ``"metadata/type"``.
+
+    """
+    parts = task.split("/")
+    if len(parts) == 1:
+        return parts[0]
+    if len(parts) == 2:
+        if parts[0] == "metadata":
+            return task
+        return parts[1]
+    if parts[-2] == "metadata":
+        return f"metadata/{parts[-1]}"
+    return task.rsplit("/", maxsplit=1)[-1]
+
+
+def task_type_iterator(
+    labels: Labels, task_type: TaskType
+) -> Iterator[tuple[str, np.ndarray]]:
+    """Iterate over labels of a specific task type.
+
+    Args:
+        labels: Labels to iterate over.
+        task_type: Label type to yield.
+
+    Returns:
+        Iterator over matching labels.
+
+    Examples:
+        >>> labels = {
+        ...     "detector/boundingbox": np.array([1]),
+        ...     "pose/keypoints": np.array([2]),
+        ... }
+        >>> [
+        ...     (task, arr.tolist())
+        ...     for task, arr in task_type_iterator(labels, "keypoints")
+        ... ]
+        [('pose/keypoints', [2])]
+
+    """
+    for task, array in labels.items():
+        if get_task_type(task) == task_type:
+            yield task, array

--- a/luxonis_ml/typing.py
+++ b/luxonis_ml/typing.py
@@ -12,6 +12,8 @@ from pydantic import BaseModel, ConfigDict
 if TYPE_CHECKING:  # pragma: no cover
     import numpy as np
 
+    from luxonis_ml.ldf import DatasetRecord, DatasetSchema
+
 
 PathType: TypeAlias = str | Path
 """A string or a `pathlib.Path`_ object.
@@ -145,6 +147,57 @@ class LoaderOutput(
     def image(self) -> "np.ndarray":
         """Returns the first image in the images dictionary."""
         return next(iter(self.images.values()))
+
+    def to_ldf(
+        self,
+        schema: "DatasetSchema | None" = None,
+        *,
+        keep_background: bool = False,
+    ) -> "DatasetRecord":
+        """Convert the labels back into one canonical LDF record.
+
+        Arrays that describe the same instance are paired by row index. The
+        returned record holds its images in memory, so it can be rendered and
+        inspected, but not added to a dataset.
+
+        Args:
+            schema: Schema of the dataset the sample came from. Taken from
+                `metadata` when omitted, where `LuxonisLoader` attaches it.
+            keep_background: Whether the background class of a semantic mask
+                becomes a detection of its own.
+
+        Returns:
+            One record holding every detection the labels describe.
+
+        Raises:
+            ValueError: If no schema is given and the metadata carries none.
+
+        """
+        from luxonis_ml.ldf.conversion import labels_to_record
+        from luxonis_ml.ldf.schema import SCHEMA_METADATA_KEY, DatasetSchema
+
+        if schema is None:
+            stored = self.metadata.get(SCHEMA_METADATA_KEY)
+            if stored is None:
+                raise ValueError(
+                    "Cannot rebuild a record without the dataset schema. "
+                    "Pass `schema=`; only samples from `LuxonisLoader` carry "
+                    "it already."
+                )
+            schema = DatasetSchema.model_validate(stored)
+
+        metadata = {
+            key: value
+            for key, value in self.metadata.items()
+            if key != SCHEMA_METADATA_KEY
+        }
+        return labels_to_record(
+            self.labels,
+            schema,
+            images=self.images,
+            sample_metadata=metadata,
+            keep_background=keep_background,
+        )
 
 
 RGB: TypeAlias = tuple[int, int, int]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,10 @@ wrap-summaries = 72
 wrap-descriptions = 72
 
 [tool.pyright]
+# `TypeForm` (PEP 747) names the type expression a pydantic
+# `__get_pydantic_core_schema__` hook receives. The PEP is not final, so
+# pyright reads the annotation only with this on.
+enableExperimentalFeatures = true
 pythonVersion = "3.10"
 exclude = [
   "**/node_modules",

--- a/tests/test_data/test_annotations.py
+++ b/tests/test_data/test_annotations.py
@@ -140,8 +140,8 @@ def test_dataset_record(tempdir: Path):
         ],
     )
 
-    record = DatasetRecord(
-        files={
+    record = DatasetRecord(  # type: ignore[call-arg]
+        media={  # type: ignore[call-arg]
             "left": left,
             "right": right,
         }
@@ -632,9 +632,9 @@ def test_record(tempdir: Path):
     filename = str((tempdir / "image.jpg").resolve())
     cv2.imwrite(filename, np.zeros((256, 256, 3), dtype=np.uint8))
     record = DatasetRecord(
-        file=filename,  # type: ignore
+        media=filename,  # type: ignore
         annotation=detection,
-        task_name="test",
+        task_name="test",  # type: ignore[call-arg]
     )
     common = {
         "file": filename,

--- a/tests/test_data/test_annotations.py
+++ b/tests/test_data/test_annotations.py
@@ -140,10 +140,12 @@ def test_dataset_record(tempdir: Path):
         ],
     )
 
-    record = DatasetRecord(  # type: ignore[call-arg]
-        media={  # type: ignore[call-arg]
-            "left": left,
-            "right": right,
+    record = DatasetRecord.model_validate(
+        {
+            "media": {
+                "left": left,
+                "right": right,
+            }
         }
     )
     with pytest.raises(ValueError, match="must have exactly one file"):
@@ -631,10 +633,8 @@ def test_record(tempdir: Path):
     )
     filename = str((tempdir / "image.jpg").resolve())
     cv2.imwrite(filename, np.zeros((256, 256, 3), dtype=np.uint8))
-    record = DatasetRecord(
-        media=filename,  # type: ignore
-        annotation=detection,
-        task_name="test",  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate(
+        {"media": filename, "annotation": detection, "task_name": "test"}
     )
     common = {
         "file": filename,

--- a/tests/test_data/test_annotations.py
+++ b/tests/test_data/test_annotations.py
@@ -68,7 +68,7 @@ def test_dataset_record(tempdir: Path):
     cv2.imwrite(str(left), np.zeros((100, 100, 3)))
     cv2.imwrite(str(right), np.zeros((100, 100, 3)))
     empty_metadata = {"sample_metadata": DEFAULT_METADATA}
-    record = DatasetRecord(file=left)  # type: ignore
+    record = DatasetRecord(media=left)  # type: ignore
     assert record.file == left
 
     compare_parquet_rows(
@@ -88,7 +88,7 @@ def test_dataset_record(tempdir: Path):
     )
 
     record = DatasetRecord(
-        file=left,  # type: ignore
+        media=left,  # type: ignore
         sample_metadata={"source": "camera-a"},
     )
     compare_parquet_rows(
@@ -108,7 +108,7 @@ def test_dataset_record(tempdir: Path):
     )
 
     record = DatasetRecord(
-        file=left,  # type: ignore
+        media=left,  # type: ignore
         annotation={
             "class": "person",
             "boundingbox": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},

--- a/tests/test_data/test_augmentations/test_empty.py
+++ b/tests/test_data/test_augmentations/test_empty.py
@@ -25,7 +25,7 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
             img = create_image(i, tempdir)
             if i < keep_samples:
                 yield {
-                    "file": img,
+                    "media": img,
                     "annotation": {
                         "class": ["dog", "cat"][i % 2],
                         "segmentation": {
@@ -53,7 +53,7 @@ def test_empty(dataset_name: str, tempdir: Path, n_samples: int):
                     },
                 }
             else:
-                yield {"file": img}
+                yield {"media": img}
 
     dataset = create_dataset(
         dataset_name, generator(n_samples), splits={"train": 1.0}

--- a/tests/test_data/test_augmentations/test_engine_config.py
+++ b/tests/test_data/test_augmentations/test_engine_config.py
@@ -7,6 +7,7 @@ import pytest
 from luxonis_ml.data import AlbumentationsEngine
 from luxonis_ml.data.augmentations import AugmentationEngine
 from luxonis_ml.data.augmentations.custom import TRANSFORMATIONS
+from luxonis_ml.data.utils import get_task_group
 from luxonis_ml.typing import Labels, LoaderMultiOutput
 
 Register = Callable[[type], type]
@@ -197,11 +198,11 @@ def test_a_task_with_no_separator_is_its_own_group() -> None:
     Collapsing these to ``""`` would tie a bare keypoints task to a bare
     bbox task it has nothing to do with.
     """
-    assert AlbumentationsEngine._get_task_group("boundingbox") == "boundingbox"
-    assert AlbumentationsEngine._get_task_group("keypoints") == "keypoints"
-    assert AlbumentationsEngine._get_task_group("metadata/id") == "metadata/id"
-    assert AlbumentationsEngine._get_task_group("group/boundingbox") == "group"
-    assert AlbumentationsEngine._get_task_group("a/b/keypoints") == "a/b"
+    assert get_task_group("boundingbox") == "boundingbox"
+    assert get_task_group("keypoints") == "keypoints"
+    assert get_task_group("metadata/id") == "metadata/id"
+    assert get_task_group("group/boundingbox") == "group"
+    assert get_task_group("a/b/keypoints") == "a/b"
 
 
 def test_default_task_types_share_one_group() -> None:
@@ -211,9 +212,9 @@ def test_default_task_types_share_one_group() -> None:
     so they have to land in the same group for the keypoints to be filtered
     and reordered along with the boxes.
     """
-    assert AlbumentationsEngine._get_task_group("/boundingbox") == ""
-    assert AlbumentationsEngine._get_task_group("/keypoints") == ""
-    assert AlbumentationsEngine._get_task_group("/metadata/id") == ""
+    assert get_task_group("/boundingbox") == ""
+    assert get_task_group("/keypoints") == ""
+    assert get_task_group("/metadata/id") == ""
 
 
 def test_unnamed_tasks_are_usable_end_to_end() -> None:

--- a/tests/test_data/test_classes_ordering.py
+++ b/tests/test_data/test_classes_ordering.py
@@ -35,7 +35,7 @@ def test_ordering_loader_background(tempdir: Path, subtests: SubTests):
     def generator(classes_list: list[str]) -> DatasetIterator:
         for i, class_name in enumerate(classes_list):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "annotation": {
                     "class": class_name,
                     "segmentation": segmentation,
@@ -97,11 +97,11 @@ def test_ordering_loader_no_background(tempdir: Path):
 
     def generator() -> DatasetIterator:
         yield {
-            "file": create_image(0, tempdir),
+            "media": create_image(0, tempdir),
             "annotation": {"class": "dog", "segmentation": right_seg},
         }
         yield {
-            "file": create_image(0, tempdir),
+            "media": create_image(0, tempdir),
             "annotation": {"class": "cat", "segmentation": left_seg},
         }
 
@@ -124,7 +124,7 @@ def test_ordering_dataset(
         for i, class_name in enumerate(classes):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "task_name": "ordering",
                 "annotation": {
                     "class": class_name,

--- a/tests/test_data/test_dataset.py
+++ b/tests/test_data/test_dataset.py
@@ -171,7 +171,7 @@ def test_dataset_fail(dataset_name: str, tempdir: Path):
         for i in range(10):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                 },
@@ -220,7 +220,7 @@ def test_make_splits(
         for i in range(_start_index, _start_index + step):
             path = create_image(i, tempdir)
             yield {
-                "file": str(path),
+                "media": str(path),
                 "annotation": {
                     "class": ["dog", "cat"][i % 2],
                 },
@@ -315,7 +315,7 @@ def test_metadata(
         img = create_image(0, tempdir)
         for i in range(10):
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "metadata": {
@@ -369,11 +369,11 @@ def test_no_labels(dataset_name: str, tempdir: Path, subtests: SubTests):
             if i == 0:
                 if total:
                     yield {
-                        "file": img,
+                        "media": img,
                     }
                 else:
                     yield {
-                        "file": img,
+                        "media": img,
                         "annotation": {
                             "class": "person",
                             "boundingbox": {
@@ -454,7 +454,7 @@ def test_deep_nested_labels(
     def generator() -> DatasetIterator:
         for i in range(10):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "annotation": {
                     "class": "car",
                     "boundingbox": {
@@ -544,18 +544,18 @@ def test_partial_labels(dataset_name: str, tempdir: Path):
             img = create_image(i, tempdir)
             if i < 2:
                 yield {
-                    "file": img,
+                    "media": img,
                 }
             elif i < 4:
                 yield {
-                    "file": img,
+                    "media": img,
                     "annotation": {
                         "class": "dog",
                     },
                 }
             elif i < 6:
                 yield {
-                    "file": img,
+                    "media": img,
                     "annotation": {
                         "class": "dog",
                         "boundingbox": {
@@ -571,7 +571,7 @@ def test_partial_labels(dataset_name: str, tempdir: Path):
                 }
             elif i < 8:
                 yield {
-                    "file": img,
+                    "media": img,
                     "annotation": {
                         "class": "dog",
                         "segmentation": {
@@ -605,7 +605,7 @@ def test_clone_dataset(
         for i in range(3):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -663,7 +663,7 @@ def test_merge_datasets(
         for i in range(3):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -674,7 +674,7 @@ def test_merge_datasets(
         for i in range(3, 6):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "dog",
                     "boundingbox": {"x": 0.2, "y": 0.2, "w": 0.2, "h": 0.2},
@@ -813,7 +813,7 @@ def test_merge_datasets_specific_split(
         for i in range(3):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -824,7 +824,7 @@ def test_merge_datasets_specific_split(
         for i in range(3, 6):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "dog",
                     "boundingbox": {"x": 0.2, "y": 0.2, "w": 0.2, "h": 0.2},
@@ -883,7 +883,7 @@ def test_clone_dataset_specific_split(
         for i in range(3):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -921,7 +921,7 @@ def test_classes_per_task(dataset_name: str, tempdir: Path):
     def generator() -> DatasetIterator:
         img = create_image(0, tempdir)
         yield {
-            "file": img,
+            "media": img,
             "annotation": {
                 "class": "person",
                 "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -930,7 +930,7 @@ def test_classes_per_task(dataset_name: str, tempdir: Path):
         }
         # Yield a second annotation with only an `instance_id` to check that we don't encounter the issue: "Detected new classes for task group '': []".
         yield {
-            "file": img,
+            "media": img,
             "annotation": {
                 "keypoints": {"keypoints": [[0.1, 0.1, 0], [0.2, 0.2, 1]]},
                 "instance_id": 0,
@@ -948,7 +948,7 @@ def test_keypoints_solo(dataset_name: str, tempdir: Path):
         for i in range(4):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "keypoints": {"keypoints": [[0.1, 0.1, 0], [0.2, 0.2, 1]]},
@@ -977,7 +977,7 @@ def test_loader_uses_columns_after_metadata_column_reorder(
 ):
     def generator() -> DatasetIterator:
         yield {
-            "file": create_image(0, tempdir),
+            "media": create_image(0, tempdir),
             "sample_metadata": {"record_id": 0, "origin": "column-order"},
         }
 
@@ -1005,7 +1005,7 @@ def test_load_df_offline_mixed_old_and_new_metadata_schemas(
     def generator() -> DatasetIterator:
         for i in range(2):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "sample_metadata": {"record_id": i},
             }
 
@@ -1045,7 +1045,7 @@ def test_add_to_old_schema_dataset_populates_metadata_column(
     def generator(start: int, end: int) -> DatasetIterator:
         for i in range(start, end):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "sample_metadata": {"record_id": i},
             }
 
@@ -1083,7 +1083,7 @@ def test_dataset_push_pull(
         for i in range(start, end):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -1204,7 +1204,7 @@ def test_merge_on_different_machines(dataset_name: str, tempdir: Path):
         for i in range(start, end):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -1262,7 +1262,7 @@ def create_test_dataset_with_classes(
         for i in range(5):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": list(task_classes["classification"].keys())[
                         i % len(task_classes["classification"])
@@ -1319,7 +1319,7 @@ def test_class_order_per_task_multiple_tasks(tempdir: Path):
         for i in range(5):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": list(original_classes["classification"].keys())[
                         i % 3
@@ -1331,7 +1331,7 @@ def test_class_order_per_task_multiple_tasks(tempdir: Path):
         for i in range(5, 10):
             img = create_image(i, tempdir)
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": list(original_classes["detection"].keys())[
                         (i - 5) % 3

--- a/tests/test_data/test_dataset_integration.py
+++ b/tests/test_data/test_dataset_integration.py
@@ -209,7 +209,7 @@ def generator(base_path: Path, tempdir: Path):
                         "w": w_new,
                         "h": h_new,
                     },
-                    "array": {"path": array_path},
+                    "array": {"data": array_path},
                     "keypoints": {"keypoints": item["keypoints"]},
                     "instance_segmentation": {"mask": adjusted_mask},
                     "metadata": {
@@ -227,13 +227,13 @@ def generator(base_path: Path, tempdir: Path):
 
             for annotation in annotations_list:
                 yield {
-                    "file": combined_filepath,
+                    "media": combined_filepath,
                     "task_name": annotation["class"],
                     "annotation": annotation,
                 }
             for i, color in enumerate(["red", "green", "blue"]):
                 yield {
-                    "file": combined_filepath,
+                    "media": combined_filepath,
                     "task_name": "color",
                     "annotation": {
                         "class": color,

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -111,7 +111,7 @@ def test_native_export_import_preserves_record_metadata(
     def generator() -> DatasetIterator:
         for i in range(2):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "annotation": {
                     "class": "person",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -198,6 +198,59 @@ def test_a_whole_image_export_keeps_its_classes(
     assert {"road", "sky"} <= imported_classes
 
 
+def test_native_export_does_not_invent_a_nameless_task(
+    dataset_name: str,
+    tempdir: Path,
+):
+    """A sample with no annotation names no task.
+
+    The exporter wrote ``{"": []}`` for such a row, and `LuxonisDataset.add`
+    registers every key of a record's annotation, so the re-import gained a
+    nameless task the original never had.
+    """
+
+    def generator() -> DatasetIterator:
+        yield {
+            "media": create_image(0, tempdir),
+            "annotation": {
+                "detection": [
+                    {
+                        "class": "person",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.1,
+                            "h": 0.1,
+                        },
+                    }
+                ]
+            },
+        }
+        # A true negative of `detection`, which must survive.
+        yield {
+            "media": create_image(1, tempdir),
+            "annotation": {"detection": []},
+        }
+        # No annotation at all, which must name nothing.
+        yield {"media": create_image(2, tempdir)}
+
+    dataset = create_dataset(dataset_name, generator(), splits=(1, 0, 0))
+    export_path = dataset.export(
+        tempdir / "exported", dataset_type=DatasetType.NATIVE
+    )
+    assert isinstance(export_path, Path)
+    imported_dataset = LuxonisParser(
+        str(Path(export_path) / dataset.identifier),
+        dataset_type=DatasetType.NATIVE,
+        dataset_name=f"{dataset_name}_imported",
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+
+    assert "" not in imported_dataset.get_tasks()
+    assert imported_dataset.get_tasks() == dataset.get_tasks()
+
+
 @pytest.mark.parametrize("url", ["COCO_people_subset.zip"])
 def test_export_edge_cases(
     dataset_name: str,

--- a/tests/test_data/test_export.py
+++ b/tests/test_data/test_export.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+import numpy as np
 import polars as pl
 import pytest
 from pytest_subtests import SubTests
@@ -144,6 +145,57 @@ def test_native_export_import_preserves_record_metadata(
     )
     assert [item["record_id"] for item in metadata] == [0, 1]
     assert {item["origin"] for item in metadata} == {"native-roundtrip"}
+
+
+@pytest.mark.parametrize(
+    "dataset_type",
+    [DatasetType.SEGMASK, DatasetType.CLSDIR, DatasetType.FIFTYONECLS],
+)
+def test_a_whole_image_export_keeps_its_classes(
+    dataset_name: str,
+    tempdir: Path,
+    dataset_type: DatasetType,
+):
+    """These three formats label a whole image, not one instance.
+
+    Each one selected its rows by an instance ID of :math:`-1`, which meant
+    that nobody had numbered the detection. Every detection now carries a
+    number, so the test matched nothing and the export came out empty. The
+    task type is what tells a whole-image label from an instance.
+    """
+
+    def generator() -> DatasetIterator:
+        for i in range(4):
+            mask = np.zeros((512, 512), dtype=np.uint8)
+            mask[: 256 + i] = 1
+            yield {
+                "media": create_image(i, tempdir),
+                "annotation": {
+                    "class": "road" if i % 2 else "sky",
+                    "segmentation": {"mask": mask},
+                },
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits=(1, 0, 0))
+    exported = dataset.export(
+        tempdir / f"exported_{dataset_type.value}", dataset_type=dataset_type
+    )
+    assert isinstance(exported, Path)
+
+    imported = LuxonisParser(
+        str(exported / dataset.identifier),
+        dataset_type=dataset_type,
+        dataset_name=f"{dataset_name}_imported",
+        delete_local=True,
+        save_dir=tempdir,
+    ).parse()
+
+    imported_classes = {
+        class_name
+        for task_classes in imported.get_classes().values()
+        for class_name in task_classes
+    }
+    assert {"road", "sky"} <= imported_classes
 
 
 @pytest.mark.parametrize("url", ["COCO_people_subset.zip"])

--- a/tests/test_data/test_export_ldf_version.py
+++ b/tests/test_data/test_export_ldf_version.py
@@ -35,6 +35,10 @@ LDF_2_0_RECORD_FIELDS = {"file", "files", "task_name", "annotation"}
 #: in 2.2.
 LDF_2_0_KEYPOINT_FIELDS = {"keypoints"}
 
+#: Record fields LDF 3.0 renamed. The manifest keeps the stored name,
+#: so an export never shows the new one.
+LDF_3_0_RENAMES = {"files": "media"}
+
 
 @pytest.fixture
 def warnings_log() -> Iterator[list[str]]:
@@ -121,13 +125,16 @@ def test_resolve_rejects_malformed_versions(version: str):
         resolve_export_version(version)
 
 
-@pytest.mark.parametrize("version", ["3.0", "2.9"])
+@pytest.mark.parametrize(
+    "version",
+    [str(LDF_VERSION.bump_major()), str(LDF_VERSION.bump_minor())],
+)
 def test_resolve_rejects_newer_than_installed(version: str):
     with pytest.raises(ValueError, match="at the newest"):
         resolve_export_version(version)
 
 
-@pytest.mark.parametrize("version", ["1.0", "2.0.1"])
+@pytest.mark.parametrize("version", ["1.0", "2.0.1", "2.9"])
 def test_resolve_rejects_unsupported_versions(version: str):
     with pytest.raises(ValueError, match="Supported versions"):
         resolve_export_version(version)
@@ -141,6 +148,7 @@ def test_every_record_field_has_a_known_ldf_version():
     """
     known = LDF_2_0_RECORD_FIELDS | set(_ADDED_FIELDS)
     assert set(DatasetRecord.model_fields) <= known
+    assert set(LDF_3_0_RENAMES) <= set(DatasetRecord.model_fields)
 
 
 def test_every_keypoint_field_has_a_known_ldf_version():
@@ -249,6 +257,45 @@ def test_export_2_1_keeps_sample_metadata_but_drops_the_task_fields(
         if "edges" in record.get("annotation", {}).get("keypoints", {})
     ]
     assert _read_stamp(root) == "2.1.0"
+
+
+def test_export_2_2_flattens_the_record_but_keeps_the_keypoint_fields(
+    dataset_name: str, tempdir: Path
+):
+    """LDF 2.2 is the last version that reads a flat record.
+
+    It already knows the keypoint task fields and the named keypoints, so
+    the downgrade only rebuilds the record shape. That splits the two
+    concerns, which no other target version does on its own.
+    """
+    dataset = create_dataset(
+        dataset_name, _keypoint_generator(tempdir), splits=(1, 0, 0)
+    )
+    dataset.set_keypoint_metadata(edges=[("nose", "left_eye")], task="pose")
+    root = _export(dataset, tempdir, "keypoints22", ldf_version="2.2")
+
+    records = _read_records(root)
+    assert records
+    assert _read_stamp(root) == "2.2.0"
+    assert all("sample_metadata" in record for record in records)
+    # The flat record names its task beside the annotation, and the
+    # annotation is the detection itself rather than a list of them.
+    assert all("task_name" in record for record in records)
+    assert all(
+        set(record) - {"sample_metadata"} <= LDF_2_0_RECORD_FIELDS
+        for record in records
+    )
+
+    keypoints = [
+        record["annotation"]["keypoints"]
+        for record in records
+        if "keypoints" in record.get("annotation", {})
+    ]
+    assert keypoints
+    named = [k for k in keypoints if isinstance(k["keypoints"], dict)]
+    assert len(named) == 1
+    assert set(named[0]["keypoints"]) == {"nose", "left_eye", "right_eye"}
+    assert named[0]["edges"]
 
 
 def test_an_export_without_the_task_fields_still_imports(

--- a/tests/test_data/test_health.py
+++ b/tests/test_data/test_health.py
@@ -96,7 +96,7 @@ def test_dataset_sanitize(
             img_copy_path.write_bytes(img.read_bytes())
             # Original image with annotations
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {
@@ -109,7 +109,7 @@ def test_dataset_sanitize(
             }
             # Duplicate image with same UUID
             yield {
-                "file": img_copy_path,
+                "media": img_copy_path,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {
@@ -122,7 +122,7 @@ def test_dataset_sanitize(
             }
             # Duplicate annotations
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "person",
                     "boundingbox": {

--- a/tests/test_data/test_keypoint_metadata.py
+++ b/tests/test_data/test_keypoint_metadata.py
@@ -686,9 +686,11 @@ def test_a_shorter_record_does_not_get_the_task_fields(
 
     val_path = exported / dataset_name / "val" / "annotations.json"
     assert [
-        record["annotation"]["keypoints"]
+        detection["keypoints"]
         for record in json.loads(val_path.read_text())
-        if "keypoints" in record["annotation"]
+        for detections in record["annotation"].values()
+        for detection in detections
+        if "keypoints" in detection
     ] == [{"keypoints": [[0.0, 0.0, 2], [0.1, 0.1, 2]]}]
 
 
@@ -732,10 +734,12 @@ def test_the_exported_names_are_written_once_per_task(
     counts = []
     for path in (exported / dataset_name).rglob("annotations.json"):
         keypoints = [
-            record["annotation"]["keypoints"]["keypoints"]
+            detection["keypoints"]["keypoints"]
             for record in json.loads(path.read_text())
+            for detections in record.get("annotation", {}).values()
+            for detection in detections
             # Every detection also emits a classification record.
-            if "keypoints" in record.get("annotation", {})
+            if "keypoints" in detection
         ]
         if keypoints:
             named = sum(isinstance(k, dict) for k in keypoints)

--- a/tests/test_data/test_ldf_equivalence.py
+++ b/tests/test_data/test_ldf_equivalence.py
@@ -2,11 +2,64 @@ import json
 import zipfile
 from pathlib import Path
 
+import numpy as np
 import pytest
 
-from luxonis_ml.data import LuxonisDataset, LuxonisParser, ldf_equivalent
+from luxonis_ml.data import (
+    LDFEquivalence,
+    LuxonisDataset,
+    LuxonisParser,
+    ldf_equivalent,
+)
+from luxonis_ml.data.datasets.base_dataset import DatasetIterator
+from luxonis_ml.data.exporters.exporter_utils import PreparedLDF
 from luxonis_ml.data.parsers.coco_parser import COCOParser
 from luxonis_ml.utils import LuxonisFileSystem
+
+from .utils import create_dataset, create_image
+
+
+def _whole_image_generator(tempdir: Path, class_name: str) -> DatasetIterator:
+    """Yield one class and one semantic mask for each image."""
+    for i in range(3):
+        mask = np.zeros((512, 512), dtype=np.uint8)
+        mask[: 256 + i] = 1
+        yield {
+            "media": create_image(i, tempdir),
+            "annotation": {
+                "class": class_name,
+                "segmentation": {"mask": mask},
+            },
+        }
+
+
+def test_a_changed_class_breaks_equivalence(dataset_name: str, tempdir: Path):
+    """A collector that returns nothing makes every comparison pass.
+
+    The classification and the segmentation collectors selected a row by an
+    instance ID of :math:`-1`, which meant that nobody had numbered the
+    detection. Every detection now carries a number, so both collectors
+    returned an empty multiset. Two datasets that share their images then
+    compared equal, whatever their labels said.
+    """
+    first = create_dataset(
+        f"{dataset_name}_a",
+        _whole_image_generator(tempdir, "road"),
+        splits=(1, 0, 0),
+    )
+    second = create_dataset(
+        f"{dataset_name}_b",
+        _whole_image_generator(tempdir, "river"),
+        splits=(1, 0, 0),
+    )
+
+    prepared = PreparedLDF.from_dataset(first)
+    assert LDFEquivalence.collect_classification_multiset(prepared)
+    assert LDFEquivalence.collect_segmentation_multiset(prepared)
+    assert LDFEquivalence.collect_segmentation_mask_overlap_multiset(prepared)
+
+    assert ldf_equivalent(first, first)
+    assert not ldf_equivalent(first, second)
 
 
 def _parse_dataset(

--- a/tests/test_data/test_ldf_migration.py
+++ b/tests/test_data/test_ldf_migration.py
@@ -1,0 +1,47 @@
+"""Opening a dataset written before the LDF 3.0 bump."""
+
+import json
+from pathlib import Path
+
+from semver.version import Version
+
+from luxonis_ml.data import LuxonisDataset, LuxonisLoader
+from luxonis_ml.data.datasets.base_dataset import DatasetIterator
+from luxonis_ml.data.utils.constants import LDF_VERSION
+
+from .utils import create_dataset, create_image
+
+
+def test_a_2_x_dataset_still_loads(dataset_name: str, tempdir: Path):
+    """A major bump sends every older dataset through a migration.
+
+    The only one that existed was written for LDF 1.0, and it renames
+    columns a 2.x dataset does not have. Without a version to dispatch on,
+    the bump would stop every stored dataset from opening.
+    """
+
+    def generator() -> DatasetIterator:
+        yield {
+            "media": create_image(0, tempdir),
+            "task_name": "vehicles",
+            "annotation": {
+                "class": "car",
+                "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+            },
+        }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    metadata_path = dataset._metadata_path / "metadata.json"
+    metadata = json.loads(metadata_path.read_text())
+    metadata["ldf_version"] = "2.1.0"
+    metadata_path.write_text(json.dumps(metadata))
+
+    reopened = LuxonisDataset(dataset_name)
+
+    assert reopened.version == Version.parse("2.1.0")
+    assert reopened.version.major != LDF_VERSION.major
+    assert reopened.get_classes() == {"vehicles": {"car": 0}}
+
+    labels = LuxonisLoader(reopened, view="train")[0].labels
+
+    assert labels["vehicles/boundingbox"].shape == (1, 5)

--- a/tests/test_data/test_ldf_migration.py
+++ b/tests/test_data/test_ldf_migration.py
@@ -3,8 +3,6 @@
 import json
 from pathlib import Path
 
-from semver.version import Version
-
 from luxonis_ml.data import LuxonisDataset, LuxonisLoader
 from luxonis_ml.data.datasets.base_dataset import DatasetIterator
 from luxonis_ml.data.utils.constants import LDF_VERSION
@@ -38,8 +36,10 @@ def test_a_2_x_dataset_still_loads(dataset_name: str, tempdir: Path):
 
     reopened = LuxonisDataset(dataset_name)
 
-    assert reopened.version == Version.parse("2.1.0")
-    assert reopened.version.major != LDF_VERSION.major
+    # The migration ran, so the dataset now reports the version it was
+    # migrated to. A dataset left on its old stamp would be migrated again
+    # on every open, and could never merge with one this version wrote.
+    assert reopened.version == LDF_VERSION
     assert reopened.get_classes() == {"vehicles": {"car": 0}}
 
     labels = LuxonisLoader(reopened, view="train")[0].labels

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -399,6 +399,157 @@ def test_metadata_leaves_a_gap_for_an_instance_without_a_value(
     assert labels["vehicles/metadata/color"].tolist() == [None, "blue"]
 
 
+def test_metadata_finds_its_instance_across_separate_records(
+    dataset_name: str, tempdir: Path
+):
+    """One sample is often written as one record per detection.
+
+    No record sets an instance ID, so the rows of one detection are found
+    again by the number the write path gives them. Numbering each record on
+    its own would give every detection the number zero, and the sample would
+    come back as a single instance.
+    """
+
+    def generator() -> DatasetIterator:
+        img = create_image(0, tempdir)
+        for x, metadata in zip(
+            (0.1, 0.4, 0.7), [{}, {"color": "red"}, {}], strict=True
+        ):
+            yield {
+                "media": img,
+                "task_name": "vehicles",
+                "annotation": {
+                    "class": "car",
+                    "boundingbox": {"x": x, "y": 0.1, "w": 0.1, "h": 0.1},
+                    "metadata": metadata,
+                },
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    labels = LuxonisLoader(dataset, view="train")[0].labels
+
+    assert labels["vehicles/boundingbox"].shape == (3, 5)
+    assert [round(row[1], 2) for row in labels["vehicles/boundingbox"]] == [
+        0.1,
+        0.4,
+        0.7,
+    ]
+    assert labels["vehicles/metadata/color"].tolist() == [None, "red", None]
+
+
+def test_an_empty_label_survives_augmentation(
+    dataset_name: str, tempdir: Path
+):
+    """A negative sample keeps a key for every task of the dataset.
+
+    The augmentation engine drops a label that has no rows, and puts back
+    only the ones grouped with a bounding box. A keypoints-only task has
+    none, so its key vanished and the two loading paths disagreed.
+    """
+
+    def generator() -> DatasetIterator:
+        yield {
+            "media": create_image(0, tempdir),
+            "task_name": "pose",
+            "annotation": {
+                "class": "person",
+                "keypoints": {"keypoints": [(0.2, 0.2, 2), (0.3, 0.3, 1)]},
+            },
+        }
+        yield {"media": create_image(1, tempdir), "task_name": "pose"}
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    plain = LuxonisLoader(dataset, view="train")
+    augmented = LuxonisLoader(dataset, view="train", height=64, width=64)
+
+    for i in range(len(plain)):
+        assert sorted(augmented[i].labels) == sorted(plain[i].labels)
+        assert "pose/keypoints" in augmented[i].labels
+
+    # The split decides the order, so the negative is found by its own shape
+    # rather than by an index.
+    assert sorted(
+        augmented[i].labels["pose/keypoints"].shape[0]
+        for i in range(len(augmented))
+    ) == [0, 1]
+
+
+def test_a_declared_background_class_survives_a_round_trip(
+    dataset_name: str, tempdir: Path
+):
+    """A dataset may annotate a class it calls ``background``.
+
+    The loader synthesizes a class of that name for the pixels no class
+    claims, and rebuilding a record drops it again. Only the synthesized one
+    may be dropped, or an annotated background is deleted.
+    """
+    road = np.zeros((512, 512), dtype=np.uint8)
+    road[:256] = 1
+    background = np.zeros((512, 512), dtype=np.uint8)
+    background[256:] = 1
+
+    def generator() -> DatasetIterator:
+        image = create_image(0, tempdir)
+        for class_name, mask in [("road", road), ("background", background)]:
+            yield {
+                "media": image,
+                "task_name": "scene",
+                "annotation": {
+                    "class": class_name,
+                    "segmentation": {"mask": mask},
+                },
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    sample = LuxonisLoader(dataset, view="train")[0]
+
+    assert sorted(
+        detection.class_name
+        for detection in sample.to_ldf().annotation["scene"]
+        if detection.segmentation is not None
+        and detection.class_name is not None
+    ) == ["background", "road"]
+
+
+def test_a_synthesized_background_class_is_dropped(
+    dataset_name: str, tempdir: Path
+):
+    """The loader fills the pixels no class claims.
+
+    That class is the loader's own, so a rebuilt record must not carry it.
+    """
+    road = np.zeros((512, 512), dtype=np.uint8)
+    road[:256] = 1
+    sky = np.zeros((512, 512), dtype=np.uint8)
+    sky[256:400] = 1
+
+    def generator() -> DatasetIterator:
+        image = create_image(0, tempdir)
+        for class_name, mask in [("road", road), ("sky", sky)]:
+            yield {
+                "media": image,
+                "task_name": "scene",
+                "annotation": {
+                    "class": class_name,
+                    "segmentation": {"mask": mask},
+                },
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    sample = LuxonisLoader(dataset, view="train")[0]
+
+    assert sorted(
+        detection.class_name
+        for detection in sample.to_ldf().annotation["scene"]
+        if detection.segmentation is not None
+        and detection.class_name is not None
+    ) == ["road", "sky"]
+
+
 def test_an_absent_metadata_label_has_no_rows(
     dataset_name: str, tempdir: Path
 ):

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -25,7 +25,7 @@ from luxonis_ml.typing import (
 )
 from luxonis_ml.utils import LuxonisFileSystem
 
-from .utils import create_dataset, create_image
+from .utils import create_dataset, create_image, stored_metadata
 
 AUGMENTATIONS_CONFIG: list[Params] = [  # type: ignore[reportAssignmentType]
     {
@@ -295,13 +295,224 @@ def test_filter_task_names_rejects_unknown_task(randint: int, tempdir: Path):
         LuxonisLoader(dataset, filter_task_names=["missing"])
 
 
+def _two_boxes_in_reverse_instance_order(
+    tempdir: Path, metadata: dict[str, dict[str, str]] | None = None
+) -> DatasetIterator:
+    """Yield two boxes whose instance IDs run against the yield order.
+
+    The optional metadata is keyed by class name.
+    """
+    metadata = metadata or {}
+    img = create_image(0, tempdir)
+    boxes = {
+        "car": (1, {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}),
+        "truck": (0, {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2}),
+    }
+    for class_name, (instance_id, box) in boxes.items():
+        yield {
+            "media": img,
+            "task_name": "vehicles",
+            "annotation": {
+                "instance_id": instance_id,
+                "class": class_name,
+                "boundingbox": box,
+                "metadata": metadata.get(class_name, {}),
+            },
+        }
+
+
+def test_class_ids_follow_their_annotations(dataset_name: str, tempdir: Path):
+    """Sorting annotations by instance ID has to move the class IDs too.
+
+    Only the annotations were sorted, so two boxes yielded against their
+    instance order came back labelled with each other's class.
+    """
+    dataset = create_dataset(
+        dataset_name,
+        _two_boxes_in_reverse_instance_order(tempdir),
+        splits={"train": 1.0},
+    )
+    classes = dataset.get_classes()["vehicles"]
+
+    boxes = LuxonisLoader(dataset, view="train")[0].labels[
+        "vehicles/boundingbox"
+    ]
+
+    # Instance 0 is the truck, so it takes the first row.
+    assert boxes[0].tolist() == pytest.approx(
+        [classes["truck"], 0.5, 0.5, 0.2, 0.2]
+    )
+    assert boxes[1].tolist() == pytest.approx(
+        [classes["car"], 0.1, 0.1, 0.1, 0.1]
+    )
+
+
+def test_metadata_is_aligned_to_its_instances(
+    dataset_name: str, tempdir: Path
+):
+    """A metadata value has to land on the row of its own instance.
+
+    Metadata kept the dataframe order while the boxes were sorted by
+    instance ID, so the values described the wrong objects.
+    """
+    dataset = create_dataset(
+        dataset_name,
+        _two_boxes_in_reverse_instance_order(
+            tempdir, {"car": {"color": "red"}, "truck": {"color": "blue"}}
+        ),
+        splits={"train": 1.0},
+    )
+
+    labels = LuxonisLoader(dataset, view="train")[0].labels
+
+    assert labels["vehicles/metadata/color"].tolist() == ["blue", "red"]
+
+
+def test_metadata_leaves_a_gap_for_an_instance_without_a_value(
+    dataset_name: str, tempdir: Path
+):
+    """A value only some instances carry still belongs to its own row.
+
+    The augmentation engine drops metadata rows by bounding-box index, so a
+    shorter metadata label silently shifted onto the wrong boxes.
+    """
+
+    def generator() -> DatasetIterator:
+        img = create_image(0, tempdir)
+        for instance_id, metadata in enumerate([{}, {"color": "blue"}]):
+            yield {
+                "media": img,
+                "task_name": "vehicles",
+                "annotation": {
+                    "instance_id": instance_id,
+                    "class": "car",
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
+                    "metadata": metadata,
+                },
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    labels = LuxonisLoader(dataset, view="train")[0].labels
+
+    assert labels["vehicles/boundingbox"].shape == (2, 5)
+    assert labels["vehicles/metadata/color"].tolist() == [None, "blue"]
+
+
+def test_an_absent_metadata_label_has_no_rows(
+    dataset_name: str, tempdir: Path
+):
+    """Metadata is per instance, so an absent one has no rows at all.
+
+    It was filled with one entry per class, which reads as that many
+    instances that were never there.
+    """
+
+    def generator() -> DatasetIterator:
+        yield {
+            "media": create_image(0, tempdir),
+            "task_name": "vehicles",
+            "annotation": {"class": "car", "metadata": {"color": "red"}},
+        }
+        yield {
+            "media": create_image(1, tempdir),
+            "task_name": "vehicles",
+            "annotation": {"class": "truck"},
+        }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+    loader = LuxonisLoader(dataset, view="train")
+
+    empty = [
+        sample.labels["vehicles/metadata/color"]
+        for sample in loader
+        if sample.labels["vehicles/metadata/color"].size == 0
+    ]
+
+    assert len(dataset.get_classes()["vehicles"]) == 2
+    assert len(empty) == 1
+    assert empty[0].shape == (0,)
+
+
+def test_a_sub_detection_uses_its_own_classes(
+    dataset_name: str, tempdir: Path
+):
+    """A sub-detection is its own task, with its own class list.
+
+    The task name was cut at the first ``"/"``, so ``"vehicle/plate"`` was
+    sized with the classes of ``"vehicle"``.
+    """
+
+    def generator() -> DatasetIterator:
+        for i, class_name in enumerate(("car", "truck", "bus")):
+            yield {
+                "media": create_image(i, tempdir),
+                "task_name": "vehicle",
+                "annotation": {
+                    "class": class_name,
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+                    "sub_detections": {
+                        "plate": {
+                            "class": "plate",
+                            "boundingbox": {
+                                "x": 0.2,
+                                "y": 0.2,
+                                "w": 0.1,
+                                "h": 0.1,
+                            },
+                        }
+                    },
+                },
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    labels = LuxonisLoader(dataset, view="train")[0].labels
+
+    assert len(dataset.get_classes()["vehicle"]) == 3
+    assert labels["vehicle/classification"].shape == (3,)
+    assert labels["vehicle/plate/classification"].shape == (1,)
+
+
+def test_a_true_negative_survives_a_task_filter(
+    dataset_name: str, tempdir: Path
+):
+    """A sample with no annotation is a negative for every task.
+
+    Its row carries the task name of the record that wrote it, so the task
+    filter dropped the sample instead of keeping it as a negative.
+    """
+
+    def generator() -> DatasetIterator:
+        yield {
+            "media": create_image(0, tempdir),
+            "task_name": "vehicles",
+            "annotation": {
+                "class": "car",
+                "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+            },
+        }
+        yield {"media": create_image(1, tempdir)}
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    loader = LuxonisLoader(
+        dataset, view="train", filter_task_names=["vehicles"]
+    )
+
+    assert len(loader) == 2
+    assert sorted(
+        sample.labels["vehicles/boundingbox"].shape[0] for sample in loader
+    ) == [0, 1]
+
+
 def test_loader_passes_is_validation_pipeline_to_legacy_engines(
     dataset_name: str, tempdir: Path
 ):
     def generator() -> DatasetIterator:
         img = create_image(0, tempdir)
         yield {
-            "file": img,
+            "media": img,
             "annotation": {
                 "class": "person",
                 "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
@@ -346,7 +557,7 @@ def test_loader_records_augmentations_in_sample_metadata(
         autopopulate_metadata=False,
     )
 
-    metadata = loader[0].metadata
+    metadata = stored_metadata(loader[0])
 
     assert isinstance(metadata["augmentations"], TrackedAugmentations)
     assert metadata == {
@@ -385,7 +596,7 @@ def test_loader_keeps_stored_metadata_over_the_reserved_augmentations_key(
     )
 
     with pytest.warns(UserWarning, match="reserved 'augmentations' key"):
-        metadata = loader[0].metadata
+        metadata = stored_metadata(loader[0])
 
     assert metadata == {
         "augmentations": {"user_pipeline": {"run_id": 42}},
@@ -414,7 +625,7 @@ def test_loader_warns_when_stored_metadata_hides_the_filenames_key(
     loader = LuxonisLoader(dataset, height=512, width=512)
 
     with pytest.warns(UserWarning, match="reserved 'filenames' key"):
-        metadata = loader[0].metadata
+        metadata = stored_metadata(loader[0])
 
     assert metadata == {"filenames": "stored-value", "augmentations": {}}
 
@@ -525,7 +736,7 @@ def test_loader_merges_metadata_only_for_applied_batch_augmentations(
         augmentation_config=[{"name": "MixUp", "params": {"p": probability}}],
     )
 
-    metadata = loader[0].metadata
+    metadata = stored_metadata(loader[0])
 
     assert ("batch_augmentation_metadata" in metadata) is metadata_is_merged
     if metadata_is_merged:
@@ -1065,3 +1276,57 @@ def test_colorspace(storage_url: str, tempdir: Path):
     gray_img, _ = cast(LoaderSingleOutput, next(iter(loader)))
     assert len(gray_img.shape) == 3
     assert gray_img.shape[2] == 1
+
+
+def test_a_loaded_sample_rebuilds_into_a_record(
+    dataset_name: str, tempdir: Path
+):
+    """The arrays carry enough to rebuild the record they came from.
+
+    The sub-detections are stored as tasks of their own, so this also
+    covers putting them back under the detection they belong to.
+    """
+
+    def generator() -> DatasetIterator:
+        img = create_image(0, tempdir)
+        for instance_id, (class_name, mood) in enumerate(
+            [("person", "happy"), ("person", "sad")]
+        ):
+            yield {
+                "media": img,
+                "task_name": "driver",
+                "annotation": {
+                    "instance_id": instance_id,
+                    "class": class_name,
+                    "boundingbox": {
+                        "x": 0.1 * instance_id,
+                        "y": 0.1,
+                        "w": 0.1,
+                        "h": 0.1,
+                    },
+                    "sub_detections": {
+                        "face": {
+                            "instance_id": instance_id,
+                            "class": mood,
+                            "boundingbox": {
+                                "x": 0.1 * instance_id,
+                                "y": 0.5,
+                                "w": 0.1,
+                                "h": 0.1,
+                            },
+                        }
+                    },
+                },
+            }
+
+    dataset = create_dataset(dataset_name, generator(), splits={"train": 1.0})
+
+    record = LuxonisLoader(dataset, view="train")[0].to_ldf()
+
+    assert set(record.annotation) == {"driver"}
+    drivers = record.annotation["driver"]
+    assert [driver.class_name for driver in drivers] == ["person", "person"]
+    assert [
+        driver.sub_detections["face"].class_name for driver in drivers
+    ] == ["happy", "sad"]
+    assert isinstance(record.file, np.ndarray)

--- a/tests/test_data/test_loader.py
+++ b/tests/test_data/test_loader.py
@@ -225,12 +225,12 @@ def _create_filter_task_names_dataset(
     def generator() -> DatasetIterator:
         img = create_image(0, tempdir)
         yield {
-            "file": img,
+            "media": img,
             "task_name": "animals",
             "annotation": {"class": "cat"},
         }
         yield {
-            "file": img,
+            "media": img,
             "task_name": "vehicles",
             "annotation": {
                 "class": "car",
@@ -240,7 +240,7 @@ def _create_filter_task_names_dataset(
 
         img = create_image(1, tempdir)
         yield {
-            "file": img,
+            "media": img,
             "task_name": "animals",
             "annotation": {
                 "class": "dog",
@@ -248,7 +248,7 @@ def _create_filter_task_names_dataset(
             },
         }
         yield {
-            "file": img,
+            "media": img,
             "task_name": "vehicles",
             "annotation": {
                 "class": "truck",
@@ -332,7 +332,7 @@ def test_loader_records_augmentations_in_sample_metadata(
     def generator() -> DatasetIterator:
         img = create_image(0, tempdir)
         yield {
-            "file": img,
+            "media": img,
             "sample_metadata": {"record_id": "sample-1"},
             "annotation": {"class": "person"},
         }
@@ -367,7 +367,7 @@ def test_loader_keeps_stored_metadata_over_the_reserved_augmentations_key(
     def generator() -> DatasetIterator:
         img = create_image(0, tempdir)
         yield {
-            "file": img,
+            "media": img,
             "sample_metadata": {
                 "augmentations": {"user_pipeline": {"run_id": 42}},
                 "record_id": "sample-1",
@@ -405,7 +405,7 @@ def test_loader_warns_when_stored_metadata_hides_the_filenames_key(
     def generator() -> DatasetIterator:
         img = create_image(0, tempdir)
         yield {
-            "file": img,
+            "media": img,
             "sample_metadata": {"filenames": "stored-value"},
             "annotation": {"class": "person"},
         }
@@ -425,7 +425,7 @@ def test_loader_preserves_metadata_for_custom_batch_engines(
     def generator() -> DatasetIterator:
         for i in range(2):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "sample_metadata": {"record_id": i},
             }
 
@@ -461,7 +461,7 @@ def test_loader_uses_metadata_from_custom_engine_single_contributor(
     def generator() -> DatasetIterator:
         for i in range(2):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "sample_metadata": {"record_id": i},
             }
 
@@ -511,7 +511,7 @@ def test_loader_merges_metadata_only_for_applied_batch_augmentations(
     def generator() -> DatasetIterator:
         for i in range(2):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "sample_metadata": {"record_id": i},
             }
 
@@ -574,7 +574,7 @@ def test_loader_tracks_metadata_through_multiple_batch_augmentations(
     def generator() -> DatasetIterator:
         for i in range(8):
             yield {
-                "file": create_image(i, tempdir),
+                "media": create_image(i, tempdir),
                 "sample_metadata": {"record_id": i},
             }
 
@@ -822,7 +822,7 @@ def test_edge_cases(tempdir: Path):
             ]
 
             yield {
-                "file": img,
+                "media": img,
                 "annotation": {
                     "class": "dog",
                     "boundingbox": {

--- a/tests/test_data/test_multi_input.py
+++ b/tests/test_data/test_multi_input.py
@@ -16,7 +16,7 @@ def test_multi_input(dataset_name: str, tempdir: Path):
             img2 = create_image(i + 4, tempdir)
             img3 = create_image(i + 8, tempdir)
             yield {
-                "files": {
+                "media": {
                     "image1": img1,
                     "image2": img2,
                     "image3": img3,

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -47,7 +47,7 @@ def test_native_parser_accepts_windows_style_file_paths(tempdir: Path):
 
     parsed_record = next(iter(generator))
     parsed_file = (
-        parsed_record["file"]
+        parsed_record["media"]
         if isinstance(parsed_record, dict)
         else parsed_record.file
     )
@@ -86,7 +86,9 @@ def test_yolov4_parser_keeps_unlabeled_image_with_duplicate_basename(
     records = list(generator)
     files = {
         Path(
-            record["file"] if isinstance(record, dict) else record.file
+            record["media"]
+            if isinstance(record, dict)
+            else next(iter(record.file_paths.values()))
         ).resolve()
         for record in records
     }
@@ -133,7 +135,7 @@ def test_native_parser_resolves_array_annotation_paths(tempdir: Path):
 
     record = next(iter(generator))
     assert isinstance(record, dict)
-    assert record["annotation"]["array"]["path"] == array_path.resolve()
+    assert record["annotation"]["array"]["data"] == array_path.resolve()
 
 
 def test_native_parser_resolves_paths_for_a_list_of_annotations(

--- a/tests/test_data/test_native_paths.py
+++ b/tests/test_data/test_native_paths.py
@@ -55,6 +55,59 @@ def test_native_parser_accepts_windows_style_file_paths(tempdir: Path):
     assert added_images == [copied_image.resolve()]
 
 
+def test_native_parser_resolves_paths_in_a_task_keyed_manifest(
+    tempdir: Path,
+):
+    """A manifest groups its detections by task name.
+
+    That is the shape an export writes, so the companion mask path inside
+    it has to be resolved. Only the deprecated flat shapes were, and the
+    record then failed to validate against the process directory.
+    """
+    image_path = create_image(0, tempdir)
+    split_dir = tempdir / "train"
+    image_dir = split_dir / "images"
+    mask_dir = split_dir / "masks"
+    image_dir.mkdir(parents=True)
+    mask_dir.mkdir(parents=True)
+    copied_image = image_dir / image_path.name
+    copied_image.write_bytes(image_path.read_bytes())
+    mask_path = mask_dir / "0.png"
+    mask_path.write_bytes(image_path.read_bytes())
+
+    annotations_path = split_dir / "annotations.json"
+    annotations_path.write_text(
+        json.dumps(
+            [
+                {
+                    "media": f"images/{image_path.name}",
+                    "annotation": {
+                        "seg": [
+                            {
+                                "class": "class0",
+                                "segmentation": {"mask": "masks/0.png"},
+                            }
+                        ]
+                    },
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    generator, _, _ = NativeParser(
+        dataset=None,  # type: ignore[arg-type]
+        dataset_type=DatasetType.NATIVE,
+        task_name=None,
+    ).from_split(annotation_path=annotations_path)
+
+    parsed_record = next(iter(generator))
+    assert isinstance(parsed_record, dict)
+    resolved = parsed_record["annotation"]["seg"][0]["segmentation"]["mask"]
+    assert Path(resolved) == mask_path.resolve()
+
+
 def test_yolov4_parser_keeps_unlabeled_image_with_duplicate_basename(
     tempdir: Path,
 ):

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -9,6 +9,7 @@ from pydantic import SecretStr
 
 from luxonis_ml.data import (
     BaseDataset,
+    DatasetIterator,
     LuxonisDataset,
     LuxonisLoader,
     LuxonisParser,
@@ -1204,7 +1205,7 @@ def test_task_names_group_a_record_by_class(dataset_name: str, tempdir: Path):
     )
     image = create_image(0, tempdir)
 
-    def generator() -> Iterator[dict[str, Any]]:
+    def generator() -> DatasetIterator:
         yield {
             "file": image,
             "annotation": [
@@ -1227,7 +1228,7 @@ def test_task_names_reject_an_unknown_class(dataset_name: str, tempdir: Path):
     parser = native_parser(dataset_name, {"car": "vehicles"})
     image = create_image(0, tempdir)
 
-    def generator() -> Iterator[dict[str, Any]]:
+    def generator() -> DatasetIterator:
         yield {"file": image, "annotation": [{"class": "bicycle"}]}
 
     with pytest.raises(ValueError, match="not found in task names"):
@@ -1242,7 +1243,7 @@ def test_an_unlabeled_record_is_yielded_for_every_task(
     )
     image = create_image(0, tempdir)
 
-    def generator() -> Iterator[dict[str, Any]]:
+    def generator() -> DatasetIterator:
         yield {"file": image}
 
     records = list(parser._wrap_generator(generator()))

--- a/tests/test_data/test_parsers.py
+++ b/tests/test_data/test_parsers.py
@@ -16,8 +16,10 @@ from luxonis_ml.data import (
 )
 from luxonis_ml.data.parsers import SOLOParser, luxonis_parser
 from luxonis_ml.data.parsers.base_parser import BaseParser, ParserOutput
+from luxonis_ml.data.parsers.native_parser import NativeParser
 from luxonis_ml.data.utils import get_task_type
 from luxonis_ml.enums import DatasetType
+from luxonis_ml.ldf import DatasetRecord
 from luxonis_ml.utils import environ
 
 from .utils import create_image
@@ -1178,3 +1180,76 @@ def test_ultralytics_version_selects_an_export(
 
     assert ultralytics_requests[0]["params"] == {"v": 3}
     assert destination == tempdir / "warehouse.v3.ndjson"
+
+
+def native_parser(
+    dataset_name: str, task_name: dict[str, str]
+) -> NativeParser:
+    return NativeParser(
+        dataset=LuxonisDataset(dataset_name, delete_local=True),
+        dataset_type=DatasetType.NATIVE,
+        task_name=task_name,
+    )
+
+
+def test_task_names_group_a_record_by_class(dataset_name: str, tempdir: Path):
+    """A record's detections split across the tasks their classes name.
+
+    A record used to carry one detection, so the parser could set a single
+    task name on it. Now the detections of one record can belong to
+    different tasks, and each has to land in its own group.
+    """
+    parser = native_parser(
+        dataset_name, {"car": "vehicles", "rain": "weather"}
+    )
+    image = create_image(0, tempdir)
+
+    def generator() -> Iterator[dict[str, Any]]:
+        yield {
+            "file": image,
+            "annotation": [
+                {"class": "car"},
+                {"class": "rain"},
+                {"boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1}},
+            ],
+        }
+
+    (record,) = list(parser._wrap_generator(generator()))
+
+    assert isinstance(record, DatasetRecord)
+    assert {
+        task_name: [detection.class_name for detection in detections]
+        for task_name, detections in record.annotation.items()
+    } == {"vehicles": ["car"], "weather": ["rain"], "": [None]}
+
+
+def test_task_names_reject_an_unknown_class(dataset_name: str, tempdir: Path):
+    parser = native_parser(dataset_name, {"car": "vehicles"})
+    image = create_image(0, tempdir)
+
+    def generator() -> Iterator[dict[str, Any]]:
+        yield {"file": image, "annotation": [{"class": "bicycle"}]}
+
+    with pytest.raises(ValueError, match="not found in task names"):
+        list(parser._wrap_generator(generator()))
+
+
+def test_an_unlabeled_record_is_yielded_for_every_task(
+    dataset_name: str, tempdir: Path
+):
+    parser = native_parser(
+        dataset_name, {"car": "vehicles", "rain": "weather"}
+    )
+    image = create_image(0, tempdir)
+
+    def generator() -> Iterator[dict[str, Any]]:
+        yield {"file": image}
+
+    records = list(parser._wrap_generator(generator()))
+
+    assert sorted(
+        task_name
+        for record in records
+        if isinstance(record, DatasetRecord)
+        for task_name in record.annotation
+    ) == ["vehicles", "weather"]

--- a/tests/test_data/test_task_ingestion.py
+++ b/tests/test_data/test_task_ingestion.py
@@ -42,7 +42,7 @@ def test_task_ingestion(
         for i in range(STEP):
             path = create_image(i, tempdir)
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "animals",
                 "annotation": {
                     "class": "dog",
@@ -50,7 +50,7 @@ def test_task_ingestion(
                 },
             }
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "animals",
                 "annotation": {
                     "class": "cat",
@@ -58,7 +58,7 @@ def test_task_ingestion(
                 },
             }
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "landmass",
                 "annotation": {
                     "class": "water",
@@ -76,7 +76,7 @@ def test_task_ingestion(
                 },
             }
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "landmass",
                 "annotation": {
                     "class": "grass",
@@ -101,14 +101,14 @@ def test_task_ingestion(
         for i in range(STEP, 2 * STEP):
             path = create_image(i, tempdir)
             yield {
-                "file": str(path),
+                "media": str(path),
                 "annotation": {
                     "class": "dog",
                     "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
                 },
             }
             yield {
-                "file": str(path),
+                "media": str(path),
                 "annotation": {
                     "class": "cat",
                     "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.1, "h": 0.3},
@@ -129,7 +129,7 @@ def test_task_ingestion(
         for i in range(2 * STEP, 3 * STEP):
             path = create_image(i, tempdir)
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "animals",
                 "annotation": {
                     "class": "dog",
@@ -137,7 +137,7 @@ def test_task_ingestion(
                 },
             }
             yield {
-                "file": str(path),
+                "media": str(path),
                 "annotation": {
                     "class": "water",
                     "segmentation": {
@@ -167,7 +167,7 @@ def test_task_ingestion(
         for i in range(3 * STEP, 4 * STEP):
             path = create_image(i, tempdir)
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "detection",
                 "annotation": {
                     "class": "bike",
@@ -175,7 +175,7 @@ def test_task_ingestion(
                 },
             }
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "segmentation",
                 "annotation": {
                     "class": "body",
@@ -192,7 +192,7 @@ def test_task_ingestion(
                 },
             }
             yield {
-                "file": str(path),
+                "media": str(path),
                 "task_name": "landmass-2",
                 "annotation": {
                     "class": "water",

--- a/tests/test_data/test_task_ingestion.py
+++ b/tests/test_data/test_task_ingestion.py
@@ -225,3 +225,51 @@ def test_task_ingestion(
         "detection": STEP,
         "segmentation": STEP,
     }
+
+
+def test_a_negative_keeps_the_stored_task_types(
+    dataset_name: str, tempdir: Path
+):
+    """A later `add` that carries only a negative declares its task.
+
+    The task then arrives with no task type, and the types the first `add`
+    stored have to survive it.
+    """
+    dataset = LuxonisDataset(dataset_name, delete_local=True)
+    dataset.add(
+        iter(
+            [
+                {
+                    "media": str(create_image(0, tempdir)),
+                    "task_name": "vehicles",
+                    "annotation": {
+                        "class": "car",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.1,
+                            "h": 0.1,
+                        },
+                    },
+                }
+            ]
+        )
+    )
+    assert dataset.get_tasks() == {
+        "vehicles": ["boundingbox", "classification"]
+    }
+
+    dataset.add(
+        iter(
+            [
+                {
+                    "media": str(create_image(1, tempdir)),
+                    "task_name": "vehicles",
+                }
+            ]
+        )
+    )
+
+    assert dataset.get_tasks() == {
+        "vehicles": ["boundingbox", "classification"]
+    }

--- a/tests/test_data/utils.py
+++ b/tests/test_data/utils.py
@@ -7,6 +7,8 @@ from luxonis_ml.data import LuxonisLoader
 from luxonis_ml.data.datasets.base_dataset import DatasetIterator
 from luxonis_ml.data.datasets.luxonis_dataset import LuxonisDataset
 from luxonis_ml.data.utils.enums import BucketStorage
+from luxonis_ml.ldf import SCHEMA_METADATA_KEY
+from luxonis_ml.typing import LoaderOutput, Params
 
 
 def gather_tasks(dataset: LuxonisDataset) -> set[str]:
@@ -57,3 +59,12 @@ def create_dataset(
     elif splits:
         dataset.make_splits(splits)
     return dataset
+
+
+def stored_metadata(sample: LoaderOutput) -> Params:
+    """Return a sample's metadata without the schema every sample carries."""
+    return {
+        key: value
+        for key, value in sample.metadata.items()
+        if key != SCHEMA_METADATA_KEY
+    }

--- a/tests/test_ldf/test_backward_compat.py
+++ b/tests/test_ldf/test_backward_compat.py
@@ -13,8 +13,15 @@ LDF_CLASS_REFERENCE = re.compile(r"luxonis_ml\.ldf\.([A-Z]\w*)")
 
 
 def test_annotation_module_reexports_everything():
-    assert annotation.__all__ == ldf.__all__
-    for name in ldf.__all__:
+    """The shim mirrors the module it stands in for, plus `ParquetRecord`.
+
+    The package exports more than the annotation module defines, such as the
+    dataset schema, and those names never lived under the old path.
+    """
+    assert set(annotation.__all__) == set(ldf.annotation.__all__) | {
+        "ParquetRecord"
+    }
+    for name in annotation.__all__:
         assert getattr(annotation, name) is getattr(ldf, name)
 
 

--- a/tests/test_ldf/test_media.py
+++ b/tests/test_ldf/test_media.py
@@ -64,6 +64,8 @@ def test_an_in_memory_image_cannot_be_stored():
 
     with pytest.raises(NotImplementedError, match="in-memory image"):
         _ = record.file_paths
+    with pytest.raises(NotImplementedError, match="in-memory image"):
+        list(record.to_parquet_rows())
 
 
 def test_an_array_annotation_takes_a_path(array: Path):

--- a/tests/test_ldf/test_media.py
+++ b/tests/test_ldf/test_media.py
@@ -1,0 +1,104 @@
+"""Media and array annotations take a path or the data itself."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from luxonis_ml.ldf import ArrayAnnotation, DatasetRecord
+
+
+@pytest.fixture
+def image(tempdir: Path) -> Path:
+    path = tempdir / "image.png"
+    path.touch()
+    return path
+
+
+@pytest.fixture
+def array(tempdir: Path) -> Path:
+    path = tempdir / "array.npy"
+    np.save(path, np.zeros(4))
+    return path
+
+
+def test_media_takes_one_file(image: Path):
+    record = DatasetRecord(media=image)  # type: ignore[call-arg]
+
+    assert record.files == {"image": image.absolute()}
+
+
+def test_media_takes_a_mapping_of_sources(tempdir: Path):
+    rgb = tempdir / "rgb.png"
+    depth = tempdir / "depth.png"
+    for path in (rgb, depth):
+        path.touch()
+
+    record = DatasetRecord(media={"rgb": rgb, "depth": depth})  # type: ignore[call-arg]
+
+    assert set(record.files) == {"rgb", "depth"}
+
+
+def test_the_deprecated_names_still_work(image: Path):
+    from_file = DatasetRecord(file=image)  # type: ignore[call-arg]
+    from_files = DatasetRecord(files={"image": image})
+
+    assert from_file.files == from_files.files == {"image": image.absolute()}
+
+
+def test_two_media_names_are_rejected(image: Path):
+    with pytest.raises(ValidationError, match="not both"):
+        DatasetRecord(media=image, file=image)  # type: ignore[call-arg]
+
+
+def test_a_record_may_hold_the_image_itself():
+    record = DatasetRecord(media=np.zeros((4, 4, 3), dtype=np.uint8))  # type: ignore[call-arg]
+
+    assert isinstance(record.file, np.ndarray)
+
+
+def test_an_in_memory_image_cannot_be_stored():
+    record = DatasetRecord(media={"rgb": np.zeros((4, 4, 3), dtype=np.uint8)})  # type: ignore[call-arg]
+
+    with pytest.raises(NotImplementedError, match="in-memory image"):
+        _ = record.file_paths
+
+
+def test_an_array_annotation_takes_a_path(array: Path):
+    annotation = ArrayAnnotation(data=array)  # type: ignore[call-arg]
+
+    assert annotation.to_numpy().tolist() == [0, 0, 0, 0]
+    # Parsed rather than compared as text: JSON escapes the backslashes of a
+    # Windows path, so the raw string differs per platform.
+    assert json.loads(annotation.model_dump_json()) == {"path": str(array)}
+
+
+def test_an_array_annotation_takes_the_data_itself():
+    annotation = ArrayAnnotation(data=np.ones(3))  # type: ignore[call-arg]
+
+    assert annotation.to_numpy().tolist() == [1, 1, 1]
+
+
+def test_an_in_memory_array_cannot_be_serialized():
+    annotation = ArrayAnnotation(data=np.ones(3))  # type: ignore[call-arg]
+
+    with pytest.raises(ValueError, match="Cannot serialize"):
+        annotation.model_dump_json()
+
+
+def test_the_deprecated_array_path_still_works(array: Path):
+    assert ArrayAnnotation(path=array).to_numpy().tolist() == [0, 0, 0, 0]
+
+
+def test_both_array_names_are_rejected(array: Path):
+    with pytest.raises(ValidationError, match="not both"):
+        ArrayAnnotation(path=array, data=array)  # type: ignore[call-arg]
+
+
+def test_a_malformed_media_value_names_the_source():
+    with pytest.raises(ValidationError) as error:
+        DatasetRecord(media={"image": 5})  # type: ignore[call-arg]
+
+    assert error.value.errors()[0]["loc"] == ("files", "image")

--- a/tests/test_ldf/test_media.py
+++ b/tests/test_ldf/test_media.py
@@ -25,7 +25,7 @@ def array(tempdir: Path) -> Path:
 
 
 def test_media_takes_one_file(image: Path):
-    record = DatasetRecord(media=image)  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate({"media": image})
 
     assert record.files == {"image": image.absolute()}
 
@@ -36,13 +36,15 @@ def test_media_takes_a_mapping_of_sources(tempdir: Path):
     for path in (rgb, depth):
         path.touch()
 
-    record = DatasetRecord(media={"rgb": rgb, "depth": depth})  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate(
+        {"media": {"rgb": rgb, "depth": depth}}
+    )
 
     assert set(record.files) == {"rgb", "depth"}
 
 
 def test_the_deprecated_names_still_work(image: Path):
-    from_file = DatasetRecord(file=image)  # type: ignore[call-arg]
+    from_file = DatasetRecord.model_validate({"file": image})
     from_files = DatasetRecord(files={"image": image})
 
     assert from_file.files == from_files.files == {"image": image.absolute()}
@@ -50,17 +52,21 @@ def test_the_deprecated_names_still_work(image: Path):
 
 def test_two_media_names_are_rejected(image: Path):
     with pytest.raises(ValidationError, match="not both"):
-        DatasetRecord(media=image, file=image)  # type: ignore[call-arg]
+        DatasetRecord.model_validate({"media": image, "file": image})
 
 
 def test_a_record_may_hold_the_image_itself():
-    record = DatasetRecord(media=np.zeros((4, 4, 3), dtype=np.uint8))  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate(
+        {"media": np.zeros((4, 4, 3), dtype=np.uint8)}
+    )
 
     assert isinstance(record.file, np.ndarray)
 
 
 def test_an_in_memory_image_cannot_be_stored():
-    record = DatasetRecord(media={"rgb": np.zeros((4, 4, 3), dtype=np.uint8)})  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate(
+        {"media": {"rgb": np.zeros((4, 4, 3), dtype=np.uint8)}}
+    )
 
     with pytest.raises(NotImplementedError, match="in-memory image"):
         _ = record.file_paths
@@ -69,7 +75,7 @@ def test_an_in_memory_image_cannot_be_stored():
 
 
 def test_an_array_annotation_takes_a_path(array: Path):
-    annotation = ArrayAnnotation(data=array)  # type: ignore[call-arg]
+    annotation = ArrayAnnotation.model_validate({"data": array})
 
     assert annotation.to_numpy().tolist() == [0, 0, 0, 0]
     # Parsed rather than compared as text: JSON escapes the backslashes of a
@@ -78,13 +84,13 @@ def test_an_array_annotation_takes_a_path(array: Path):
 
 
 def test_an_array_annotation_takes_the_data_itself():
-    annotation = ArrayAnnotation(data=np.ones(3))  # type: ignore[call-arg]
+    annotation = ArrayAnnotation.model_validate({"data": np.ones(3)})
 
     assert annotation.to_numpy().tolist() == [1, 1, 1]
 
 
 def test_an_in_memory_array_cannot_be_serialized():
-    annotation = ArrayAnnotation(data=np.ones(3))  # type: ignore[call-arg]
+    annotation = ArrayAnnotation.model_validate({"data": np.ones(3)})
 
     with pytest.raises(ValueError, match="Cannot serialize"):
         annotation.model_dump_json()
@@ -96,11 +102,11 @@ def test_the_deprecated_array_path_still_works(array: Path):
 
 def test_both_array_names_are_rejected(array: Path):
     with pytest.raises(ValidationError, match="not both"):
-        ArrayAnnotation(path=array, data=array)  # type: ignore[call-arg]
+        ArrayAnnotation.model_validate({"path": array, "data": array})
 
 
 def test_a_malformed_media_value_names_the_source():
     with pytest.raises(ValidationError) as error:
-        DatasetRecord(media={"image": 5})  # type: ignore[call-arg]
+        DatasetRecord.model_validate({"media": {"image": 5}})
 
     assert error.value.errors()[0]["loc"] == ("files", "image")

--- a/tests/test_ldf/test_record_tasks.py
+++ b/tests/test_ldf/test_record_tasks.py
@@ -33,23 +33,30 @@ def rows(record: DatasetRecord) -> list[tuple[str, str | None, str | None]]:
 
 
 def test_a_bare_detection_lands_in_the_default_task(image: Path):
-    record = DatasetRecord(media=image, annotation=CAR)  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate({"media": image, "annotation": CAR})
 
     assert set(record.annotation) == {""}
     assert record.annotation[""][0].class_name == "car"
 
 
 def test_a_detection_and_a_one_item_list_agree(image: Path):
-    single = DatasetRecord(media=image, annotation=CAR)  # type: ignore[call-arg]
-    listed = DatasetRecord(media=image, annotation=[CAR])  # type: ignore[call-arg]
+    single = DatasetRecord.model_validate({"media": image, "annotation": CAR})
+    listed = DatasetRecord.model_validate(
+        {"media": image, "annotation": [CAR]}
+    )
 
     assert list(single.to_parquet_rows()) == list(listed.to_parquet_rows())
 
 
 def test_detections_are_grouped_by_task(image: Path):
-    record = DatasetRecord(
-        media=image,  # type: ignore[call-arg]
-        annotation={"vehicles": [CAR, TRUCK], "weather": [{"class": "rain"}]},
+    record = DatasetRecord.model_validate(
+        {
+            "media": image,
+            "annotation": {
+                "vehicles": [CAR, TRUCK],
+                "weather": [{"class": "rain"}],
+            },
+        }
     )
 
     assert rows(record) == [
@@ -62,10 +69,8 @@ def test_detections_are_grouped_by_task(image: Path):
 
 
 def test_the_deprecated_task_name_becomes_the_mapping_key(image: Path):
-    record = DatasetRecord(
-        media=image,  # type: ignore[call-arg]
-        task_name="vehicles",  # type: ignore[call-arg]
-        annotation=[CAR],
+    record = DatasetRecord.model_validate(
+        {"media": image, "task_name": "vehicles", "annotation": [CAR]}
     )
 
     assert set(record.annotation) == {"vehicles"}
@@ -77,17 +82,18 @@ def test_the_deprecated_task_name_becomes_the_mapping_key(image: Path):
 
 def test_a_task_name_beside_a_mapping_has_to_match(image: Path):
     with pytest.raises(ValidationError, match="does not match the tasks"):
-        DatasetRecord(
-            media=image,  # type: ignore[call-arg]
-            task_name="weather",  # type: ignore[call-arg]
-            annotation={"vehicles": [CAR]},
+        DatasetRecord.model_validate(
+            {
+                "media": image,
+                "task_name": "weather",
+                "annotation": {"vehicles": [CAR]},
+            }
         )
 
 
 def test_a_task_name_without_detections_declares_the_task(image: Path):
-    record = DatasetRecord(  # type: ignore[call-arg]
-        media=image,  # type: ignore[call-arg]
-        task_name="vehicles",  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate(
+        {"media": image, "task_name": "vehicles"}
     )
 
     assert record.annotation == {"vehicles": []}
@@ -95,16 +101,15 @@ def test_a_task_name_without_detections_declares_the_task(image: Path):
 
 
 def test_a_record_without_an_annotation_declares_nothing(image: Path):
-    record = DatasetRecord(media=image)  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate({"media": image})
 
     assert record.annotation == {}
     assert rows(record) == [("", None, None)]
 
 
 def test_task_names_may_name_a_sub_detection(image: Path):
-    record = DatasetRecord(
-        media=image,  # type: ignore[call-arg]
-        annotation={"driver/face": [{"class": "face"}]},
+    record = DatasetRecord.model_validate(
+        {"media": image, "annotation": {"driver/face": [{"class": "face"}]}}
     )
 
     assert rows(record) == [("driver/face", "classification", "face")]
@@ -112,16 +117,20 @@ def test_task_names_may_name_a_sub_detection(image: Path):
 
 def test_an_empty_part_of_a_task_name_is_rejected(image: Path):
     with pytest.raises(ValidationError, match="empty part"):
-        DatasetRecord(
-            media=image,  # type: ignore[call-arg]
-            annotation={"driver//face": [{"class": "face"}]},
+        DatasetRecord.model_validate(
+            {
+                "media": image,
+                "annotation": {"driver//face": [{"class": "face"}]},
+            }
         )
 
 
 def test_the_task_name_property_needs_a_single_task(image: Path):
-    record = DatasetRecord(
-        media=image,  # type: ignore[call-arg]
-        annotation={"vehicles": [CAR], "weather": [{"class": "rain"}]},
+    record = DatasetRecord.model_validate(
+        {
+            "media": image,
+            "annotation": {"vehicles": [CAR], "weather": [{"class": "rain"}]},
+        }
     )
 
     with pytest.raises(ValueError, match="no single task name"):
@@ -139,16 +148,18 @@ def test_every_secondary_source_gets_exactly_one_empty_row(tempdir: Path):
     for path in (rgb, depth):
         path.touch()
 
-    record = DatasetRecord(  # type: ignore[call-arg]
-        media={"rgb": rgb, "depth": depth},  # type: ignore[call-arg]
-        annotation={
-            "driver": [
-                Detection(
-                    class_name="person",
-                    sub_detections={"face": Detection(class_name="face")},
-                )
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": {"rgb": rgb, "depth": depth},
+            "annotation": {
+                "driver": [
+                    Detection(
+                        class_name="person",
+                        sub_detections={"face": Detection(class_name="face")},
+                    )
+                ]
+            },
+        }
     )
 
     emitted = [
@@ -164,16 +175,18 @@ def test_every_secondary_source_gets_exactly_one_empty_row(tempdir: Path):
 
 
 def test_detections_keep_their_own_sub_detections(image: Path):
-    record = DatasetRecord(
-        media=image,  # type: ignore[call-arg]
-        annotation={
-            "driver": [
-                Detection(
-                    class_name="person",
-                    sub_detections={"face": Detection(class_name="face")},
-                )
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": image,
+            "annotation": {
+                "driver": [
+                    Detection(
+                        class_name="person",
+                        sub_detections={"face": Detection(class_name="face")},
+                    )
+                ]
+            },
+        }
     )
 
     assert rows(record) == [

--- a/tests/test_ldf/test_record_tasks.py
+++ b/tests/test_ldf/test_record_tasks.py
@@ -1,0 +1,182 @@
+"""A record groups its detections by task name."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from luxonis_ml.ldf import DatasetRecord, Detection
+
+CAR = {
+    "class": "car",
+    "boundingbox": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
+}
+TRUCK = {
+    "class": "truck",
+    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+}
+
+
+@pytest.fixture
+def image(tempdir: Path) -> Path:
+    path = tempdir / "image.png"
+    path.touch()
+    return path
+
+
+def rows(record: DatasetRecord) -> list[tuple[str, str | None, str | None]]:
+    """Return the task name, task type and class of each parquet row."""
+    return [
+        (row["task_name"], row["task_type"], row["class_name"])
+        for row in record.to_parquet_rows()
+    ]
+
+
+def test_a_bare_detection_lands_in_the_default_task(image: Path):
+    record = DatasetRecord(media=image, annotation=CAR)  # type: ignore[call-arg]
+
+    assert set(record.annotation) == {""}
+    assert record.annotation[""][0].class_name == "car"
+
+
+def test_a_detection_and_a_one_item_list_agree(image: Path):
+    single = DatasetRecord(media=image, annotation=CAR)  # type: ignore[call-arg]
+    listed = DatasetRecord(media=image, annotation=[CAR])  # type: ignore[call-arg]
+
+    assert list(single.to_parquet_rows()) == list(listed.to_parquet_rows())
+
+
+def test_detections_are_grouped_by_task(image: Path):
+    record = DatasetRecord(
+        media=image,  # type: ignore[call-arg]
+        annotation={"vehicles": [CAR, TRUCK], "weather": [{"class": "rain"}]},
+    )
+
+    assert rows(record) == [
+        ("vehicles", "boundingbox", "car"),
+        ("vehicles", "classification", "car"),
+        ("vehicles", "boundingbox", "truck"),
+        ("vehicles", "classification", "truck"),
+        ("weather", "classification", "rain"),
+    ]
+
+
+def test_the_deprecated_task_name_becomes_the_mapping_key(image: Path):
+    record = DatasetRecord(
+        media=image,  # type: ignore[call-arg]
+        task_name="vehicles",  # type: ignore[call-arg]
+        annotation=[CAR],
+    )
+
+    assert set(record.annotation) == {"vehicles"}
+    assert rows(record) == [
+        ("vehicles", "boundingbox", "car"),
+        ("vehicles", "classification", "car"),
+    ]
+
+
+def test_a_task_name_beside_a_mapping_has_to_match(image: Path):
+    with pytest.raises(ValidationError, match="does not match the tasks"):
+        DatasetRecord(
+            media=image,  # type: ignore[call-arg]
+            task_name="weather",  # type: ignore[call-arg]
+            annotation={"vehicles": [CAR]},
+        )
+
+
+def test_a_task_name_without_detections_declares_the_task(image: Path):
+    record = DatasetRecord(  # type: ignore[call-arg]
+        media=image,  # type: ignore[call-arg]
+        task_name="vehicles",  # type: ignore[call-arg]
+    )
+
+    assert record.annotation == {"vehicles": []}
+    assert rows(record) == [("vehicles", None, None)]
+
+
+def test_a_record_without_an_annotation_declares_nothing(image: Path):
+    record = DatasetRecord(media=image)  # type: ignore[call-arg]
+
+    assert record.annotation == {}
+    assert rows(record) == [("", None, None)]
+
+
+def test_task_names_may_name_a_sub_detection(image: Path):
+    record = DatasetRecord(
+        media=image,  # type: ignore[call-arg]
+        annotation={"driver/face": [{"class": "face"}]},
+    )
+
+    assert rows(record) == [("driver/face", "classification", "face")]
+
+
+def test_an_empty_part_of_a_task_name_is_rejected(image: Path):
+    with pytest.raises(ValidationError, match="empty part"):
+        DatasetRecord(
+            media=image,  # type: ignore[call-arg]
+            annotation={"driver//face": [{"class": "face"}]},
+        )
+
+
+def test_the_task_name_property_needs_a_single_task(image: Path):
+    record = DatasetRecord(
+        media=image,  # type: ignore[call-arg]
+        annotation={"vehicles": [CAR], "weather": [{"class": "rain"}]},
+    )
+
+    with pytest.raises(ValueError, match="no single task name"):
+        _ = record.task_name
+
+
+def test_every_secondary_source_gets_exactly_one_empty_row(tempdir: Path):
+    """A sub-detection must not add a row to the other sources.
+
+    The rows were emitted once per detection level, so a nested detection
+    repeated the empty row of every secondary source.
+    """
+    rgb = tempdir / "rgb.png"
+    depth = tempdir / "depth.png"
+    for path in (rgb, depth):
+        path.touch()
+
+    record = DatasetRecord(  # type: ignore[call-arg]
+        media={"rgb": rgb, "depth": depth},  # type: ignore[call-arg]
+        annotation={
+            "driver": [
+                Detection(
+                    class_name="person",
+                    sub_detections={"face": Detection(class_name="face")},
+                )
+            ]
+        },
+    )
+
+    emitted = [
+        (row["source_name"], row["task_name"], row["task_type"])
+        for row in record.to_parquet_rows()
+    ]
+
+    # The main source is the first file in path order, so the other one
+    # carries the single empty row.
+    empty = [row for row in emitted if row[2] is None]
+    assert len(empty) == 1
+    assert empty[0][1] == "driver"
+
+
+def test_detections_keep_their_own_sub_detections(image: Path):
+    record = DatasetRecord(
+        media=image,  # type: ignore[call-arg]
+        annotation={
+            "driver": [
+                Detection(
+                    class_name="person",
+                    sub_detections={"face": Detection(class_name="face")},
+                )
+            ]
+        },
+    )
+
+    assert rows(record) == [
+        ("driver", "classification", "person"),
+        ("driver/face", "classification", "face"),
+    ]

--- a/tests/test_ldf/test_round_trip.py
+++ b/tests/test_ldf/test_round_trip.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from luxonis_ml.ldf import Category, DatasetRecord, DatasetSchema
+from luxonis_ml.ldf.conversion import labels_to_record
 
 IMAGE = np.zeros((8, 8, 3), dtype=np.uint8)
 
@@ -377,3 +378,188 @@ def test_rebuilding_without_a_schema_is_refused():
 
     with pytest.raises(ValueError, match="without the dataset schema"):
         sample.to_ldf()
+
+
+def test_sub_detections_follow_their_parent_out_of_order():
+    """The parents sort by instance ID; their faces must move with them.
+
+    A sub-detection carries no instance ID of its own, so sorting the faces
+    on their own leaves them in the order they were written while the
+    parents move.
+    """
+    schema = DatasetSchema(
+        tasks={
+            "driver": ["boundingbox", "classification"],
+            "driver/face": ["boundingbox", "classification"],
+        },
+        classes={
+            "driver": {"person": 0},
+            "driver/face": {"happy": 0, "sad": 1},
+        },
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "driver": [
+                {
+                    "class": "person",
+                    "instance_id": 1,
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
+                    "sub_detections": {
+                        "face": {
+                            "class": "sad",
+                            "boundingbox": {
+                                "x": 0.15,
+                                "y": 0.2,
+                                "w": 0.05,
+                                "h": 0.05,
+                            },
+                        }
+                    },
+                },
+                {
+                    "class": "person",
+                    "instance_id": 0,
+                    "boundingbox": {"x": 0.6, "y": 0.1, "w": 0.1, "h": 0.1},
+                    "sub_detections": {
+                        "face": {
+                            "class": "happy",
+                            "boundingbox": {
+                                "x": 0.65,
+                                "y": 0.2,
+                                "w": 0.05,
+                                "h": 0.05,
+                            },
+                        }
+                    },
+                },
+            ]
+        },
+    )
+
+    drivers = roundtrip(record, schema).annotation["driver"]
+
+    faces = {
+        round(driver.boundingbox.x, 3): (  # type: ignore[union-attr]
+            driver.sub_detections["face"].class_name,
+            round(driver.sub_detections["face"].boundingbox.x, 3),  # type: ignore[union-attr]
+        )
+        for driver in drivers
+    }
+    assert faces == {0.1: ("sad", 0.15), 0.6: ("happy", 0.65)}
+
+
+def test_a_class_the_schema_does_not_define_is_refused():
+    """An array numbers its classes, so the schema has to know them all."""
+    schema = DatasetSchema(
+        tasks={"vehicles": ["boundingbox", "classification"]},
+        classes={"vehicles": {"car": 0}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "vehicles": [
+                {
+                    "class": "van",
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
+                }
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="does not define the class 'van'"):
+        record.to_loader_output(schema)
+
+
+def test_a_class_id_the_schema_does_not_know_rebuilds_without_a_name():
+    """A rebuild must not invent a name for an ID the schema lacks."""
+    schema = DatasetSchema(
+        tasks={"v": ["boundingbox", "classification"]},
+        classes={"v": {"car": 0}},
+    )
+
+    record = labels_to_record(
+        {"v/boundingbox": np.array([[7, 0.1, 0.2, 0.3, 0.4]])}, schema
+    )
+
+    (detection,) = record.annotation["v"]
+    assert detection.class_name is None
+    assert detection.boundingbox is not None
+    assert detection.boundingbox.x == pytest.approx(0.1)
+
+
+def test_a_sub_task_without_a_parent_keeps_its_own_name():
+    """Nothing may be dropped when the parent task has no detections."""
+    schema = DatasetSchema(
+        tasks={"driver/face": ["boundingbox", "classification"]},
+        classes={"driver/face": {"happy": 0}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "driver/face": [
+                {
+                    "class": "happy",
+                    "boundingbox": {"x": 0.3, "y": 0.1, "w": 0.1, "h": 0.1},
+                }
+            ]
+        },
+    )
+
+    rebuilt = roundtrip(record, schema)
+
+    assert set(rebuilt.annotation) == {"driver/face"}
+    (face,) = rebuilt.annotation["driver/face"]
+    assert face.boundingbox is not None
+    assert face.boundingbox.x == pytest.approx(0.3)
+
+
+def test_a_sub_detection_without_a_parent_is_not_dropped():
+    """More children than parents: the extra one keeps its own task."""
+    schema = DatasetSchema(
+        tasks={
+            "driver": ["boundingbox"],
+            "driver/face": ["boundingbox"],
+        },
+        classes={"driver": {"person": 0}, "driver/face": {"happy": 0}},
+    )
+
+    record = labels_to_record(
+        {
+            "driver/boundingbox": np.array([[0, 0.1, 0.1, 0.1, 0.1]]),
+            "driver/face/boundingbox": np.array(
+                [[0, 0.2, 0.2, 0.1, 0.1], [0, 0.6, 0.6, 0.1, 0.1]]
+            ),
+        },
+        schema,
+    )
+
+    assert len(record.annotation["driver"]) == 1
+    assert list(record.annotation["driver"][0].sub_detections) == ["face"]
+    assert len(record.annotation["driver/face"]) == 1
+
+
+def test_a_named_task_is_not_nested_under_the_default_task():
+    """The default task is named ``""``, and every name ends with it.
+
+    A rebuild that splits a task name on its last ``"/"`` reads ``"vehicles"``
+    as the ``"vehicles"`` sub-detection of the default task, and the named
+    task disappears.
+    """
+    schema = DatasetSchema(
+        tasks={"": ["classification"], "vehicles": ["classification"]},
+        classes={"": {"scene": 0}, "vehicles": {"car": 0}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "": [{"class": "scene"}],
+            "vehicles": [{"class": "car"}],
+        },
+    )
+
+    rebuilt = roundtrip(record, schema)
+
+    assert set(rebuilt.annotation) == {"", "vehicles"}
+    assert rebuilt.annotation["vehicles"][0].class_name == "car"
+    assert rebuilt.annotation[""][0].sub_detections == {}

--- a/tests/test_ldf/test_round_trip.py
+++ b/tests/test_ldf/test_round_trip.py
@@ -23,20 +23,32 @@ def test_boxes_keep_their_class_and_coordinates():
         tasks={"vehicles": ["boundingbox", "classification"]},
         classes={"vehicles": {"car": 0, "truck": 1}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "vehicles": [
-                {
-                    "class": "truck",
-                    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
-                },
-                {
-                    "class": "car",
-                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
-                },
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "vehicles": [
+                    {
+                        "class": "truck",
+                        "boundingbox": {
+                            "x": 0.5,
+                            "y": 0.5,
+                            "w": 0.2,
+                            "h": 0.2,
+                        },
+                    },
+                    {
+                        "class": "car",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.2,
+                            "h": 0.2,
+                        },
+                    },
+                ]
+            },
+        }
     )
 
     rebuilt = roundtrip(record, schema)
@@ -59,17 +71,26 @@ def test_keypoints_take_the_class_of_their_instance():
         classes={"pose": {"person": 0}},
         n_keypoints={"pose": 2},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "pose": [
-                {
-                    "class": "person",
-                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
-                    "keypoints": {"keypoints": [(0.2, 0.2, 2), (0.3, 0.3, 1)]},
-                }
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "pose": [
+                    {
+                        "class": "person",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.5,
+                            "h": 0.5,
+                        },
+                        "keypoints": {
+                            "keypoints": [(0.2, 0.2, 2), (0.3, 0.3, 1)]
+                        },
+                    }
+                ]
+            },
+        }
     )
 
     (detection,) = roundtrip(record, schema).annotation["pose"]
@@ -89,11 +110,13 @@ def test_semantic_masks_keep_one_detection_per_class():
         tasks={"scene": ["segmentation", "classification"]},
         classes={"scene": {"road": 0, "sky": 1}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "scene": [{"class": "road", "segmentation": {"mask": mask}}]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "scene": [{"class": "road", "segmentation": {"mask": mask}}]
+            },
+        }
     )
 
     (detection,) = roundtrip(record, schema).annotation["scene"]
@@ -112,17 +135,24 @@ def test_instance_masks_pair_with_their_box():
         },
         classes={"cars": {"car": 0}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "cars": [
-                {
-                    "class": "car",
-                    "boundingbox": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.3},
-                    "instance_segmentation": {"mask": mask},
-                }
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "cars": [
+                    {
+                        "class": "car",
+                        "boundingbox": {
+                            "x": 0.2,
+                            "y": 0.2,
+                            "w": 0.3,
+                            "h": 0.3,
+                        },
+                        "instance_segmentation": {"mask": mask},
+                    }
+                ]
+            },
+        }
     )
 
     (detection,) = roundtrip(record, schema).annotation["cars"]
@@ -140,11 +170,15 @@ def test_arrays_keep_their_data(tempdir: Path):
         tasks={"embeddings": ["array", "classification"]},
         classes={"embeddings": {"vector": 0}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "embeddings": [{"class": "vector", "array": {"data": array_path}}]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "embeddings": [
+                    {"class": "vector", "array": {"data": array_path}}
+                ]
+            },
+        }
     )
 
     (detection,) = roundtrip(record, schema).annotation["embeddings"]
@@ -169,22 +203,34 @@ def test_metadata_stays_with_its_own_instance():
             "vehicles/metadata/color": {"red": 0, "blue": 1}
         },
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "vehicles": [
-                {
-                    "class": "car",
-                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
-                    "metadata": {"color": Category("blue"), "wheels": 4},
-                },
-                {
-                    "class": "car",
-                    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
-                    "metadata": {"color": Category("red"), "wheels": 6},
-                },
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "vehicles": [
+                    {
+                        "class": "car",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.2,
+                            "h": 0.2,
+                        },
+                        "metadata": {"color": Category("blue"), "wheels": 4},
+                    },
+                    {
+                        "class": "car",
+                        "boundingbox": {
+                            "x": 0.5,
+                            "y": 0.5,
+                            "w": 0.2,
+                            "h": 0.2,
+                        },
+                        "metadata": {"color": Category("red"), "wheels": 6},
+                    },
+                ]
+            },
+        }
     )
 
     detections = roundtrip(record, schema).annotation["vehicles"]
@@ -198,7 +244,7 @@ def test_a_true_negative_stays_empty():
         tasks={"vehicles": ["boundingbox", "classification"]},
         classes={"vehicles": {"car": 0}},
     )
-    record = DatasetRecord(media=IMAGE)  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate({"media": IMAGE})
 
     rebuilt = roundtrip(record, schema)
 
@@ -216,27 +262,34 @@ def test_a_sub_detection_comes_back_nested():
             "driver/face": {"face": 0},
         },
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "driver": [
-                {
-                    "class": "person",
-                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
-                    "sub_detections": {
-                        "face": {
-                            "class": "face",
-                            "boundingbox": {
-                                "x": 0.2,
-                                "y": 0.2,
-                                "w": 0.1,
-                                "h": 0.1,
-                            },
-                        }
-                    },
-                }
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "driver": [
+                    {
+                        "class": "person",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.5,
+                            "h": 0.5,
+                        },
+                        "sub_detections": {
+                            "face": {
+                                "class": "face",
+                                "boundingbox": {
+                                    "x": 0.2,
+                                    "y": 0.2,
+                                    "w": 0.1,
+                                    "h": 0.1,
+                                },
+                            }
+                        },
+                    }
+                ]
+            },
+        }
     )
 
     rebuilt = roundtrip(record, schema)
@@ -263,28 +316,35 @@ def test_two_levels_of_sub_detections_come_back_nested():
             "vehicle/plate/text": {"CO": 0},
         },
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "vehicle": [
-                {
-                    "class": "car",
-                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
-                    "sub_detections": {
-                        "plate": {
-                            "class": "plate",
-                            "boundingbox": {
-                                "x": 0.2,
-                                "y": 0.2,
-                                "w": 0.1,
-                                "h": 0.1,
-                            },
-                            "sub_detections": {"text": {"class": "CO"}},
-                        }
-                    },
-                }
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "vehicle": [
+                    {
+                        "class": "car",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.5,
+                            "h": 0.5,
+                        },
+                        "sub_detections": {
+                            "plate": {
+                                "class": "plate",
+                                "boundingbox": {
+                                    "x": 0.2,
+                                    "y": 0.2,
+                                    "w": 0.1,
+                                    "h": 0.1,
+                                },
+                                "sub_detections": {"text": {"class": "CO"}},
+                            }
+                        },
+                    }
+                ]
+            },
+        }
     )
 
     rebuilt = roundtrip(record, schema)
@@ -307,35 +367,37 @@ def test_every_parent_keeps_its_own_sub_detection():
             "driver/face": {"happy": 0, "sad": 1},
         },
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "driver": [
-                {
-                    "class": "person",
-                    "instance_id": index,
-                    "boundingbox": {
-                        "x": 0.1 * index,
-                        "y": 0.1,
-                        "w": 0.1,
-                        "h": 0.1,
-                    },
-                    "sub_detections": {
-                        "face": {
-                            "class": mood,
-                            "instance_id": index,
-                            "boundingbox": {
-                                "x": 0.1 * index,
-                                "y": 0.5,
-                                "w": 0.1,
-                                "h": 0.1,
-                            },
-                        }
-                    },
-                }
-                for index, mood in enumerate(["happy", "sad", "happy"])
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "driver": [
+                    {
+                        "class": "person",
+                        "instance_id": index,
+                        "boundingbox": {
+                            "x": 0.1 * index,
+                            "y": 0.1,
+                            "w": 0.1,
+                            "h": 0.1,
+                        },
+                        "sub_detections": {
+                            "face": {
+                                "class": mood,
+                                "instance_id": index,
+                                "boundingbox": {
+                                    "x": 0.1 * index,
+                                    "y": 0.5,
+                                    "w": 0.1,
+                                    "h": 0.1,
+                                },
+                            }
+                        },
+                    }
+                    for index, mood in enumerate(["happy", "sad", "happy"])
+                ]
+            },
+        }
     )
 
     drivers = roundtrip(record, schema).annotation["driver"]
@@ -354,10 +416,12 @@ def test_the_schema_travels_with_the_sample():
         tasks={"vehicles": ["classification"]},
         classes={"vehicles": {"car": 0}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={"vehicles": [{"class": "car"}]},
-        sample_metadata={"camera": "left"},
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {"vehicles": [{"class": "car"}]},
+            "sample_metadata": {"camera": "left"},
+        }
     )
 
     sample = record.to_loader_output(schema)
@@ -369,9 +433,8 @@ def test_the_schema_travels_with_the_sample():
 
 def test_rebuilding_without_a_schema_is_refused():
     schema = DatasetSchema(classes={"": {"car": 0}})
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={"": [{"class": "car"}]},
+    record = DatasetRecord.model_validate(
+        {"media": IMAGE, "annotation": {"": [{"class": "car"}]}}
     )
     sample = record.to_loader_output(schema)
     sample.metadata.clear()
@@ -397,44 +460,56 @@ def test_sub_detections_follow_their_parent_out_of_order():
             "driver/face": {"happy": 0, "sad": 1},
         },
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "driver": [
-                {
-                    "class": "person",
-                    "instance_id": 1,
-                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
-                    "sub_detections": {
-                        "face": {
-                            "class": "sad",
-                            "boundingbox": {
-                                "x": 0.15,
-                                "y": 0.2,
-                                "w": 0.05,
-                                "h": 0.05,
-                            },
-                        }
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "driver": [
+                    {
+                        "class": "person",
+                        "instance_id": 1,
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.1,
+                            "h": 0.1,
+                        },
+                        "sub_detections": {
+                            "face": {
+                                "class": "sad",
+                                "boundingbox": {
+                                    "x": 0.15,
+                                    "y": 0.2,
+                                    "w": 0.05,
+                                    "h": 0.05,
+                                },
+                            }
+                        },
                     },
-                },
-                {
-                    "class": "person",
-                    "instance_id": 0,
-                    "boundingbox": {"x": 0.6, "y": 0.1, "w": 0.1, "h": 0.1},
-                    "sub_detections": {
-                        "face": {
-                            "class": "happy",
-                            "boundingbox": {
-                                "x": 0.65,
-                                "y": 0.2,
-                                "w": 0.05,
-                                "h": 0.05,
-                            },
-                        }
+                    {
+                        "class": "person",
+                        "instance_id": 0,
+                        "boundingbox": {
+                            "x": 0.6,
+                            "y": 0.1,
+                            "w": 0.1,
+                            "h": 0.1,
+                        },
+                        "sub_detections": {
+                            "face": {
+                                "class": "happy",
+                                "boundingbox": {
+                                    "x": 0.65,
+                                    "y": 0.2,
+                                    "w": 0.05,
+                                    "h": 0.05,
+                                },
+                            }
+                        },
                     },
-                },
-            ]
-        },
+                ]
+            },
+        }
     )
 
     drivers = roundtrip(record, schema).annotation["driver"]
@@ -455,16 +530,23 @@ def test_a_class_the_schema_does_not_define_is_refused():
         tasks={"vehicles": ["boundingbox", "classification"]},
         classes={"vehicles": {"car": 0}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "vehicles": [
-                {
-                    "class": "van",
-                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.1, "h": 0.1},
-                }
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "vehicles": [
+                    {
+                        "class": "van",
+                        "boundingbox": {
+                            "x": 0.1,
+                            "y": 0.1,
+                            "w": 0.1,
+                            "h": 0.1,
+                        },
+                    }
+                ]
+            },
+        }
     )
 
     with pytest.raises(ValueError, match="does not define the class 'van'"):
@@ -494,16 +576,23 @@ def test_a_sub_task_without_a_parent_keeps_its_own_name():
         tasks={"driver/face": ["boundingbox", "classification"]},
         classes={"driver/face": {"happy": 0}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "driver/face": [
-                {
-                    "class": "happy",
-                    "boundingbox": {"x": 0.3, "y": 0.1, "w": 0.1, "h": 0.1},
-                }
-            ]
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "driver/face": [
+                    {
+                        "class": "happy",
+                        "boundingbox": {
+                            "x": 0.3,
+                            "y": 0.1,
+                            "w": 0.1,
+                            "h": 0.1,
+                        },
+                    }
+                ]
+            },
+        }
     )
 
     rebuilt = roundtrip(record, schema)
@@ -550,12 +639,14 @@ def test_a_named_task_is_not_nested_under_the_default_task():
         tasks={"": ["classification"], "vehicles": ["classification"]},
         classes={"": {"scene": 0}, "vehicles": {"car": 0}},
     )
-    record = DatasetRecord(
-        media=IMAGE,  # type: ignore[call-arg]
-        annotation={
-            "": [{"class": "scene"}],
-            "vehicles": [{"class": "car"}],
-        },
+    record = DatasetRecord.model_validate(
+        {
+            "media": IMAGE,
+            "annotation": {
+                "": [{"class": "scene"}],
+                "vehicles": [{"class": "car"}],
+            },
+        }
     )
 
     rebuilt = roundtrip(record, schema)

--- a/tests/test_ldf/test_round_trip.py
+++ b/tests/test_ldf/test_round_trip.py
@@ -1,0 +1,379 @@
+"""A record survives a trip through the arrays a loader returns."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from luxonis_ml.ldf import Category, DatasetRecord, DatasetSchema
+
+IMAGE = np.zeros((8, 8, 3), dtype=np.uint8)
+
+
+def roundtrip(
+    record: DatasetRecord, schema: DatasetSchema, **kwargs
+) -> DatasetRecord:
+    """Convert a record to loader arrays and back."""
+    return record.to_loader_output(schema, **kwargs).to_ldf()
+
+
+def test_boxes_keep_their_class_and_coordinates():
+    schema = DatasetSchema(
+        tasks={"vehicles": ["boundingbox", "classification"]},
+        classes={"vehicles": {"car": 0, "truck": 1}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "vehicles": [
+                {
+                    "class": "truck",
+                    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+                },
+                {
+                    "class": "car",
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+                },
+            ]
+        },
+    )
+
+    rebuilt = roundtrip(record, schema)
+
+    detections = rebuilt.annotation["vehicles"]
+    assert [detection.class_name for detection in detections] == [
+        "truck",
+        "car",
+    ]
+    assert (
+        detections[0].boundingbox
+        == record.annotation["vehicles"][0].boundingbox
+    )
+
+
+def test_keypoints_take_the_class_of_their_instance():
+    """A keypoint row carries no class, so its box has to supply one."""
+    schema = DatasetSchema(
+        tasks={"pose": ["boundingbox", "keypoints", "classification"]},
+        classes={"pose": {"person": 0}},
+        n_keypoints={"pose": 2},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "pose": [
+                {
+                    "class": "person",
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                    "keypoints": {"keypoints": [(0.2, 0.2, 2), (0.3, 0.3, 1)]},
+                }
+            ]
+        },
+    )
+
+    (detection,) = roundtrip(record, schema).annotation["pose"]
+
+    assert detection.class_name == "person"
+    assert detection.keypoints is not None
+    assert list(detection.keypoints.keypoints.values()) == [
+        (0.2, 0.2, 2),
+        (0.3, 0.3, 1),
+    ]
+
+
+def test_semantic_masks_keep_one_detection_per_class():
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[0:4] = 1
+    schema = DatasetSchema(
+        tasks={"scene": ["segmentation", "classification"]},
+        classes={"scene": {"road": 0, "sky": 1}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "scene": [{"class": "road", "segmentation": {"mask": mask}}]
+        },
+    )
+
+    (detection,) = roundtrip(record, schema).annotation["scene"]
+
+    assert detection.class_name == "road"
+    assert detection.segmentation is not None
+    assert np.array_equal(detection.segmentation.to_numpy(), mask)
+
+
+def test_instance_masks_pair_with_their_box():
+    mask = np.zeros((8, 8), dtype=np.uint8)
+    mask[2:5, 2:5] = 1
+    schema = DatasetSchema(
+        tasks={
+            "cars": ["boundingbox", "instance_segmentation", "classification"]
+        },
+        classes={"cars": {"car": 0}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "cars": [
+                {
+                    "class": "car",
+                    "boundingbox": {"x": 0.2, "y": 0.2, "w": 0.3, "h": 0.3},
+                    "instance_segmentation": {"mask": mask},
+                }
+            ]
+        },
+    )
+
+    (detection,) = roundtrip(record, schema).annotation["cars"]
+
+    assert detection.class_name == "car"
+    assert detection.boundingbox is not None
+    assert detection.instance_segmentation is not None
+    assert np.array_equal(detection.instance_segmentation.to_numpy(), mask)
+
+
+def test_arrays_keep_their_data(tempdir: Path):
+    array_path = tempdir / "embedding.npy"
+    np.save(array_path, np.array([1.0, 2.0, 3.0]))
+    schema = DatasetSchema(
+        tasks={"embeddings": ["array", "classification"]},
+        classes={"embeddings": {"vector": 0}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "embeddings": [{"class": "vector", "array": {"data": array_path}}]
+        },
+    )
+
+    (detection,) = roundtrip(record, schema).annotation["embeddings"]
+
+    assert detection.class_name == "vector"
+    assert detection.array is not None
+    assert detection.array.to_numpy().tolist() == [1.0, 2.0, 3.0]
+
+
+def test_metadata_stays_with_its_own_instance():
+    schema = DatasetSchema(
+        tasks={
+            "vehicles": [
+                "boundingbox",
+                "classification",
+                "metadata/color",
+                "metadata/wheels",
+            ]
+        },
+        classes={"vehicles": {"car": 0}},
+        categorical_encodings={
+            "vehicles/metadata/color": {"red": 0, "blue": 1}
+        },
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "vehicles": [
+                {
+                    "class": "car",
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.2, "h": 0.2},
+                    "metadata": {"color": Category("blue"), "wheels": 4},
+                },
+                {
+                    "class": "car",
+                    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
+                    "metadata": {"color": Category("red"), "wheels": 6},
+                },
+            ]
+        },
+    )
+
+    detections = roundtrip(record, schema).annotation["vehicles"]
+
+    assert detections[0].metadata == {"color": Category("blue"), "wheels": 4}
+    assert detections[1].metadata == {"color": Category("red"), "wheels": 6}
+
+
+def test_a_true_negative_stays_empty():
+    schema = DatasetSchema(
+        tasks={"vehicles": ["boundingbox", "classification"]},
+        classes={"vehicles": {"car": 0}},
+    )
+    record = DatasetRecord(media=IMAGE)  # type: ignore[call-arg]
+
+    rebuilt = roundtrip(record, schema)
+
+    assert rebuilt.annotation == {"vehicles": []}
+
+
+def test_a_sub_detection_comes_back_nested():
+    schema = DatasetSchema(
+        tasks={
+            "driver": ["boundingbox", "classification"],
+            "driver/face": ["boundingbox", "classification"],
+        },
+        classes={
+            "driver": {"person": 0},
+            "driver/face": {"face": 0},
+        },
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "driver": [
+                {
+                    "class": "person",
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                    "sub_detections": {
+                        "face": {
+                            "class": "face",
+                            "boundingbox": {
+                                "x": 0.2,
+                                "y": 0.2,
+                                "w": 0.1,
+                                "h": 0.1,
+                            },
+                        }
+                    },
+                }
+            ]
+        },
+    )
+
+    rebuilt = roundtrip(record, schema)
+
+    assert set(rebuilt.annotation) == {"driver"}
+    (driver,) = rebuilt.annotation["driver"]
+    assert driver.class_name == "person"
+    face = driver.sub_detections["face"]
+    assert face.class_name == "face"
+    assert face.boundingbox is not None
+    assert face.boundingbox.x == pytest.approx(0.2)
+
+
+def test_two_levels_of_sub_detections_come_back_nested():
+    schema = DatasetSchema(
+        tasks={
+            "vehicle": ["boundingbox", "classification"],
+            "vehicle/plate": ["boundingbox", "classification"],
+            "vehicle/plate/text": ["classification"],
+        },
+        classes={
+            "vehicle": {"car": 0},
+            "vehicle/plate": {"plate": 0},
+            "vehicle/plate/text": {"CO": 0},
+        },
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "vehicle": [
+                {
+                    "class": "car",
+                    "boundingbox": {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5},
+                    "sub_detections": {
+                        "plate": {
+                            "class": "plate",
+                            "boundingbox": {
+                                "x": 0.2,
+                                "y": 0.2,
+                                "w": 0.1,
+                                "h": 0.1,
+                            },
+                            "sub_detections": {"text": {"class": "CO"}},
+                        }
+                    },
+                }
+            ]
+        },
+    )
+
+    rebuilt = roundtrip(record, schema)
+
+    (vehicle,) = rebuilt.annotation["vehicle"]
+    plate = vehicle.sub_detections["plate"]
+    assert plate.class_name == "plate"
+    assert plate.sub_detections["text"].class_name == "CO"
+
+
+def test_every_parent_keeps_its_own_sub_detection():
+    """Parents and children pair by row index, so the order has to hold."""
+    schema = DatasetSchema(
+        tasks={
+            "driver": ["boundingbox", "classification"],
+            "driver/face": ["boundingbox", "classification"],
+        },
+        classes={
+            "driver": {"person": 0},
+            "driver/face": {"happy": 0, "sad": 1},
+        },
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={
+            "driver": [
+                {
+                    "class": "person",
+                    "instance_id": index,
+                    "boundingbox": {
+                        "x": 0.1 * index,
+                        "y": 0.1,
+                        "w": 0.1,
+                        "h": 0.1,
+                    },
+                    "sub_detections": {
+                        "face": {
+                            "class": mood,
+                            "instance_id": index,
+                            "boundingbox": {
+                                "x": 0.1 * index,
+                                "y": 0.5,
+                                "w": 0.1,
+                                "h": 0.1,
+                            },
+                        }
+                    },
+                }
+                for index, mood in enumerate(["happy", "sad", "happy"])
+            ]
+        },
+    )
+
+    drivers = roundtrip(record, schema).annotation["driver"]
+
+    assert [
+        driver.sub_detections["face"].class_name for driver in drivers
+    ] == ["happy", "sad", "happy"]
+    assert [
+        driver.boundingbox.x  # type: ignore[union-attr]
+        for driver in drivers
+    ] == pytest.approx([0.0, 0.1, 0.2])
+
+
+def test_the_schema_travels_with_the_sample():
+    schema = DatasetSchema(
+        tasks={"vehicles": ["classification"]},
+        classes={"vehicles": {"car": 0}},
+    )
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={"vehicles": [{"class": "car"}]},
+        sample_metadata={"camera": "left"},
+    )
+
+    sample = record.to_loader_output(schema)
+
+    assert sample.metadata["camera"] == "left"
+    # The record rebuilds without being handed the schema again.
+    assert sample.to_ldf().sample_metadata == {"camera": "left"}
+
+
+def test_rebuilding_without_a_schema_is_refused():
+    schema = DatasetSchema(classes={"": {"car": 0}})
+    record = DatasetRecord(
+        media=IMAGE,  # type: ignore[call-arg]
+        annotation={"": [{"class": "car"}]},
+    )
+    sample = record.to_loader_output(schema)
+    sample.metadata.clear()
+
+    with pytest.raises(ValueError, match="without the dataset schema"):
+        sample.to_ldf()

--- a/tests/test_ldf/test_split_from_numpy.py
+++ b/tests/test_ldf/test_split_from_numpy.py
@@ -105,8 +105,8 @@ def test_arrays_come_back_from_their_class_slot(tempdir: Path):
     np.save(first, np.array([1.0, 2.0]))
     np.save(second, np.array([3.0, 4.0]))
     arrays = [
-        ArrayAnnotation(data=first),  # type: ignore[call-arg]
-        ArrayAnnotation(data=second),  # type: ignore[call-arg]
+        ArrayAnnotation.model_validate({"data": first}),
+        ArrayAnnotation.model_validate({"data": second}),
     ]
     combined = ArrayAnnotation.combine_to_numpy(arrays, [2, 0], 3)
 

--- a/tests/test_ldf/test_split_from_numpy.py
+++ b/tests/test_ldf/test_split_from_numpy.py
@@ -1,0 +1,141 @@
+"""`split_from_numpy` is the inverse of `combine_to_numpy`."""
+
+from pathlib import Path
+
+import numpy as np
+
+from luxonis_ml.ldf import (
+    ArrayAnnotation,
+    BBoxAnnotation,
+    ClassificationAnnotation,
+    InstanceSegmentationAnnotation,
+    KeypointAnnotation,
+    SegmentationAnnotation,
+)
+
+
+def test_bounding_boxes_keep_their_coordinates_and_class():
+    boxes = [
+        BBoxAnnotation(x=0.1, y=0.2, w=0.3, h=0.4),
+        BBoxAnnotation(x=0.5, y=0.5, w=0.2, h=0.2),
+    ]
+    combined = BBoxAnnotation.combine_to_numpy(boxes, [2, 0])
+
+    split = BBoxAnnotation.split_from_numpy(combined)
+
+    assert [class_id for _, class_id in split] == [2, 0]
+    assert [annotation for annotation, _ in split] == boxes
+
+
+def test_keypoints_keep_their_visibility():
+    keypoints = [
+        KeypointAnnotation.model_validate(
+            {"keypoints": [(0.1, 0.2, 2), (0.3, 0.4, 0)]}
+        ),
+        KeypointAnnotation.model_validate(
+            {"keypoints": [(0.5, 0.6, 1), (0.7, 0.8, 2)]}
+        ),
+    ]
+    combined = KeypointAnnotation.combine_to_numpy(keypoints)
+
+    split = KeypointAnnotation.split_from_numpy(combined)
+
+    assert [annotation for annotation, _ in split] == keypoints
+    assert all(class_id is None for _, class_id in split)
+
+
+def test_semantic_masks_come_back_per_class():
+    road = np.zeros((4, 4), dtype=np.uint8)
+    road[0:2] = 1
+    sky = np.zeros((4, 4), dtype=np.uint8)
+    sky[3] = 1
+    masks = [
+        SegmentationAnnotation.model_validate({"mask": road}),
+        SegmentationAnnotation.model_validate({"mask": sky}),
+    ]
+    combined = SegmentationAnnotation.combine_to_numpy(masks, [1, 2], 3)
+
+    split = SegmentationAnnotation.split_from_numpy(combined)
+
+    assert [class_id for _, class_id in split] == [1, 2]
+    assert np.array_equal(split[0][0].to_numpy(), road)
+    assert np.array_equal(split[1][0].to_numpy(), sky)
+
+
+def test_an_empty_class_has_no_annotation():
+    mask = np.ones((2, 2), dtype=np.uint8)
+    combined = SegmentationAnnotation.combine_to_numpy(
+        [SegmentationAnnotation.model_validate({"mask": mask})], [0], 3
+    )
+
+    assert len(SegmentationAnnotation.split_from_numpy(combined)) == 1
+
+
+def test_instance_masks_come_back_per_instance():
+    first = np.zeros((3, 3), dtype=np.uint8)
+    first[0] = 1
+    second = np.zeros((3, 3), dtype=np.uint8)
+    second[2] = 1
+    masks = [
+        InstanceSegmentationAnnotation.model_validate({"mask": first}),
+        InstanceSegmentationAnnotation.model_validate({"mask": second}),
+    ]
+    combined = InstanceSegmentationAnnotation.combine_to_numpy(masks)
+
+    split = InstanceSegmentationAnnotation.split_from_numpy(combined)
+
+    assert np.array_equal(split[0][0].to_numpy(), first)
+    assert np.array_equal(split[1][0].to_numpy(), second)
+    assert all(class_id is None for _, class_id in split)
+
+
+def test_a_multi_hot_vector_becomes_one_annotation_per_class():
+    combined = ClassificationAnnotation.combine_to_numpy(
+        [ClassificationAnnotation(), ClassificationAnnotation()], [0, 3], 4
+    )
+
+    split = ClassificationAnnotation.split_from_numpy(combined)
+
+    assert [class_id for _, class_id in split] == [0, 3]
+
+
+def test_arrays_come_back_from_their_class_slot(tempdir: Path):
+    first = tempdir / "first.npy"
+    second = tempdir / "second.npy"
+    np.save(first, np.array([1.0, 2.0]))
+    np.save(second, np.array([3.0, 4.0]))
+    arrays = [
+        ArrayAnnotation(data=first),  # type: ignore[call-arg]
+        ArrayAnnotation(data=second),  # type: ignore[call-arg]
+    ]
+    combined = ArrayAnnotation.combine_to_numpy(arrays, [2, 0], 3)
+
+    split = ArrayAnnotation.split_from_numpy(combined)
+
+    assert [class_id for _, class_id in split] == [2, 0]
+    assert split[0][0].to_numpy().tolist() == [1.0, 2.0]
+    assert split[1][0].to_numpy().tolist() == [3.0, 4.0]
+
+
+def test_an_all_zero_array_reports_no_class():
+    combined = np.zeros((1, 3, 2))
+
+    (annotation, class_id) = ArrayAnnotation.split_from_numpy(combined)[0]
+
+    assert class_id is None
+    assert annotation.to_numpy().tolist() == [0.0, 0.0]
+
+
+def test_visibility_survives_a_float_round_trip():
+    """The arrays are float, so the visibility comes back as one too."""
+    keypoints = KeypointAnnotation.model_validate(
+        {"keypoints": [(0.1, 0.2, 1)]}
+    )
+    combined = KeypointAnnotation.combine_to_numpy([keypoints])
+
+    (annotation, _) = KeypointAnnotation.split_from_numpy(combined)[0]
+
+    # A record that carries a plain list keys its keypoints by position.
+    visibility = annotation.keypoints["0"].visibility
+    assert visibility == 1
+    assert isinstance(visibility, int)

--- a/tests/test_ldf/test_validation.py
+++ b/tests/test_ldf/test_validation.py
@@ -26,7 +26,7 @@ from luxonis_ml.typing import TaskType
 def test_bbox_missing_field_is_a_validation_error():
     """Indexing the raw input used to raise a bare ``KeyError: 'h'``."""
     with pytest.raises(pydantic.ValidationError) as info:
-        BBoxAnnotation(x=0.1, y=0.1, w=0.1)  # type: ignore[call-arg]
+        BBoxAnnotation.model_validate({"x": 0.1, "y": 0.1, "w": 0.1})
     assert [(e["loc"], e["type"]) for e in info.value.errors()] == [
         (("h",), "missing")
     ]
@@ -172,10 +172,8 @@ def test_mask_size_wins_over_supplied_height_and_width():
     mask = np.zeros((4, 6), dtype=np.uint8)
     mask[1:3, 2:5] = 1
 
-    annotation = SegmentationAnnotation(
-        mask=mask,  # type: ignore[call-arg]
-        height=999,
-        width=999,
+    annotation = SegmentationAnnotation.model_validate(
+        {"mask": mask, "height": 999, "width": 999}
     )
 
     assert (annotation.height, annotation.width) == (4, 6)
@@ -185,12 +183,14 @@ def test_mask_size_wins_over_supplied_height_and_width():
 def test_record_rejects_both_file_and_files(tempdir: Path):
     """`files` used to be silently replaced by the single `file`."""
     with pytest.raises(pydantic.ValidationError, match="not both"):
-        DatasetRecord(
-            file=tempdir / "image.png",  # type: ignore[call-arg]
-            files={
-                "left": tempdir / "left.png",
-                "right": tempdir / "right.png",
-            },
+        DatasetRecord.model_validate(
+            {
+                "file": tempdir / "image.png",
+                "files": {
+                    "left": tempdir / "left.png",
+                    "right": tempdir / "right.png",
+                },
+            }
         )
 
 
@@ -216,19 +216,23 @@ def test_record_rejects_conflicting_task_and_task_name(tempdir: Path):
     """The deprecated `task` used to silently win over `task_name`."""
     (tempdir / "image.png").touch()
     with pytest.raises(pydantic.ValidationError, match="Conflicting values"):
-        DatasetRecord(
-            file=tempdir / "image.png",  # type: ignore[call-arg]
-            task="detection",  # type: ignore[call-arg]
-            task_name="segmentation",  # type: ignore[call-arg]
+        DatasetRecord.model_validate(
+            {
+                "file": tempdir / "image.png",
+                "task": "detection",
+                "task_name": "segmentation",
+            }
         )
 
 
 def test_record_accepts_matching_task_and_task_name(tempdir: Path):
     (tempdir / "image.png").touch()
-    record = DatasetRecord(
-        file=tempdir / "image.png",  # type: ignore[call-arg]
-        task="detection",  # type: ignore[call-arg]
-        task_name="detection",  # type: ignore[call-arg]
+    record = DatasetRecord.model_validate(
+        {
+            "file": tempdir / "image.png",
+            "task": "detection",
+            "task_name": "detection",
+        }
     )
 
     assert record.task_name == "detection"
@@ -249,7 +253,9 @@ def test_png_mask_is_read_without_opencv(tempdir: Path):
     mask[1:3, 2:5] = 1
     Image.fromarray(mask * 255).save(tempdir / "mask.png")
 
-    annotation = SegmentationAnnotation(mask=tempdir / "mask.png")  # type: ignore[call-arg]
+    annotation = SegmentationAnnotation.model_validate(
+        {"mask": tempdir / "mask.png"}
+    )
 
     np.testing.assert_array_equal(annotation.to_numpy(), mask)
 
@@ -268,7 +274,9 @@ def test_array_path_falls_back_when_mmap_is_unavailable(
 
     monkeypatch.setattr(np, "load", no_mmap)
 
-    annotation = ArrayAnnotation(data=tempdir / "array.npy")  # type: ignore[call-arg]
+    annotation = ArrayAnnotation.model_validate(
+        {"data": tempdir / "array.npy"}
+    )
 
     assert isinstance(annotation.path, Path)
     assert annotation.path.name == "array.npy"
@@ -277,13 +285,15 @@ def test_array_path_falls_back_when_mmap_is_unavailable(
 def test_sub_detections_inherit_the_record_metadata(tempdir: Path):
     """The serialized metadata is now threaded through the recursion."""
     (tempdir / "image.png").touch()
-    record = DatasetRecord(
-        file=tempdir / "image.png",  # type: ignore[call-arg]
-        sample_metadata={"camera": "left"},
-        annotation=Detection(
-            class_name="person",
-            sub_detections={"head": Detection(class_name="head")},
-        ),
+    record = DatasetRecord.model_validate(
+        {
+            "file": tempdir / "image.png",
+            "sample_metadata": {"camera": "left"},
+            "annotation": Detection(
+                class_name="person",
+                sub_detections={"head": Detection(class_name="head")},
+            ),
+        }
     )
 
     rows = list(record.to_parquet_rows())

--- a/tests/test_ldf/test_validation.py
+++ b/tests/test_ldf/test_validation.py
@@ -218,7 +218,7 @@ def test_record_rejects_conflicting_task_and_task_name(tempdir: Path):
         DatasetRecord(
             file=tempdir / "image.png",  # type: ignore[call-arg]
             task="detection",  # type: ignore[call-arg]
-            task_name="segmentation",
+            task_name="segmentation",  # type: ignore[call-arg]
         )
 
 
@@ -227,7 +227,7 @@ def test_record_accepts_matching_task_and_task_name(tempdir: Path):
     record = DatasetRecord(
         file=tempdir / "image.png",  # type: ignore[call-arg]
         task="detection",  # type: ignore[call-arg]
-        task_name="detection",
+        task_name="detection",  # type: ignore[call-arg]
     )
 
     assert record.task_name == "detection"
@@ -267,7 +267,10 @@ def test_array_path_falls_back_when_mmap_is_unavailable(
 
     monkeypatch.setattr(np, "load", no_mmap)
 
-    assert ArrayAnnotation(path=tempdir / "array.npy").path.name == "array.npy"
+    annotation = ArrayAnnotation(data=tempdir / "array.npy")  # type: ignore[call-arg]
+
+    assert isinstance(annotation.path, Path)
+    assert annotation.path.name == "array.npy"
 
 
 def test_sub_detections_inherit_the_record_metadata(tempdir: Path):

--- a/tests/test_ldf/test_validation.py
+++ b/tests/test_ldf/test_validation.py
@@ -20,6 +20,7 @@ from luxonis_ml.ldf import (
     SegmentationAnnotation,
     load_annotation,
 )
+from luxonis_ml.typing import TaskType
 
 
 def test_bbox_missing_field_is_a_validation_error():
@@ -141,12 +142,12 @@ def test_keypoint_clipping_does_not_mutate_the_input():
     ],
 )
 def test_load_annotation_does_not_mutate_the_input(
-    task_type: str, data: dict[str, Any]
+    task_type: TaskType, data: dict[str, Any]
 ):
     """The mapping is validated directly, so nothing must leak back."""
     original = json.dumps(data)
 
-    load_annotation(task_type, data)  # type: ignore[arg-type]
+    load_annotation(task_type, data)
 
     assert json.dumps(data) == original
 
@@ -160,10 +161,10 @@ def test_load_annotation_does_not_mutate_the_input(
     ],
 )
 def test_load_annotation_accepts_a_read_only_mapping(
-    task_type: str, data: dict[str, Any]
+    task_type: TaskType, data: dict[str, Any]
 ):
     """`load_annotation` is typed to take any `Mapping`."""
-    load_annotation(task_type, MappingProxyType(data))  # type: ignore[arg-type]
+    load_annotation(task_type, MappingProxyType(data))
 
 
 def test_mask_size_wins_over_supplied_height_and_width():


### PR DESCRIPTION
## Purpose

A `DatasetRecord` carries one detection and one task name. A sample with three
objects therefore needs three records. A sample annotated for two tasks cannot be
written at all.

Nothing converts a record into the arrays `LuxonisLoader` returns. The two
representations drift apart, and six loader defects follow from that.

This PR makes one record describe a whole sample. It adds the conversion in both
directions, and the loader builds its output through it.

### Record shape examples

The usual single-task case does not specify `task_name`. Before, each detection
needed its own record:

```python
car = {
    "class": "car",
    "boundingbox": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
}
truck = {
    "class": "truck",
    "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
}

records = [
    DatasetRecord(file="images/frame_001.jpg", annotation=car),
    DatasetRecord(file="images/frame_001.jpg", annotation=truck),
]
```

After, the same default-task form holds both detections in one record:

```python
record = DatasetRecord(
    media="images/frame_001.jpg",
    annotation=[car, truck],
)
```

For a multi-task sample, two object detections and a scene label for the same
image previously required three separate records:

```python
records = [
    DatasetRecord(
        file="images/frame_001.jpg",
        task_name="vehicles",
        annotation={
            "class": "car",
            "boundingbox": {"x": 0.1, "y": 0.2, "w": 0.3, "h": 0.4},
        },
    ),
    DatasetRecord(
        file="images/frame_001.jpg",
        task_name="vehicles",
        annotation={
            "class": "truck",
            "boundingbox": {"x": 0.5, "y": 0.5, "w": 0.2, "h": 0.2},
        },
    ),
    DatasetRecord(
        file="images/frame_001.jpg",
        task_name="weather",
        annotation={"class": "rain"},
    ),
]
```

After, one task-keyed record contains the complete sample:

```python
record = DatasetRecord(
    media="images/frame_001.jpg",
    annotation={
        "vehicles": [
            {
                "class": "car",
                "boundingbox": {
                    "x": 0.1,
                    "y": 0.2,
                    "w": 0.3,
                    "h": 0.4,
                },
            },
            {
                "class": "truck",
                "boundingbox": {
                    "x": 0.5,
                    "y": 0.5,
                    "w": 0.2,
                    "h": 0.2,
                },
            },
        ],
        "weather": {"class": "rain"},
    },
)
```

## Specification

**The record shape.** LDF becomes 3.0.

- `annotation` maps a task name to the detections of that task.
- An empty mapping marks a true negative. It counts as a negative for every task
  of the dataset.
- A task mapped to an empty list declares the task. A dataset can thus hold a
  task with no positive sample yet.
- The flat forms still work. A single detection, a list of them, and a
  `task_name` beside them all normalize into the mapping.
- `task_name` survives as a read-only property. It raises on a record with
  several tasks.
- The parquet rows do not move.

**Media.**

- `media` takes one path, or a mapping of source names to paths.
- `media` also takes an in-memory image or array.
- `file` and `files` still work. Both warn.

**Conversion.**

- `DatasetRecord.to_loader_output` builds the arrays a model consumes.
- `LoaderOutput.to_ldf` turns those arrays back into a record.
- Every annotation type implements `split_from_numpy` beside its
  `combine_to_numpy`.
- `DatasetSchema` holds the tasks, the class IDs, the keypoint metadata, the
  keypoint counts and the categorical encodings. Every sample carries it under
  the reserved `"schema"` key, so a consumer can read class names off the arrays.
- All samples of one loader share that one schema object.

**The write path.** Every detection gets an instance number when it is written. A
sub-detection takes the number of its parent, which records that it belongs to
it.

**Fixed defects.** The left column is the behaviour of the base branch.

| Before | After |
| --- | --- |
| Two boxes of one sample came back labelled with each other's class. Annotations sorted by instance ID, but their class IDs kept the dataframe order. | Row `i` of every array of a task describes the same instance. |
| A metadata value described the wrong object. Metadata never sorted at all. | Metadata sorts with the rest of the task. |
| An absent metadata label had shape `(n_classes,)`, which reads as that many instances. | It has shape `(0,)`. |
| A sub-detection counted the classes of its parent. | `vehicle/plate` counts its own classes. |
| A true negative did not survive `filter_task_names`. | A record with no annotation is a negative for every task, so it survives. |
| A nested detection repeated the empty row of each secondary source once per level. | Each secondary source gets one empty row. |

A batch augmentation carries the one schema object over instead of a copy. That
costs 45 times less.

**Versions.**

- A dataset written by LDF 1.x or 2.x still opens. The migrations dispatch on the
  stored version, and the dataset takes the new stamp.
- The native export writes 3.0, 2.2, 2.1 or 2.0. An older target rebuilds the
  flat record and drops the fields that version does not know.

## Dependencies & Potential Impact

This PR is stacked on #491, and its base branch is
`feat/advanced-keypoint-annotation`. Merge #491 first.

LDF 3.0 breaks the record contract. The impact on the other repositories is
small:

- The label keys and the array shapes `LuxonisLoader` returns do not change.
  `luxonis-train`, `luxonis-eval` and `modelconverter` therefore read a dataset
  as they do today.
- `record.file`, `record.files` and `record.task_name` still work. Each one
  warns.
- A stored dataset needs no action. The migration runs when the dataset opens.

## Deployment Plan

None / not applicable. This is a library change, and it ships with the next
release.

## Testing & Validation

New tests cover the task-keyed record, the record-to-arrays round trip,
`split_from_numpy`, the media forms, the instance numbers, the LDF 2.x migration,
and the 2.2, 2.1 and 2.0 export targets.

`pyright --warnings --level warning` reports 0 errors and 0 warnings.
`pre-commit run --all-files` passes every hook.

## AI Usage

Assisted-by: Claude Code:claude-opus-5[1m]

Submitted code was reviewed by a human: YES/NO

The author is taking the responsibility for the contribution: YES/NO
